### PR TITLE
feat: Add basic authentication to Flow Dashboard

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <RepositoryUrl>https://github.com/hoangsnowy/FlowOrchestrator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/hoangsnowy/FlowOrchestrator</PackageProjectUrl>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -93,9 +93,18 @@ From the Aspire dashboard you can:
 {
   "ConnectionStrings": {
     "FlowOrchestrator": "Server=(localdb)\\mssqllocaldb;Database=FlowOrchestrator;Trusted_Connection=True;TrustServerCertificate=True"
+  },
+  "FlowDashboard": {
+    "BasicAuth": {
+      "Username": "admin",
+      "Password": "change-me",
+      "Realm": "FlowOrchestrator Dashboard"
+    }
   }
 }
 ```
+
+`FlowDashboard:BasicAuth` is optional. Leave `Username`/`Password` empty to disable dashboard auth.
 
 2. Run the app:
 
@@ -110,6 +119,8 @@ The app starts on `http://localhost:5201` by default.
 ## 4. Using the dashboard
 
 Open `http://localhost:5201/flows` to access the built-in dashboard.
+If `FlowDashboard:BasicAuth` is configured, the browser will prompt for HTTP Basic credentials.
+Webhook endpoint (`/flows/api/webhook/{idOrSlug}`) is intentionally not protected by dashboard basic auth; use `webhookSecret` for webhook security.
 
 ### Pages
 
@@ -130,6 +141,15 @@ Open `http://localhost:5201/flows` to access the built-in dashboard.
 1. Go to **Flows** → click a flow card.
 2. Click the **Trigger** button.
 3. Switch to the **Runs** page to monitor execution.
+
+### Polling demo flow
+
+`PollingDemoFlow` (`00000000-0000-0000-0000-000000000003`) demonstrates real polling behavior using `CallExternalApi`:
+- `pollEnabled = true`
+- `pollMinAttempts = 3` (forces at least 3 poll attempts before success)
+- `pollIntervalSeconds = 5`
+
+This lets you observe **Pending -> Pending -> Succeeded** progression in the Runs timeline.
 
 ### Retrying a failed step
 

--- a/samples/FlowOrchestrator.SampleApp/Flows/HelloWorldFlow.cs
+++ b/samples/FlowOrchestrator.SampleApp/Flows/HelloWorldFlow.cs
@@ -27,7 +27,7 @@ public sealed class HelloWorldFlow : IFlowDefinition
             ["step2"] = new StepMetadata
             {
                 Type = "LogMessage",
-                RunAfter = new RunAfterCollection { ["step1"] = ["Succeeded"] },
+                RunAfter = new RunAfterCollection { ["step1"] = [StepStatus.Succeeded] },
                 Inputs = new Dictionary<string, object?> { ["message"] = "Hello from step 2 – workflow complete!" }
             }
         }

--- a/samples/FlowOrchestrator.SampleApp/Flows/OrderProcessingFlow.cs
+++ b/samples/FlowOrchestrator.SampleApp/Flows/OrderProcessingFlow.cs
@@ -29,23 +29,27 @@ public sealed class OrderProcessingFlow : IFlowDefinition
                 Inputs = new Dictionary<string, object?>
                 {
                     ["sql"] = "SELECT TOP 10 Id, CustomerName, Total FROM Orders WHERE Status = @Status",
-                    ["parameters"] = new Dictionary<string, object?> { ["Status"] = "Pending" }
+                    ["parameters"] = new Dictionary<string, object?> { ["Status"] = OrderStatus.Pending.ToString() }
                 }
             },
             ["enrich_data"] = new StepMetadata
             {
                 Type = "CallExternalApi",
-                RunAfter = new RunAfterCollection { ["fetch_orders"] = ["Succeeded"] },
+                RunAfter = new RunAfterCollection { ["fetch_orders"] = [StepStatus.Succeeded] },
                 Inputs = new Dictionary<string, object?>
                 {
                     ["method"] = "GET",
-                    ["path"] = "/posts/1"
+                    ["path"] = "/posts/1",
+                    ["pollEnabled"] = true,
+                    ["pollIntervalSeconds"] = 10,
+                    ["pollTimeoutSeconds"] = 120,
+                    ["pollConditionPath"] = "id"
                 }
             },
             ["save_result"] = new StepMetadata
             {
                 Type = "SaveResult",
-                RunAfter = new RunAfterCollection { ["enrich_data"] = ["Succeeded"] },
+                RunAfter = new RunAfterCollection { ["enrich_data"] = [StepStatus.Succeeded] },
                 Inputs = new Dictionary<string, object?>
                 {
                     ["table"] = "ProcessedResults"

--- a/samples/FlowOrchestrator.SampleApp/Flows/OrderStatus.cs
+++ b/samples/FlowOrchestrator.SampleApp/Flows/OrderStatus.cs
@@ -1,0 +1,8 @@
+namespace FlowOrchestrator.SampleApp.Flows;
+
+public enum OrderStatus
+{
+    Pending = 0,
+    Completed = 1,
+    Cancelled = 2
+}

--- a/samples/FlowOrchestrator.SampleApp/Flows/PollingDemoFlow.cs
+++ b/samples/FlowOrchestrator.SampleApp/Flows/PollingDemoFlow.cs
@@ -1,0 +1,43 @@
+using FlowOrchestrator.Core.Abstractions;
+
+namespace FlowOrchestrator.SampleApp.Flows;
+
+public sealed class PollingDemoFlow : IFlowDefinition
+{
+    public Guid Id { get; } = new Guid("00000000-0000-0000-0000-000000000003");
+    public string Version => "1.0";
+    public FlowManifest Manifest { get; set; } = new FlowManifest
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual },
+        },
+        Steps = new StepCollection
+        {
+            ["poll_external_status"] = new StepMetadata
+            {
+                Type = "CallExternalApi",
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["method"] = "GET",
+                    ["path"] = "/posts/1",
+                    ["pollEnabled"] = true,
+                    ["pollMinAttempts"] = 3,
+                    ["pollIntervalSeconds"] = 5,
+                    ["pollTimeoutSeconds"] = 90,
+                    ["pollConditionPath"] = "id",
+                    ["pollConditionEquals"] = 1
+                }
+            },
+            ["log_done"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                RunAfter = new RunAfterCollection { ["poll_external_status"] = [StepStatus.Succeeded] },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "Polling demo completed after retries."
+                }
+            }
+        }
+    };
+}

--- a/samples/FlowOrchestrator.SampleApp/Program.cs
+++ b/samples/FlowOrchestrator.SampleApp/Program.cs
@@ -29,6 +29,7 @@ builder.Services.AddFlowOrchestrator(options =>
     options.UseHangfire();
     options.AddFlow<HelloWorldFlow>();
     options.AddFlow<OrderProcessingFlow>();
+    options.AddFlow<PollingDemoFlow>();
 });
 
 builder.Services.AddStepHandler<LogMessageStepHandler>("LogMessage");
@@ -45,7 +46,7 @@ builder.Services.AddHttpClient("ExternalApi", client =>
     client.Timeout = TimeSpan.FromSeconds(30);
 });
 
-builder.Services.AddFlowDashboard();
+builder.Services.AddFlowDashboard(builder.Configuration);
 
 var app = builder.Build();
 

--- a/samples/FlowOrchestrator.SampleApp/Steps/CallExternalApiStep.cs
+++ b/samples/FlowOrchestrator.SampleApp/Steps/CallExternalApiStep.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
@@ -7,10 +8,14 @@ namespace FlowOrchestrator.SampleApp.Steps;
 /// <summary>
 /// Calls an external HTTP API and returns the parsed JSON response.
 /// Inputs: method (GET/POST/...), path (string), body (optional)
+/// Poll inputs (optional): pollEnabled, pollIntervalSeconds, pollTimeoutSeconds, pollConditionPath, pollConditionEquals, pollMinAttempts
 /// Output: deserialized JSON response
 /// </summary>
 public sealed class CallExternalApiStep : IStepHandler
 {
+    private const string PollStartedAtInputKey = "__pollStartedAtUtc";
+    private const string PollAttemptInputKey = "__pollAttempt";
+
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<CallExternalApiStep> _logger;
 
@@ -44,6 +49,236 @@ public sealed class CallExternalApiStep : IStepHandler
 
         _logger.LogInformation("[CallExternalApi] RunId={RunId} Response status={Status}", ctx.RunId, response.StatusCode);
 
-        return result;
+        if (!GetBoolInput(step.Inputs, "pollEnabled", defaultValue: false))
+        {
+            return result;
+        }
+
+        var intervalSeconds = Math.Max(1, GetIntInput(step.Inputs, "pollIntervalSeconds", defaultValue: 10));
+        var timeoutSeconds = Math.Max(intervalSeconds, GetIntInput(step.Inputs, "pollTimeoutSeconds", defaultValue: 300));
+        var minAttempts = Math.Max(1, GetIntInput(step.Inputs, "pollMinAttempts", defaultValue: 1));
+        var pollStartedAt = GetPollStartedAt(step);
+        var currentAttempt = IncrementPollAttempt(step);
+
+        if (currentAttempt >= minAttempts && IsPollConditionMatched(result, step.Inputs))
+        {
+            ResetPollState(step);
+            _logger.LogInformation(
+                "[CallExternalApi] RunId={RunId} Polling condition matched at attempt {Attempt}. Continue flow.",
+                ctx.RunId,
+                currentAttempt);
+            return result;
+        }
+
+        var elapsed = DateTimeOffset.UtcNow - pollStartedAt;
+        if (elapsed >= TimeSpan.FromSeconds(timeoutSeconds))
+        {
+            ResetPollState(step);
+            return new StepResult
+            {
+                Key = step.Key,
+                Status = StepStatus.Failed,
+                FailedReason = $"Polling timed out after {timeoutSeconds} seconds.",
+                Result = result
+            };
+        }
+
+        _logger.LogInformation(
+            "[CallExternalApi] RunId={RunId} Polling condition not met at attempt {Attempt}/{MinAttempts}. Retry in {Delay}s.",
+            ctx.RunId,
+            currentAttempt,
+            minAttempts,
+            intervalSeconds);
+
+        return new StepResult
+        {
+            Key = step.Key,
+            Status = StepStatus.Pending,
+            DelayNextStep = TimeSpan.FromSeconds(intervalSeconds),
+            Result = result
+        };
+    }
+
+    private static DateTimeOffset GetPollStartedAt(IStepInstance step)
+    {
+        if (step.Inputs.TryGetValue(PollStartedAtInputKey, out var current)
+            && TryParseDateTimeOffset(current, out var parsed))
+        {
+            return parsed;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        step.Inputs[PollStartedAtInputKey] = now.ToString("O", CultureInfo.InvariantCulture);
+        return now;
+    }
+
+    private static int IncrementPollAttempt(IStepInstance step)
+    {
+        if (step.Inputs.TryGetValue(PollAttemptInputKey, out var current))
+        {
+            var parsed = current switch
+            {
+                int i => i,
+                long l when l >= int.MinValue && l <= int.MaxValue => (int)l,
+                string s when int.TryParse(s, out var value) => value,
+                JsonElement { ValueKind: JsonValueKind.Number } je when je.TryGetInt32(out var value) => value,
+                JsonElement { ValueKind: JsonValueKind.String } je when int.TryParse(je.GetString(), out var value) => value,
+                _ => 0
+            };
+
+            var next = parsed + 1;
+            step.Inputs[PollAttemptInputKey] = next;
+            return next;
+        }
+
+        step.Inputs[PollAttemptInputKey] = 1;
+        return 1;
+    }
+
+    private static void ResetPollState(IStepInstance step)
+    {
+        step.Inputs.Remove(PollStartedAtInputKey);
+        step.Inputs.Remove(PollAttemptInputKey);
+    }
+
+    private static bool IsPollConditionMatched(JsonElement payload, IDictionary<string, object?> inputs)
+    {
+        var conditionPath = GetStringInput(inputs, "pollConditionPath");
+        if (!TryResolvePath(payload, conditionPath, out var target))
+        {
+            return false;
+        }
+
+        if (!inputs.TryGetValue("pollConditionEquals", out var expected))
+        {
+            return HasData(target);
+        }
+
+        return string.Equals(Normalize(target), Normalize(expected), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryResolvePath(JsonElement payload, string? path, out JsonElement target)
+    {
+        target = payload;
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return true;
+        }
+
+        foreach (var segment in path.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (target.ValueKind == JsonValueKind.Object && target.TryGetProperty(segment, out var objectValue))
+            {
+                target = objectValue;
+                continue;
+            }
+
+            if (target.ValueKind == JsonValueKind.Array && int.TryParse(segment, out var index))
+            {
+                if (index >= 0 && index < target.GetArrayLength())
+                {
+                    target = target[index];
+                    continue;
+                }
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool HasData(JsonElement target) => target.ValueKind switch
+    {
+        JsonValueKind.Null or JsonValueKind.Undefined => false,
+        JsonValueKind.String => !string.IsNullOrWhiteSpace(target.GetString()),
+        JsonValueKind.Array => target.GetArrayLength() > 0,
+        JsonValueKind.Object => target.EnumerateObject().MoveNext(),
+        _ => true
+    };
+
+    private static string Normalize(object? value) => value switch
+    {
+        null => string.Empty,
+        JsonElement json => Normalize(json),
+        IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+        _ => value.ToString() ?? string.Empty
+    };
+
+    private static string Normalize(JsonElement value) => value.ValueKind switch
+    {
+        JsonValueKind.Null or JsonValueKind.Undefined => string.Empty,
+        JsonValueKind.String => value.GetString() ?? string.Empty,
+        JsonValueKind.True => bool.TrueString,
+        JsonValueKind.False => bool.FalseString,
+        JsonValueKind.Number => value.GetRawText(),
+        _ => value.GetRawText()
+    };
+
+    private static int GetIntInput(IDictionary<string, object?> inputs, string key, int defaultValue)
+    {
+        if (!inputs.TryGetValue(key, out var value) || value is null)
+        {
+            return defaultValue;
+        }
+
+        return value switch
+        {
+            int i => i,
+            long l when l >= int.MinValue && l <= int.MaxValue => (int)l,
+            JsonElement { ValueKind: JsonValueKind.Number } je when je.TryGetInt32(out var parsedInt) => parsedInt,
+            JsonElement { ValueKind: JsonValueKind.String } je when int.TryParse(je.GetString(), out var parsedString) => parsedString,
+            string s when int.TryParse(s, out var parsed) => parsed,
+            _ => defaultValue
+        };
+    }
+
+    private static bool GetBoolInput(IDictionary<string, object?> inputs, string key, bool defaultValue)
+    {
+        if (!inputs.TryGetValue(key, out var value) || value is null)
+        {
+            return defaultValue;
+        }
+
+        return value switch
+        {
+            bool b => b,
+            JsonElement { ValueKind: JsonValueKind.True } => true,
+            JsonElement { ValueKind: JsonValueKind.False } => false,
+            JsonElement { ValueKind: JsonValueKind.String } je when bool.TryParse(je.GetString(), out var parsedBool) => parsedBool,
+            string s when bool.TryParse(s, out var parsed) => parsed,
+            _ => defaultValue
+        };
+    }
+
+    private static string? GetStringInput(IDictionary<string, object?> inputs, string key)
+    {
+        if (!inputs.TryGetValue(key, out var value) || value is null)
+        {
+            return null;
+        }
+
+        return value switch
+        {
+            string s => s,
+            JsonElement { ValueKind: JsonValueKind.String } je => je.GetString(),
+            _ => value.ToString()
+        };
+    }
+
+    private static bool TryParseDateTimeOffset(object? value, out DateTimeOffset dateTimeOffset)
+    {
+        var text = value switch
+        {
+            string s => s,
+            JsonElement { ValueKind: JsonValueKind.String } je => je.GetString(),
+            _ => null
+        };
+
+        return DateTimeOffset.TryParse(
+            text,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind,
+            out dateTimeOffset);
     }
 }

--- a/samples/FlowOrchestrator.SampleApp/appsettings.Development.json
+++ b/samples/FlowOrchestrator.SampleApp/appsettings.Development.json
@@ -7,5 +7,12 @@
   },
   "ConnectionStrings": {
     "FlowOrchestrator": "Server=(localdb)\\mssqllocaldb;Database=FlowOrchestrator;Trusted_Connection=True;TrustServerCertificate=True"
+  },
+  "FlowDashboard": {
+    "BasicAuth": {
+      "Username": "admin",
+      "Password": "admin",
+      "Realm": "FlowOrchestrator Dashboard"
+    }
   }
 }

--- a/samples/FlowOrchestrator.SampleApp/appsettings.json
+++ b/samples/FlowOrchestrator.SampleApp/appsettings.json
@@ -5,5 +5,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "FlowDashboard": {
+    "BasicAuth": {
+      "Username": "admin",
+      "Password": "admin",
+      "Realm": "FlowOrchestrator Dashboard"
+    }
+  },
   "AllowedHosts": "*"
 }

--- a/src/FlowOrchestrator.Core/Abstractions/RunAfterCollection.cs
+++ b/src/FlowOrchestrator.Core/Abstractions/RunAfterCollection.cs
@@ -1,5 +1,5 @@
 namespace FlowOrchestrator.Core.Abstractions;
 
-public sealed class RunAfterCollection : Dictionary<string, string[]>
+public sealed class RunAfterCollection : Dictionary<string, StepStatus[]>
 {
 }

--- a/src/FlowOrchestrator.Core/Abstractions/StepMetadata.cs
+++ b/src/FlowOrchestrator.Core/Abstractions/StepMetadata.cs
@@ -12,7 +12,7 @@ public class StepMetadata
 
     public IDictionary<string, object?> Inputs { get; set; } = new Dictionary<string, object?>();
 
-    public virtual bool ShouldExecute(string precedingStepKey, string status)
+    public virtual bool ShouldExecute(string precedingStepKey, StepStatus status)
     {
         if (RunAfter.Count == 0)
         {
@@ -24,6 +24,6 @@ public class StepMetadata
             return false;
         }
 
-        return allowedStatuses.Contains(status, StringComparer.OrdinalIgnoreCase);
+        return allowedStatuses.Contains(status);
     }
 }

--- a/src/FlowOrchestrator.Core/Abstractions/StepStatus.cs
+++ b/src/FlowOrchestrator.Core/Abstractions/StepStatus.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace FlowOrchestrator.Core.Abstractions;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum StepStatus
+{
+    Pending = 0,
+    Running = 1,
+    Succeeded = 2,
+    Failed = 3,
+    Skipped = 4
+}

--- a/src/FlowOrchestrator.Core/Configuration/StepHandlerMetadata.cs
+++ b/src/FlowOrchestrator.Core/Configuration/StepHandlerMetadata.cs
@@ -29,10 +29,20 @@ internal sealed class StepHandlerMetadata<THandler> : IStepHandlerMetadata
                 break;
         }
 
+        if (result is IStepResult stepResult)
+        {
+            if (string.IsNullOrWhiteSpace(stepResult.Key))
+            {
+                stepResult.Key = step.Key;
+            }
+
+            return stepResult;
+        }
+
         return new StepResult
         {
             Key = step.Key,
-            Status = "Succeeded",
+            Status = StepStatus.Succeeded,
             Result = result
         };
     }

--- a/src/FlowOrchestrator.Core/Execution/IStepResult.cs
+++ b/src/FlowOrchestrator.Core/Execution/IStepResult.cs
@@ -1,9 +1,11 @@
+using FlowOrchestrator.Core.Abstractions;
+
 namespace FlowOrchestrator.Core.Execution;
 
 public interface IStepResult
 {
     string Key { get; set; }
-    string Status { get; set; }
+    StepStatus Status { get; set; }
     object? Result { get; set; }
     string? FailedReason { get; set; }
     bool ReThrow { get; set; }

--- a/src/FlowOrchestrator.Core/Execution/StepResult.cs
+++ b/src/FlowOrchestrator.Core/Execution/StepResult.cs
@@ -1,9 +1,11 @@
+using FlowOrchestrator.Core.Abstractions;
+
 namespace FlowOrchestrator.Core.Execution;
 
 public sealed class StepResult : IStepResult
 {
     public string Key { get; set; } = default!;
-    public string Status { get; set; } = "Succeeded";
+    public StepStatus Status { get; set; } = StepStatus.Succeeded;
     public object? Result { get; set; }
     public string? FailedReason { get; set; }
     public bool ReThrow { get; set; }

--- a/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
@@ -9,7 +11,9 @@ using Hangfire.Storage;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace FlowOrchestrator.Dashboard;
 
@@ -17,14 +21,48 @@ public static class DashboardServiceCollectionExtensions
 {
     public static IServiceCollection AddFlowDashboard(this IServiceCollection services)
     {
+        services.AddOptions<FlowDashboardOptions>();
+        return services;
+    }
+
+    public static IServiceCollection AddFlowDashboard(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string sectionName = FlowDashboardOptions.DefaultSectionName)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddFlowDashboard();
+        services.Configure<FlowDashboardOptions>(configuration.GetSection(sectionName));
+        return services;
+    }
+
+    public static IServiceCollection AddFlowDashboard(
+        this IServiceCollection services,
+        Action<FlowDashboardOptions> configureOptions)
+    {
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        services.AddFlowDashboard();
+        services.Configure(configureOptions);
         return services;
     }
 
     public static IEndpointRouteBuilder MapFlowDashboard(this IEndpointRouteBuilder endpoints, string basePath = "/flows")
     {
+        var options = endpoints.ServiceProvider
+                          .GetService<IOptions<FlowDashboardOptions>>()?.Value
+                      ?? new FlowDashboardOptions();
+        var group = endpoints.MapGroup(basePath);
+
+        if (options.BasicAuth.IsEnabled)
+        {
+            group.AddEndpointFilter(new FlowDashboardBasicAuthFilter(options.BasicAuth));
+        }
+
         var html = DashboardHtml.Render(basePath);
 
-        endpoints.MapGet(basePath, (HttpContext http) =>
+        group.MapGet("", (HttpContext http) =>
         {
             http.Response.ContentType = "text/html; charset=utf-8";
             return http.Response.WriteAsync(html);
@@ -32,13 +70,13 @@ public static class DashboardServiceCollectionExtensions
 
         // ── Flow catalog endpoints ──
 
-        endpoints.MapGet($"{basePath}/api/flows", async (HttpContext http, IFlowStore store) =>
+        group.MapGet("/api/flows", async (HttpContext http, IFlowStore store) =>
         {
             var flows = await store.GetAllAsync();
             await http.Response.WriteAsJsonAsync(flows);
         });
 
-        endpoints.MapGet($"{basePath}/api/flows/{{id:guid}}", async (HttpContext http, IFlowStore store, Guid id) =>
+        group.MapGet("/api/flows/{id:guid}", async (HttpContext http, IFlowStore store, Guid id) =>
         {
             var flow = await store.GetByIdAsync(id);
             if (flow is null)
@@ -49,7 +87,7 @@ public static class DashboardServiceCollectionExtensions
             await http.Response.WriteAsJsonAsync(flow);
         });
 
-        endpoints.MapPost($"{basePath}/api/flows/{{id:guid}}/enable", async (HttpContext http, IFlowStore store, IRecurringTriggerSync triggerSync, Guid id) =>
+        group.MapPost("/api/flows/{id:guid}/enable", async (HttpContext http, IFlowStore store, IRecurringTriggerSync triggerSync, Guid id) =>
         {
             try
             {
@@ -63,7 +101,7 @@ public static class DashboardServiceCollectionExtensions
             }
         });
 
-        endpoints.MapPost($"{basePath}/api/flows/{{id:guid}}/disable", async (HttpContext http, IFlowStore store, IRecurringTriggerSync triggerSync, Guid id) =>
+        group.MapPost("/api/flows/{id:guid}/disable", async (HttpContext http, IFlowStore store, IRecurringTriggerSync triggerSync, Guid id) =>
         {
             try
             {
@@ -77,7 +115,7 @@ public static class DashboardServiceCollectionExtensions
             }
         });
 
-        endpoints.MapPost($"{basePath}/api/flows/{{id:guid}}/trigger", async (HttpContext http, IFlowRepository repo, Guid id) =>
+        group.MapPost("/api/flows/{id:guid}/trigger", async (HttpContext http, IFlowRepository repo, Guid id) =>
         {
             var flows = await repo.GetAllFlowsAsync();
             var flow = flows.FirstOrDefault(f => f.Id == id);
@@ -195,7 +233,7 @@ public static class DashboardServiceCollectionExtensions
             await http.Response.WriteAsJsonAsync(new { runId = ctx.RunId, message = $"Flow '{flow.GetType().Name}' triggered via webhook." });
         });
 
-        endpoints.MapGet($"{basePath}/api/handlers", (HttpContext http, IEnumerable<IStepHandlerMetadata> handlers) =>
+        group.MapGet("/api/handlers", (HttpContext http, IEnumerable<IStepHandlerMetadata> handlers) =>
         {
             var list = handlers.Select(h => new { type = h.Type }).ToList();
             return http.Response.WriteAsJsonAsync(list);
@@ -203,7 +241,7 @@ public static class DashboardServiceCollectionExtensions
 
         // ── Run monitoring endpoints ──
 
-        endpoints.MapGet($"{basePath}/api/runs", async (HttpContext http, IFlowRunStore store) =>
+        group.MapGet("/api/runs", async (HttpContext http, IFlowRunStore store) =>
         {
             var query = http.Request.Query;
             Guid? flowId = query.TryGetValue("flowId", out var flowIdValues) && Guid.TryParse(flowIdValues, out var fid) ? fid : null;
@@ -214,19 +252,19 @@ public static class DashboardServiceCollectionExtensions
             await http.Response.WriteAsJsonAsync(runs);
         });
 
-        endpoints.MapGet($"{basePath}/api/runs/active", async (HttpContext http, IFlowRunStore store) =>
+        group.MapGet("/api/runs/active", async (HttpContext http, IFlowRunStore store) =>
         {
             var runs = await store.GetActiveRunsAsync();
             await http.Response.WriteAsJsonAsync(runs);
         });
 
-        endpoints.MapGet($"{basePath}/api/runs/stats", async (HttpContext http, IFlowRunStore store) =>
+        group.MapGet("/api/runs/stats", async (HttpContext http, IFlowRunStore store) =>
         {
             var stats = await store.GetStatisticsAsync();
             await http.Response.WriteAsJsonAsync(stats);
         });
 
-        endpoints.MapGet($"{basePath}/api/runs/{{id:guid}}", async (HttpContext http, IFlowRunStore store, Guid id) =>
+        group.MapGet("/api/runs/{id:guid}", async (HttpContext http, IFlowRunStore store, Guid id) =>
         {
             var run = await store.GetRunDetailAsync(id);
             if (run is null)
@@ -237,7 +275,7 @@ public static class DashboardServiceCollectionExtensions
             await http.Response.WriteAsJsonAsync(run);
         });
 
-        endpoints.MapGet($"{basePath}/api/runs/{{id:guid}}/steps", async (HttpContext http, IFlowRunStore store, Guid id) =>
+        group.MapGet("/api/runs/{id:guid}/steps", async (HttpContext http, IFlowRunStore store, Guid id) =>
         {
             var run = await store.GetRunDetailAsync(id);
             if (run is null)
@@ -248,7 +286,7 @@ public static class DashboardServiceCollectionExtensions
             await http.Response.WriteAsJsonAsync(run.Steps ?? []);
         });
 
-        endpoints.MapPost($"{basePath}/api/runs/{{runId:guid}}/steps/{{stepKey}}/retry", async (HttpContext http, IFlowRunStore store, Guid runId, string stepKey) =>
+        group.MapPost("/api/runs/{runId:guid}/steps/{stepKey}/retry", async (HttpContext http, IFlowRunStore store, Guid runId, string stepKey) =>
         {
             var run = await store.GetRunDetailAsync(runId);
             if (run is null)
@@ -272,7 +310,7 @@ public static class DashboardServiceCollectionExtensions
 
         // ── Schedule management endpoints ──
 
-        endpoints.MapGet($"{basePath}/api/schedules", async (HttpContext http, IFlowStore store) =>
+        group.MapGet("/api/schedules", async (HttpContext http, IFlowStore store) =>
         {
             using var connection = JobStorage.Current.GetConnection();
             var recurringJobs = connection.GetRecurringJobs();
@@ -322,7 +360,7 @@ public static class DashboardServiceCollectionExtensions
             await http.Response.WriteAsJsonAsync(result);
         });
 
-        endpoints.MapPost($"{basePath}/api/schedules/{{jobId}}/trigger", async (HttpContext http, IRecurringJobManager manager, string jobId) =>
+        group.MapPost("/api/schedules/{jobId}/trigger", async (HttpContext http, IRecurringJobManager manager, string jobId) =>
         {
             try
             {
@@ -342,7 +380,7 @@ public static class DashboardServiceCollectionExtensions
             }
         });
 
-        endpoints.MapPost($"{basePath}/api/schedules/{{jobId}}/pause", async (HttpContext http, IRecurringJobManager manager, IFlowStore store, string jobId) =>
+        group.MapPost("/api/schedules/{jobId}/pause", async (HttpContext http, IRecurringJobManager manager, IFlowStore store, string jobId) =>
         {
             if (!ParseJobId(jobId, out var flowId, out var triggerKey))
             {
@@ -360,7 +398,7 @@ public static class DashboardServiceCollectionExtensions
             await http.Response.WriteAsJsonAsync(new { success = true, message = $"Job '{jobId}' paused." });
         });
 
-        endpoints.MapPost($"{basePath}/api/schedules/{{jobId}}/resume", async (HttpContext http, IRecurringJobManager manager, IFlowStore store, string jobId) =>
+        group.MapPost("/api/schedules/{jobId}/resume", async (HttpContext http, IRecurringJobManager manager, IFlowStore store, string jobId) =>
         {
             if (!ParseJobId(jobId, out var flowId, out var triggerKey))
             {
@@ -392,7 +430,7 @@ public static class DashboardServiceCollectionExtensions
             await http.Response.WriteAsJsonAsync(new { success = true, message = $"Job '{jobId}' resumed with cron '{cronExpr}'." });
         });
 
-        endpoints.MapPut($"{basePath}/api/schedules/{{jobId}}/cron", async (HttpContext http, IRecurringJobManager manager, IFlowStore store, string jobId) =>
+        group.MapPut("/api/schedules/{jobId}/cron", async (HttpContext http, IRecurringJobManager manager, IFlowStore store, string jobId) =>
         {
             if (!ParseJobId(jobId, out var flowId, out var triggerKey))
             {
@@ -432,6 +470,79 @@ public static class DashboardServiceCollectionExtensions
         });
 
         return endpoints;
+    }
+
+    private sealed class FlowDashboardBasicAuthFilter(FlowDashboardBasicAuthOptions options) : IEndpointFilter
+    {
+        public ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+        {
+            if (IsAuthorized(context.HttpContext, options))
+            {
+                return next(context);
+            }
+
+            var realm = string.IsNullOrWhiteSpace(options.Realm)
+                ? "FlowOrchestrator Dashboard"
+                : options.Realm.Replace("\"", string.Empty, StringComparison.Ordinal);
+
+            context.HttpContext.Response.Headers.WWWAuthenticate = $"Basic realm=\"{realm}\", charset=\"UTF-8\"";
+            return ValueTask.FromResult<object?>(Results.Unauthorized());
+        }
+    }
+
+    private static bool IsAuthorized(HttpContext http, FlowDashboardBasicAuthOptions options)
+    {
+        if (!options.IsEnabled)
+        {
+            return true;
+        }
+
+        if (!http.Request.Headers.TryGetValue("Authorization", out var authHeaders))
+        {
+            return false;
+        }
+
+        const string basicPrefix = "Basic ";
+        var headerValue = authHeaders.ToString();
+        if (!headerValue.StartsWith(basicPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var encoded = headerValue[basicPrefix.Length..].Trim();
+        if (string.IsNullOrWhiteSpace(encoded))
+        {
+            return false;
+        }
+
+        string userAndPassword;
+        try
+        {
+            var decodedBytes = Convert.FromBase64String(encoded);
+            userAndPassword = Encoding.UTF8.GetString(decodedBytes);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        var separatorIndex = userAndPassword.IndexOf(':');
+        if (separatorIndex <= 0)
+        {
+            return false;
+        }
+
+        var username = userAndPassword[..separatorIndex];
+        var password = userAndPassword[(separatorIndex + 1)..];
+        return SecureEquals(username, options.Username!) &&
+               SecureEquals(password, options.Password!);
+    }
+
+    private static bool SecureEquals(string left, string right)
+    {
+        var leftBytes = Encoding.UTF8.GetBytes(left);
+        var rightBytes = Encoding.UTF8.GetBytes(right);
+        return CryptographicOperations.FixedTimeEquals(leftBytes, rightBytes);
     }
 
     private static bool ParseJobId(string jobId, out Guid flowId, out string triggerKey)

--- a/src/FlowOrchestrator.Dashboard/FlowDashboardOptions.cs
+++ b/src/FlowOrchestrator.Dashboard/FlowDashboardOptions.cs
@@ -1,0 +1,21 @@
+namespace FlowOrchestrator.Dashboard;
+
+public sealed class FlowDashboardOptions
+{
+    public const string DefaultSectionName = "FlowDashboard";
+
+    public FlowDashboardBasicAuthOptions BasicAuth { get; set; } = new();
+}
+
+public sealed class FlowDashboardBasicAuthOptions
+{
+    public string? Username { get; set; }
+
+    public string? Password { get; set; }
+
+    public string Realm { get; set; } = "FlowOrchestrator Dashboard";
+
+    public bool IsEnabled =>
+        !string.IsNullOrWhiteSpace(Username) &&
+        !string.IsNullOrWhiteSpace(Password);
+}

--- a/src/FlowOrchestrator.Hangfire/DefaultStepExecutor.cs
+++ b/src/FlowOrchestrator.Hangfire/DefaultStepExecutor.cs
@@ -28,7 +28,7 @@ internal sealed class DefaultStepExecutor : IStepExecutor
             return new StepResult
             {
                 Key = step.Key,
-                Status = "Skipped",
+                Status = StepStatus.Skipped,
                 FailedReason = "Step metadata not found."
             };
         }
@@ -41,7 +41,7 @@ internal sealed class DefaultStepExecutor : IStepExecutor
             return new StepResult
             {
                 Key = step.Key,
-                Status = "Skipped",
+                Status = StepStatus.Skipped,
                 FailedReason = $"No handler registered for type '{metadata.Type}'."
             };
         }

--- a/src/FlowOrchestrator.Hangfire/HangfireFlowOrchestrator.cs
+++ b/src/FlowOrchestrator.Hangfire/HangfireFlowOrchestrator.cs
@@ -117,7 +117,7 @@ public sealed class HangfireFlowOrchestrator : IHangfireFlowTrigger, IHangfireSt
                 result = new StepResult
                 {
                     Key = step.Key,
-                    Status = "Failed",
+                    Status = StepStatus.Failed,
                     FailedReason = ex.ToString(),
                     ReThrow = false
                 };
@@ -126,12 +126,23 @@ public sealed class HangfireFlowOrchestrator : IHangfireFlowTrigger, IHangfireSt
             try
             {
                 var outputJson = SafeSerialize(result.Result);
-                await _runStore.RecordStepCompleteAsync(ctx.RunId, step.Key, result.Status, outputJson, result.FailedReason)
+                await _runStore.RecordStepCompleteAsync(ctx.RunId, step.Key, result.Status.ToString(), outputJson, result.FailedReason)
                     .ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to track step completion.");
+            }
+
+            if (result.Status == StepStatus.Pending)
+            {
+                var retryDelay = result.DelayNextStep ?? TimeSpan.FromSeconds(10);
+
+                _backgroundJobClient.Schedule<IHangfireStepRunner>(
+                    runner => runner.RunStepAsync(ctx, flow, step, null),
+                    retryDelay);
+
+                return result.Result;
             }
 
             var next = await _flowExecutor.GetNextStep(ctx, flow, step, result).ConfigureAwait(false);
@@ -153,7 +164,7 @@ public sealed class HangfireFlowOrchestrator : IHangfireFlowTrigger, IHangfireSt
             {
                 try
                 {
-                    await _runStore.CompleteRunAsync(ctx.RunId, result.Status).ConfigureAwait(false);
+                    await _runStore.CompleteRunAsync(ctx.RunId, result.Status.ToString()).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {

--- a/tests/FlowOrchestrator.Core.Tests/Abstractions/StepCollectionTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Abstractions/StepCollectionTests.cs
@@ -71,7 +71,7 @@ public class StepCollectionTests
         var step2 = new StepMetadata
         {
             Type = "B",
-            RunAfter = new RunAfterCollection { ["step1"] = new[] { "Succeeded" } }
+            RunAfter = new RunAfterCollection { ["step1"] = new[] { StepStatus.Succeeded } }
         };
         var collection = new StepCollection
         {
@@ -98,7 +98,7 @@ public class StepCollectionTests
         var step2 = new StepMetadata
         {
             Type = "B",
-            RunAfter = new RunAfterCollection { ["other"] = new[] { "Succeeded" } }
+            RunAfter = new RunAfterCollection { ["other"] = new[] { StepStatus.Succeeded } }
         };
         var collection = new StepCollection
         {

--- a/tests/FlowOrchestrator.Core.Tests/Abstractions/StepMetadataTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Abstractions/StepMetadataTests.cs
@@ -10,7 +10,7 @@ public class StepMetadataTests
     {
         var step = new StepMetadata { Type = "A", RunAfter = new RunAfterCollection() };
 
-        step.ShouldExecute("anyStep", "Succeeded").Should().BeTrue();
+        step.ShouldExecute("anyStep", StepStatus.Succeeded).Should().BeTrue();
     }
 
     [Fact]
@@ -19,11 +19,11 @@ public class StepMetadataTests
         var step = new StepMetadata
         {
             Type = "B",
-            RunAfter = new RunAfterCollection { ["step1"] = new[] { "Succeeded", "Failed" } }
+            RunAfter = new RunAfterCollection { ["step1"] = new[] { StepStatus.Succeeded, StepStatus.Failed } }
         };
 
-        step.ShouldExecute("step1", "Succeeded").Should().BeTrue();
-        step.ShouldExecute("step1", "Failed").Should().BeTrue();
+        step.ShouldExecute("step1", StepStatus.Succeeded).Should().BeTrue();
+        step.ShouldExecute("step1", StepStatus.Failed).Should().BeTrue();
     }
 
     [Fact]
@@ -32,10 +32,10 @@ public class StepMetadataTests
         var step = new StepMetadata
         {
             Type = "B",
-            RunAfter = new RunAfterCollection { ["step1"] = new[] { "Succeeded" } }
+            RunAfter = new RunAfterCollection { ["step1"] = new[] { StepStatus.Succeeded } }
         };
 
-        step.ShouldExecute("step1", "Failed").Should().BeFalse();
+        step.ShouldExecute("step1", StepStatus.Failed).Should().BeFalse();
     }
 
     [Fact]
@@ -44,23 +44,10 @@ public class StepMetadataTests
         var step = new StepMetadata
         {
             Type = "B",
-            RunAfter = new RunAfterCollection { ["step1"] = new[] { "Succeeded" } }
+            RunAfter = new RunAfterCollection { ["step1"] = new[] { StepStatus.Succeeded } }
         };
 
-        step.ShouldExecute("step2", "Succeeded").Should().BeFalse();
-    }
-
-    [Fact]
-    public void ShouldExecute_CaseInsensitiveStatusMatch()
-    {
-        var step = new StepMetadata
-        {
-            Type = "B",
-            RunAfter = new RunAfterCollection { ["step1"] = new[] { "Succeeded" } }
-        };
-
-        step.ShouldExecute("step1", "succeeded").Should().BeTrue();
-        step.ShouldExecute("step1", "SUCCEEDED").Should().BeTrue();
+        step.ShouldExecute("step2", StepStatus.Succeeded).Should().BeFalse();
     }
 
     [Fact]

--- a/tests/FlowOrchestrator.Core.Tests/Execution/FlowExecutorTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Execution/FlowExecutorTests.cs
@@ -44,7 +44,7 @@ public class FlowExecutorTests
             ["step2"] = new StepMetadata
             {
                 Type = "Save",
-                RunAfter = new RunAfterCollection { ["step1"] = new[] { "Succeeded" } }
+                RunAfter = new RunAfterCollection { ["step1"] = new[] { StepStatus.Succeeded } }
             }
         };
         var flow = CreateFlow(steps);
@@ -66,7 +66,7 @@ public class FlowExecutorTests
             ["step1"] = new StepMetadata
             {
                 Type = "A",
-                RunAfter = new RunAfterCollection { ["step0"] = new[] { "Succeeded" } }
+                RunAfter = new RunAfterCollection { ["step0"] = new[] { StepStatus.Succeeded } }
             }
         };
         var flow = CreateFlow(steps);
@@ -87,14 +87,14 @@ public class FlowExecutorTests
             ["step2"] = new StepMetadata
             {
                 Type = "B",
-                RunAfter = new RunAfterCollection { ["step1"] = new[] { "Succeeded" } },
+                RunAfter = new RunAfterCollection { ["step1"] = new[] { StepStatus.Succeeded } },
                 Inputs = new Dictionary<string, object?> { ["key"] = "val" }
             }
         };
         var flow = CreateFlow(steps);
         var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
         var currentStep = new StepInstance("step1", "A") { RunId = ctx.RunId };
-        var result = new StepResult { Key = "step1", Status = "Succeeded" };
+        var result = new StepResult { Key = "step1", Status = StepStatus.Succeeded };
 
         var next = await _sut.GetNextStep(ctx, flow, currentStep, result);
 
@@ -114,7 +114,7 @@ public class FlowExecutorTests
         var flow = CreateFlow(steps);
         var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
         var currentStep = new StepInstance("step1", "A") { RunId = ctx.RunId };
-        var result = new StepResult { Key = "step1", Status = "Succeeded" };
+        var result = new StepResult { Key = "step1", Status = StepStatus.Succeeded };
 
         var next = await _sut.GetNextStep(ctx, flow, currentStep, result);
 
@@ -130,13 +130,13 @@ public class FlowExecutorTests
             ["step2"] = new StepMetadata
             {
                 Type = "B",
-                RunAfter = new RunAfterCollection { ["step1"] = new[] { "Succeeded" } }
+                RunAfter = new RunAfterCollection { ["step1"] = new[] { StepStatus.Succeeded } }
             }
         };
         var flow = CreateFlow(steps);
         var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
         var currentStep = new StepInstance("step1", "A") { RunId = ctx.RunId };
-        var result = new StepResult { Key = "step1", Status = "Failed" };
+        var result = new StepResult { Key = "step1", Status = StepStatus.Failed };
 
         var next = await _sut.GetNextStep(ctx, flow, currentStep, result);
 

--- a/tests/FlowOrchestrator.Core.Tests/Execution/StepResultTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Execution/StepResultTests.cs
@@ -1,3 +1,4 @@
+using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
 using FluentAssertions;
 
@@ -10,7 +11,7 @@ public class StepResultTests
     {
         var result = new StepResult();
 
-        result.Status.Should().Be("Succeeded");
+        result.Status.Should().Be(StepStatus.Succeeded);
     }
 
     [Fact]
@@ -36,7 +37,7 @@ public class StepResultTests
         var result = new StepResult
         {
             Key = "step1",
-            Status = "Failed",
+            Status = StepStatus.Failed,
             Result = new { data = 42 },
             FailedReason = "Something went wrong",
             ReThrow = true,
@@ -44,7 +45,7 @@ public class StepResultTests
         };
 
         result.Key.Should().Be("step1");
-        result.Status.Should().Be("Failed");
+        result.Status.Should().Be(StepStatus.Failed);
         result.Result.Should().NotBeNull();
         result.FailedReason.Should().Be("Something went wrong");
         result.ReThrow.Should().BeTrue();

--- a/tests/FlowOrchestrator.Core.Tests/Serialization/StepMetadataJsonConverterTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Serialization/StepMetadataJsonConverterTests.cs
@@ -25,7 +25,7 @@ public class StepMetadataJsonConverterTests
         result.Should().BeOfType<StepMetadata>().And.NotBeOfType<LoopStepMetadata>();
         result!.Type.Should().Be("LogMessage");
         result.RunAfter.Should().ContainKey("step0");
-        result.RunAfter["step0"].Should().Contain("Succeeded");
+        result.RunAfter["step0"].Should().Contain(StepStatus.Succeeded);
         result.Inputs.Should().ContainKey("message");
     }
 
@@ -61,7 +61,7 @@ public class StepMetadataJsonConverterTests
         var step = new StepMetadata
         {
             Type = "LogMessage",
-            RunAfter = new RunAfterCollection { ["step0"] = new[] { "Succeeded" } },
+            RunAfter = new RunAfterCollection { ["step0"] = new[] { StepStatus.Succeeded } },
             Inputs = new Dictionary<string, object?> { ["message"] = "hello" }
         };
 
@@ -78,7 +78,7 @@ public class StepMetadataJsonConverterTests
         var original = new StepMetadata
         {
             Type = "QueryDatabase",
-            RunAfter = new RunAfterCollection { ["prev"] = new[] { "Succeeded", "Failed" } },
+            RunAfter = new RunAfterCollection { ["prev"] = new[] { StepStatus.Succeeded, StepStatus.Failed } },
             Inputs = new Dictionary<string, object?> { ["sql"] = "SELECT 1", ["timeout"] = 30 }
         };
 
@@ -88,7 +88,7 @@ public class StepMetadataJsonConverterTests
         deserialized.Should().NotBeNull();
         deserialized!.Type.Should().Be(original.Type);
         deserialized.RunAfter.Should().ContainKey("prev");
-        deserialized.RunAfter["prev"].Should().BeEquivalentTo(new[] { "Succeeded", "Failed" });
+        deserialized.RunAfter["prev"].Should().BeEquivalentTo(new[] { StepStatus.Succeeded, StepStatus.Failed });
     }
 
     [Fact]

--- a/tests/FlowOrchestrator.Hangfire.Tests/DefaultStepExecutorTests.cs
+++ b/tests/FlowOrchestrator.Hangfire.Tests/DefaultStepExecutorTests.cs
@@ -35,7 +35,7 @@ public class DefaultStepExecutorTests
 
         var result = await executor.ExecuteAsync(ctx, flow, step);
 
-        result.Status.Should().Be("Skipped");
+        result.Status.Should().Be(StepStatus.Skipped);
         result.FailedReason.Should().Contain("not found");
     }
 
@@ -53,7 +53,7 @@ public class DefaultStepExecutorTests
 
         var result = await executor.ExecuteAsync(ctx, flow, step);
 
-        result.Status.Should().Be("Skipped");
+        result.Status.Should().Be(StepStatus.Skipped);
         result.FailedReason.Should().Contain("No handler");
     }
 
@@ -71,13 +71,13 @@ public class DefaultStepExecutorTests
         var handlerMeta = Substitute.For<IStepHandlerMetadata>();
         handlerMeta.Type.Returns("LogMessage");
         handlerMeta.ExecuteAsync(_serviceProvider, ctx, flow, step)
-            .Returns(new StepResult { Key = "step1", Status = "Succeeded", Result = "done" });
+            .Returns(new StepResult { Key = "step1", Status = StepStatus.Succeeded, Result = "done" });
 
         var executor = CreateExecutor(handlerMeta);
 
         var result = await executor.ExecuteAsync(ctx, flow, step);
 
-        result.Status.Should().Be("Succeeded");
+        result.Status.Should().Be(StepStatus.Succeeded);
         result.Key.Should().Be("step1");
         await handlerMeta.Received(1).ExecuteAsync(_serviceProvider, ctx, flow, step);
     }
@@ -96,7 +96,7 @@ public class DefaultStepExecutorTests
         var handlerMeta = Substitute.For<IStepHandlerMetadata>();
         handlerMeta.Type.Returns("LogMessage");
         handlerMeta.ExecuteAsync(default!, default!, default!, default!)
-            .ReturnsForAnyArgs(new StepResult { Key = "step1", Status = "Succeeded" });
+            .ReturnsForAnyArgs(new StepResult { Key = "step1", Status = StepStatus.Succeeded });
 
         var executor = CreateExecutor(handlerMeta);
 
@@ -119,12 +119,12 @@ public class DefaultStepExecutorTests
         var handlerMeta = Substitute.For<IStepHandlerMetadata>();
         handlerMeta.Type.Returns("LogMessage");
         handlerMeta.ExecuteAsync(default!, default!, default!, default!)
-            .ReturnsForAnyArgs(new StepResult { Key = "step1", Status = "Succeeded" });
+            .ReturnsForAnyArgs(new StepResult { Key = "step1", Status = StepStatus.Succeeded });
 
         var executor = CreateExecutor(handlerMeta);
 
         var result = await executor.ExecuteAsync(ctx, flow, step);
 
-        result.Status.Should().Be("Succeeded");
+        result.Status.Should().Be(StepStatus.Succeeded);
     }
 }

--- a/tests/FlowOrchestrator.Hangfire.Tests/HangfireFlowOrchestratorTests.cs
+++ b/tests/FlowOrchestrator.Hangfire.Tests/HangfireFlowOrchestratorTests.cs
@@ -145,7 +145,7 @@ public class HangfireFlowOrchestratorTests
         var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
         var step = new StepInstance("step1", "LogMessage") { RunId = ctx.RunId };
 
-        var stepResult = new StepResult { Key = "step1", Status = "Succeeded", Result = "ok" };
+        var stepResult = new StepResult { Key = "step1", Status = StepStatus.Succeeded, Result = "ok" };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
         _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns((IStepInstance?)null);
 
@@ -162,7 +162,7 @@ public class HangfireFlowOrchestratorTests
         var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
         var step = new StepInstance("step1", "LogMessage") { RunId = ctx.RunId };
 
-        var stepResult = new StepResult { Key = "step1", Status = "Succeeded" };
+        var stepResult = new StepResult { Key = "step1", Status = StepStatus.Succeeded };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
         _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns((IStepInstance?)null);
 
@@ -180,12 +180,41 @@ public class HangfireFlowOrchestratorTests
         var step = new StepInstance("step1", "A") { RunId = ctx.RunId };
         var nextStep = new StepInstance("step2", "B") { RunId = ctx.RunId };
 
-        var stepResult = new StepResult { Key = "step1", Status = "Succeeded" };
+        var stepResult = new StepResult { Key = "step1", Status = StepStatus.Succeeded };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
         _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns(nextStep);
 
         await sut.RunStepAsync(ctx, flow, step);
 
+        await _runStore.DidNotReceive().CompleteRunAsync(Arg.Any<Guid>(), Arg.Any<string>());
+        _jobClient.ReceivedCalls().Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task RunStepAsync_PendingStatus_ReschedulesCurrentStep()
+    {
+        var sut = CreateSut();
+        var flow = CreateFlow();
+        var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
+        var step = new StepInstance("step1", "LogMessage") { RunId = ctx.RunId };
+
+        var stepResult = new StepResult
+        {
+            Key = "step1",
+            Status = StepStatus.Pending,
+            DelayNextStep = TimeSpan.FromSeconds(3)
+        };
+        _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
+
+        await sut.RunStepAsync(ctx, flow, step);
+
+        await _runStore.Received(1).RecordStepCompleteAsync(
+            ctx.RunId, "step1", "Pending", Arg.Any<string?>(), Arg.Any<string?>());
+        await _flowExecutor.DidNotReceive().GetNextStep(
+            Arg.Any<IExecutionContext>(),
+            Arg.Any<IFlowDefinition>(),
+            Arg.Any<IStepInstance>(),
+            Arg.Any<IStepResult>());
         await _runStore.DidNotReceive().CompleteRunAsync(Arg.Any<Guid>(), Arg.Any<string>());
         _jobClient.ReceivedCalls().Should().NotBeEmpty();
     }
@@ -215,7 +244,7 @@ public class HangfireFlowOrchestratorTests
         var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
         var step = new StepInstance("step1", "LogMessage") { RunId = ctx.RunId };
 
-        var stepResult = new StepResult { Key = "step1", Status = "Failed", ReThrow = true, FailedReason = "critical" };
+        var stepResult = new StepResult { Key = "step1", Status = StepStatus.Failed, ReThrow = true, FailedReason = "critical" };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
         _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns((IStepInstance?)null);
 


### PR DESCRIPTION
- Introduced FlowDashboardOptions and FlowDashboardBasicAuthOptions classes for configuration.
- Updated appsettings.json and appsettings.Development.json to include BasicAuth settings.
- Implemented BasicAuth filter in DashboardServiceCollectionExtensions to secure dashboard endpoints.
- Modified existing endpoints to utilize the new BasicAuth filter.
- Added new enum StepStatus to standardize step statuses across the application.
- Refactored RunAfterCollection to use StepStatus instead of string arrays.
- Updated various classes and tests to accommodate the new StepStatus enum.
- Created new flows: OrderStatus and PollingDemoFlow to demonstrate usage of the new features.