### PR TITLE
feat: Add support for .NET 10.0 and update versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           dotnet-version: |
             8.0.x
             9.0.x
+            10.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
           dotnet-version: |
             8.0.x
             9.0.x
+            10.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <RepositoryUrl>https://github.com/hoangsnowy/FlowOrchestrator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/hoangsnowy/FlowOrchestrator</PackageProjectUrl>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.3.1</VersionPrefix>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ FlowOrchestrator is an open-source .NET library that lets you **orchestrate work
 
 ---
 
+## Compatibility
+
+- NuGet packages (`FlowOrchestrator.Core`, `FlowOrchestrator.Hangfire`, `FlowOrchestrator.SqlServer`, `FlowOrchestrator.Dashboard`) target: `net8.0`, `net9.0`, `net10.0`.
+- Demo projects (`FlowOrchestrator.SampleApp`, `FlowOrchestrator.AppHost`) currently run on `net8.0`.
+
+---
+
 ## 1. High-level design
 
 - **Flow**
@@ -16,12 +23,12 @@ FlowOrchestrator is an open-source .NET library that lets you **orchestrate work
   Each step has:
   - `type`: logical name (e.g. `ValidateOrder`, `ProcessPayment`).
   - `runAfter`: declarative dependencies on previous steps and their statuses.
-  - `inputs`: expressions referencing trigger/body or previous step outputs.
+  - `inputs`: expressions referencing trigger body/headers or previous step outputs.
 
 - **Execution engine (`FlowOrchestrator.Core`)**
   - `IFlowExecutor`: decides which step to run next.
   - `IStepExecutor`: resolves inputs, invokes the right handler, stores outputs.
-  - `IOutputsRepository`: stores trigger data, step inputs/outputs, events.
+  - `IOutputsRepository`: stores trigger data/headers, step inputs/outputs, events.
   - `IFlowStore` / `IFlowRunStore`: abstractions for persistence of flows and run history.
   - `IFlowRepository`: in-memory registry of code-defined `IFlowDefinition` instances.
 
@@ -121,6 +128,7 @@ The app starts on `http://localhost:5201` by default.
 Open `http://localhost:5201/flows` to access the built-in dashboard.
 If `FlowDashboard:BasicAuth` is configured, the browser will prompt for HTTP Basic credentials.
 Webhook endpoint (`/flows/api/webhook/{idOrSlug}`) is intentionally not protected by dashboard basic auth; use `webhookSecret` for webhook security.
+Manual trigger and webhook endpoints capture request body plus non-sensitive headers for input expressions (see section 5.5).
 
 ### Pages
 
@@ -212,6 +220,26 @@ Content-Type: application/json
 {}
 ```
 
+### 5.5 Trigger expression reference (`inputs`)
+
+`FlowOrchestrator.Hangfire` supports trigger expressions in step inputs:
+
+```json
+{
+  "orderId": "@triggerBody()?.orderId",
+  "requestId": "@triggerHeaders()['X-Request-Id']",
+  "allHeaders": "@triggerHeaders()"
+}
+```
+
+- `@triggerBody()` returns the full trigger payload as JSON.
+- `@triggerBody()?.path.to.value` returns a specific value from trigger payload.
+- `@triggerHeaders()` returns all captured trigger headers as JSON object.
+- `@triggerHeaders()['Header-Name']` (or `["Header-Name"]`) returns a specific header value.
+
+Captured headers are case-insensitive and exclude sensitive/transport headers:
+`Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`, `X-Webhook-Key`, `Connection`, `Transfer-Encoding`, `Upgrade`, `Content-Length`.
+
 ---
 
 ## 6. Writing your own flow
@@ -239,7 +267,11 @@ public sealed class MyFlow : IFlowDefinition
             ["validateOrder"] = new StepMetadata
             {
                 Type = "ValidateOrder",
-                Inputs = new Dictionary<string, object?> { ["orderId"] = "@triggerBody()?.orderId" }
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["orderId"] = "@triggerBody()?.orderId",
+                    ["requestId"] = "@triggerHeaders()['X-Request-Id']"
+                }
             },
             ["processPayment"] = new StepMetadata
             {
@@ -257,11 +289,11 @@ public sealed class MyFlow : IFlowDefinition
 |------|-------------|-----------------|
 | `Manual` | Triggered by dashboard button or API call | None |
 | `Cron` | Runs on a recurring schedule via Hangfire `RecurringJob` | `cronExpression` (Hangfire cron syntax, e.g. `*/5 * * * *`) |
-| `Webhook` | Triggered by external HTTP POST (e.g. customer webhook) | Optional: `webhookSlug` (URL path), `webhookSecret` (for `X-Webhook-Key` validation) |
+| `Webhook` | Triggered by external HTTP POST (e.g. customer webhook) | Optional: `webhookSlug` (URL path), `webhookSecret` (for `X-Webhook-Key` validation). Trigger body and non-sensitive headers are available via expressions |
 
 Cron triggers are automatically registered as Hangfire recurring jobs on startup. Disabling a flow via the dashboard removes its recurring jobs; re-enabling restores them.
 
-**Webhook trigger:** Use `POST /flows/api/webhook/{flowId}` or `POST /flows/api/webhook/{slug}` to trigger from external systems. If `webhookSecret` is set in the trigger inputs, clients must send `X-Webhook-Key: <secret>` or `Authorization: Bearer <secret>`. The dashboard shows the webhook URL and a Copy button in the Triggers tab.
+**Webhook trigger:** Use `POST /flows/api/webhook/{flowId}` or `POST /flows/api/webhook/{slug}` to trigger from external systems. If `webhookSecret` is set in the trigger inputs, clients must send `X-Webhook-Key: <secret>` or `Authorization: Bearer <secret>`. The dashboard shows the webhook URL and a Copy button in the Triggers tab. `X-Webhook-Key` and other sensitive headers are intentionally excluded from captured trigger headers.
 
 ### 6.2 Implement step handlers
 

--- a/src/FlowOrchestrator.Core/Execution/ExecutionContext.cs
+++ b/src/FlowOrchestrator.Core/Execution/ExecutionContext.cs
@@ -5,4 +5,5 @@ public sealed class ExecutionContext : IExecutionContext
     public Guid RunId { get; set; }
     public string? PrincipalId { get; set; }
     public object? TriggerData { get; set; }
+    public IReadOnlyDictionary<string, string>? TriggerHeaders { get; set; }
 }

--- a/src/FlowOrchestrator.Core/Execution/FlowExecutor.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowExecutor.cs
@@ -15,7 +15,9 @@ public sealed class FlowExecutor : IFlowExecutor
     public async ValueTask<IStepInstance> TriggerFlow(ITriggerContext context)
     {
         context.TriggerData = context.Trigger.Data;
+        context.TriggerHeaders = context.Trigger.Headers;
         await _outputsRepository.SaveTriggerDataAsync(context, context.Flow, context.Trigger).ConfigureAwait(false);
+        await _outputsRepository.SaveTriggerHeadersAsync(context, context.Flow, context.Trigger).ConfigureAwait(false);
 
         var steps = context.Flow.Manifest.Steps;
 
@@ -31,6 +33,7 @@ public sealed class FlowExecutor : IFlowExecutor
             RunId = context.RunId,
             PrincipalId = context.PrincipalId,
             TriggerData = context.TriggerData,
+            TriggerHeaders = context.TriggerHeaders,
             ScheduledTime = DateTimeOffset.UtcNow,
             Inputs = new Dictionary<string, object?>(first.Value.Inputs)
         };
@@ -59,6 +62,7 @@ public sealed class FlowExecutor : IFlowExecutor
             RunId = context.RunId,
             PrincipalId = context.PrincipalId,
             TriggerData = context.TriggerData,
+            TriggerHeaders = context.TriggerHeaders,
             ScheduledTime = DateTimeOffset.UtcNow,
             Inputs = new Dictionary<string, object?>(nextMetadata.Inputs)
         };

--- a/src/FlowOrchestrator.Core/Execution/IExecutionContext.cs
+++ b/src/FlowOrchestrator.Core/Execution/IExecutionContext.cs
@@ -5,4 +5,5 @@ public interface IExecutionContext
     Guid RunId { get; set; }
     string? PrincipalId { get; set; }
     object? TriggerData { get; set; }
+    IReadOnlyDictionary<string, string>? TriggerHeaders { get; set; }
 }

--- a/src/FlowOrchestrator.Core/Execution/ITrigger.cs
+++ b/src/FlowOrchestrator.Core/Execution/ITrigger.cs
@@ -5,4 +5,5 @@ public interface ITrigger
     string Key { get; }
     string Type { get; }
     object? Data { get; }
+    IReadOnlyDictionary<string, string>? Headers { get; }
 }

--- a/src/FlowOrchestrator.Core/Execution/StepInstance.cs
+++ b/src/FlowOrchestrator.Core/Execution/StepInstance.cs
@@ -11,6 +11,7 @@ public sealed class StepInstance : IStepInstance
     public Guid RunId { get; set; }
     public string? PrincipalId { get; set; }
     public object? TriggerData { get; set; }
+    public IReadOnlyDictionary<string, string>? TriggerHeaders { get; set; }
     public DateTimeOffset ScheduledTime { get; set; }
     public string Type { get; set; }
     public string Key { get; }

--- a/src/FlowOrchestrator.Core/Execution/Trigger.cs
+++ b/src/FlowOrchestrator.Core/Execution/Trigger.cs
@@ -2,14 +2,16 @@ namespace FlowOrchestrator.Core.Execution;
 
 public sealed class Trigger : ITrigger
 {
-    public Trigger(string key, string type, object? data)
+    public Trigger(string key, string type, object? data, IReadOnlyDictionary<string, string>? headers = null)
     {
         Key = key;
         Type = type;
         Data = data;
+        Headers = headers;
     }
 
     public string Key { get; }
     public string Type { get; }
     public object? Data { get; }
+    public IReadOnlyDictionary<string, string>? Headers { get; }
 }

--- a/src/FlowOrchestrator.Core/Execution/TriggerContext.cs
+++ b/src/FlowOrchestrator.Core/Execution/TriggerContext.cs
@@ -7,6 +7,7 @@ public sealed class TriggerContext : ITriggerContext
     public Guid RunId { get; set; }
     public string? PrincipalId { get; set; }
     public object? TriggerData { get; set; }
+    public IReadOnlyDictionary<string, string>? TriggerHeaders { get; set; }
     public IFlowDefinition Flow { get; set; } = default!;
     public ITrigger Trigger { get; set; } = default!;
     public string? JobId { get; set; }

--- a/src/FlowOrchestrator.Core/FlowOrchestrator.Core.csproj
+++ b/src/FlowOrchestrator.Core/FlowOrchestrator.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/FlowOrchestrator.Core/Storage/IOutputsRepository.cs
+++ b/src/FlowOrchestrator.Core/Storage/IOutputsRepository.cs
@@ -8,6 +8,8 @@ public interface IOutputsRepository
     ValueTask SaveStepOutputAsync(IExecutionContext ctx, IFlowDefinition flow, IStepInstance step, IStepResult result);
     ValueTask SaveTriggerDataAsync(ITriggerContext ctx, IFlowDefinition flow, ITrigger trigger);
     ValueTask<object?> GetTriggerDataAsync(Guid runId);
+    ValueTask SaveTriggerHeadersAsync(ITriggerContext ctx, IFlowDefinition flow, ITrigger trigger);
+    ValueTask<IReadOnlyDictionary<string, string>?> GetTriggerHeadersAsync(Guid runId);
     ValueTask SaveStepInputAsync(IExecutionContext ctx, IFlowDefinition flow, IStepInstance step);
     ValueTask<object?> GetStepOutputAsync(Guid runId, string stepKey);
     ValueTask EndScopeAsync(IExecutionContext ctx, IFlowDefinition flow, IStepInstance step);

--- a/src/FlowOrchestrator.Core/Storage/InMemoryOutputsRepository.cs
+++ b/src/FlowOrchestrator.Core/Storage/InMemoryOutputsRepository.cs
@@ -10,6 +10,7 @@ public sealed class InMemoryOutputsRepository : IOutputsRepository
     private static readonly JsonSerializerOptions _webOptions = new(JsonSerializerDefaults.Web);
 
     private readonly ConcurrentDictionary<Guid, JsonElement> _triggerData = new();
+    private readonly ConcurrentDictionary<Guid, IReadOnlyDictionary<string, string>> _triggerHeaders = new();
     private readonly ConcurrentDictionary<(Guid RunId, string StepKey), JsonElement> _stepOutputs = new();
 
     private static JsonElement ToJsonElement(object? value)
@@ -44,6 +45,21 @@ public sealed class InMemoryOutputsRepository : IOutputsRepository
         }
 
         return ValueTask.FromResult<object?>(null);
+    }
+
+    public ValueTask SaveTriggerHeadersAsync(ITriggerContext ctx, IFlowDefinition flow, ITrigger trigger)
+    {
+        if (trigger.Headers is not null)
+        {
+            _triggerHeaders[ctx.RunId] = trigger.Headers;
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<IReadOnlyDictionary<string, string>?> GetTriggerHeadersAsync(Guid runId)
+    {
+        _triggerHeaders.TryGetValue(runId, out var headers);
+        return ValueTask.FromResult<IReadOnlyDictionary<string, string>?>(headers);
     }
 
     public ValueTask SaveStepInputAsync(IExecutionContext ctx, IFlowDefinition flow, IStepInstance step)

--- a/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
@@ -19,6 +19,13 @@ namespace FlowOrchestrator.Dashboard;
 
 public static class DashboardServiceCollectionExtensions
 {
+    // Headers excluded from trigger capture: sensitive auth/session headers and low-level transport headers
+    private static readonly HashSet<string> _sensitiveHeaders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Authorization", "Cookie", "Set-Cookie",
+        "X-Webhook-Key", "Proxy-Authorization",
+        "Connection", "Transfer-Encoding", "Upgrade", "Content-Length"
+    };
     public static IServiceCollection AddFlowDashboard(this IServiceCollection services)
     {
         services.AddOptions<FlowDashboardOptions>();
@@ -115,7 +122,7 @@ public static class DashboardServiceCollectionExtensions
             }
         });
 
-        group.MapPost("/api/flows/{id:guid}/trigger", async (HttpContext http, IFlowRepository repo, Guid id) =>
+        group.MapPost("/api/flows/{id:guid}/trigger", async (HttpContext http, IFlowRepository repo, Guid id, IHangfireFlowTrigger flowTrigger) =>
         {
             var flows = await repo.GetAllFlowsAsync();
             var flow = flows.FirstOrDefault(f => f.Id == id);
@@ -126,19 +133,25 @@ public static class DashboardServiceCollectionExtensions
                 return;
             }
 
-            object? body = null;
-            if (http.Request.ContentLength > 0)
+            var (isValidBody, body) = await TryReadJsonBodyAsync(http.Request);
+            if (!isValidBody)
             {
-                body = await JsonSerializer.DeserializeAsync<object>(http.Request.Body);
+                http.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await http.Response.WriteAsJsonAsync(new { error = "Invalid JSON payload." });
+                return;
             }
+
+            var headers = (IReadOnlyDictionary<string, string>)http.Request.Headers
+                .Where(h => !_sensitiveHeaders.Contains(h.Key))
+                .ToDictionary(h => h.Key, h => h.Value.ToString(), StringComparer.OrdinalIgnoreCase);
 
             var ctx = new TriggerContext
             {
                 RunId = Guid.NewGuid(),
                 Flow = flow,
-                Trigger = new Trigger("manual", "Manual", body)
+                Trigger = new Trigger("manual", "Manual", body, headers)
             };
-            BackgroundJob.Enqueue<IHangfireFlowTrigger>(t => t.TriggerAsync(ctx, null));
+            await flowTrigger.TriggerAsync(ctx);
             await http.Response.WriteAsJsonAsync(new { runId = ctx.RunId, message = $"Flow '{flow.GetType().Name}' triggered." });
         });
 
@@ -146,7 +159,7 @@ public static class DashboardServiceCollectionExtensions
         // - idOrSlug = flow GUID: use first Webhook trigger (only Webhook has external URL)
         // - idOrSlug = slug: lookup flow by webhookSlug in Webhook trigger Inputs
         // - If trigger has webhookSecret in Inputs, require X-Webhook-Key header to match
-        endpoints.MapPost($"{basePath}/api/webhook/{{idOrSlug}}", async (HttpContext http, IFlowRepository repo, IFlowStore store, string idOrSlug) =>
+        endpoints.MapPost($"{basePath}/api/webhook/{{idOrSlug}}", async (HttpContext http, IFlowRepository repo, IFlowStore store, string idOrSlug, IHangfireFlowTrigger flowTrigger) =>
         {
             var flows = (await repo.GetAllFlowsAsync()).ToList();
             Core.Abstractions.IFlowDefinition? flow = null;
@@ -217,19 +230,25 @@ public static class DashboardServiceCollectionExtensions
                 }
             }
 
-            object? body = null;
-            if (http.Request.ContentLength > 0)
+            var (isValidBody, body) = await TryReadJsonBodyAsync(http.Request);
+            if (!isValidBody)
             {
-                body = await JsonSerializer.DeserializeAsync<object>(http.Request.Body);
+                http.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await http.Response.WriteAsJsonAsync(new { error = "Invalid JSON payload." });
+                return;
             }
+
+            var headers = (IReadOnlyDictionary<string, string>)http.Request.Headers
+                .Where(h => !_sensitiveHeaders.Contains(h.Key))
+                .ToDictionary(h => h.Key, h => h.Value.ToString(), StringComparer.OrdinalIgnoreCase);
 
             var ctx = new TriggerContext
             {
                 RunId = Guid.NewGuid(),
                 Flow = flow,
-                Trigger = new Trigger(triggerKey, TriggerType.Webhook.ToString(), body)
+                Trigger = new Trigger(triggerKey, TriggerType.Webhook.ToString(), body, headers)
             };
-            BackgroundJob.Enqueue<IHangfireFlowTrigger>(t => t.TriggerAsync(ctx, null));
+            await flowTrigger.TriggerAsync(ctx);
             await http.Response.WriteAsJsonAsync(new { runId = ctx.RunId, message = $"Flow '{flow.GetType().Name}' triggered via webhook." });
         });
 
@@ -493,6 +512,40 @@ public static class DashboardServiceCollectionExtensions
         });
 
         return endpoints;
+    }
+
+    private static async ValueTask<(bool IsValidBody, object? Body)> TryReadJsonBodyAsync(HttpRequest request)
+    {
+        if (request.ContentLength == 0)
+        {
+            return (true, null);
+        }
+
+        try
+        {
+            if (request.ContentLength is > 0)
+            {
+                var body = await JsonSerializer.DeserializeAsync<object>(request.Body);
+                return (true, body);
+            }
+
+            // Content-Length may be null for chunked requests. Buffer once so we can
+            // treat empty payload as "no body" instead of throwing JSON parse errors.
+            using var buffered = new MemoryStream();
+            await request.Body.CopyToAsync(buffered);
+            if (buffered.Length == 0)
+            {
+                return (true, null);
+            }
+
+            buffered.Position = 0;
+            var chunkedBody = await JsonSerializer.DeserializeAsync<object>(buffered);
+            return (true, chunkedBody);
+        }
+        catch (JsonException)
+        {
+            return (false, null);
+        }
     }
 
     private sealed class FlowDashboardBasicAuthFilter(FlowDashboardBasicAuthOptions options) : IEndpointFilter

--- a/src/FlowOrchestrator.Dashboard/FlowOrchestrator.Dashboard.csproj
+++ b/src/FlowOrchestrator.Dashboard/FlowOrchestrator.Dashboard.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RazorLangVersion>8.0</RazorLangVersion>

--- a/src/FlowOrchestrator.Hangfire/DefaultStepExecutor.cs
+++ b/src/FlowOrchestrator.Hangfire/DefaultStepExecutor.cs
@@ -36,7 +36,7 @@ internal sealed class DefaultStepExecutor : IStepExecutor
             };
         }
 
-        step.Inputs = ResolveInputs(step.Inputs, context.TriggerData);
+        step.Inputs = ResolveInputs(step.Inputs, context.TriggerData, context.TriggerHeaders);
         await _outputsRepository.SaveStepInputAsync(context, flow, step).ConfigureAwait(false);
 
         var handler = _handlerMetadata.FirstOrDefault(h => string.Equals(h.Type, metadata.Type, StringComparison.OrdinalIgnoreCase));
@@ -53,7 +53,7 @@ internal sealed class DefaultStepExecutor : IStepExecutor
         return await handler.ExecuteAsync(_serviceProvider, context, flow, step).ConfigureAwait(false);
     }
 
-    private static IDictionary<string, object?> ResolveInputs(IDictionary<string, object?> inputs, object? triggerData)
+    private static IDictionary<string, object?> ResolveInputs(IDictionary<string, object?> inputs, object? triggerData, IReadOnlyDictionary<string, string>? triggerHeaders)
     {
         if (inputs.Count == 0)
         {
@@ -63,43 +63,44 @@ internal sealed class DefaultStepExecutor : IStepExecutor
         var resolved = new Dictionary<string, object?>(inputs.Count);
         foreach (var (key, value) in inputs)
         {
-            resolved[key] = ResolveValue(value, triggerData);
+            resolved[key] = ResolveValue(value, triggerData, triggerHeaders);
         }
 
         return resolved;
     }
 
-    private static object? ResolveValue(object? value, object? triggerData)
+    private static object? ResolveValue(object? value, object? triggerData, IReadOnlyDictionary<string, string>? triggerHeaders)
     {
         switch (value)
         {
             case null:
                 return null;
             case string s:
-                return TryResolveTriggerBodyExpression(s, triggerData, out var resolvedExpression)
-                    ? resolvedExpression
-                    : s;
+                if (TryResolveTriggerBodyExpression(s, triggerData, out var resolvedBody))
+                    return resolvedBody;
+                if (TryResolveTriggerHeadersExpression(s, triggerHeaders, out var resolvedHeader))
+                    return resolvedHeader;
+                return s;
             case JsonElement element:
-                return ResolveJsonElement(element, triggerData);
+                return ResolveJsonElement(element, triggerData, triggerHeaders);
             case IDictionary<string, object?> dict:
-                return ResolveInputs(dict, triggerData);
+                return ResolveInputs(dict, triggerData, triggerHeaders);
             case IEnumerable<object?> sequence:
-                return sequence.Select(item => ResolveValue(item, triggerData)).ToArray();
+                return sequence.Select(item => ResolveValue(item, triggerData, triggerHeaders)).ToArray();
             default:
                 return value;
         }
     }
 
-    private static object? ResolveJsonElement(JsonElement element, object? triggerData)
+    private static object? ResolveJsonElement(JsonElement element, object? triggerData, IReadOnlyDictionary<string, string>? triggerHeaders)
     {
         if (element.ValueKind == JsonValueKind.String)
         {
             var stringValue = element.GetString();
-            if (TryResolveTriggerBodyExpression(stringValue, triggerData, out var resolvedExpression))
-            {
-                return resolvedExpression;
-            }
-
+            if (TryResolveTriggerBodyExpression(stringValue, triggerData, out var resolvedBody))
+                return resolvedBody;
+            if (TryResolveTriggerHeadersExpression(stringValue, triggerHeaders, out var resolvedHeader))
+                return resolvedHeader;
             return element.Clone();
         }
 
@@ -107,14 +108,14 @@ internal sealed class DefaultStepExecutor : IStepExecutor
         {
             var objectValue = JsonSerializer.Deserialize<Dictionary<string, object?>>(element.GetRawText(), _jsonOptions)
                               ?? new Dictionary<string, object?>();
-            return ResolveInputs(objectValue, triggerData);
+            return ResolveInputs(objectValue, triggerData, triggerHeaders);
         }
 
         if (element.ValueKind == JsonValueKind.Array)
         {
             var arrayValue = JsonSerializer.Deserialize<List<object?>>(element.GetRawText(), _jsonOptions)
                              ?? [];
-            return arrayValue.Select(item => ResolveValue(item, triggerData)).ToArray();
+            return arrayValue.Select(item => ResolveValue(item, triggerData, triggerHeaders)).ToArray();
         }
 
         return element.Clone();
@@ -170,6 +171,40 @@ internal sealed class DefaultStepExecutor : IStepExecutor
 
         resolved = null;
         return true;
+    }
+
+    private static bool TryResolveTriggerHeadersExpression(string? expression, IReadOnlyDictionary<string, string>? headers, out object? resolved)
+    {
+        resolved = null;
+        if (string.IsNullOrWhiteSpace(expression))
+            return false;
+
+        const string prefix = "@triggerHeaders()";
+        var trimmed = expression.Trim();
+        if (!trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var remainder = trimmed[prefix.Length..].Trim();
+        if (string.IsNullOrEmpty(remainder))
+        {
+            resolved = headers is null ? null : ToJsonElement(headers);
+            return true;
+        }
+
+        // Support ['Header-Name'] and ["Header-Name"] notation for headers with dashes
+        string? headerName = null;
+        if (remainder.StartsWith("['", StringComparison.Ordinal) && remainder.EndsWith("']", StringComparison.Ordinal))
+            headerName = remainder[2..^2];
+        else if (remainder.StartsWith("[\"", StringComparison.Ordinal) && remainder.EndsWith("\"]", StringComparison.Ordinal))
+            headerName = remainder[2..^2];
+
+        if (headerName is not null)
+        {
+            resolved = headers is not null && headers.TryGetValue(headerName, out var val) ? val : null;
+            return true;
+        }
+
+        return false;
     }
 
     private static JsonElement ToJsonElement(object value)

--- a/src/FlowOrchestrator.Hangfire/FlowOrchestrator.Hangfire.csproj
+++ b/src/FlowOrchestrator.Hangfire/FlowOrchestrator.Hangfire.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/FlowOrchestrator.Hangfire/HangfireFlowOrchestrator.cs
+++ b/src/FlowOrchestrator.Hangfire/HangfireFlowOrchestrator.cs
@@ -51,27 +51,34 @@ public sealed class HangfireFlowOrchestrator : IHangfireFlowTrigger, IHangfireSt
 
     private async ValueTask EnsureTriggerDataAsync(IExecutionContext ctx)
     {
-        if (ctx.TriggerData is not null)
+        // Prefer the repository as the authoritative source. When RunStepAsync is
+        // invoked as a Hangfire background job, ctx.TriggerData may have been
+        // corrupted during Hangfire (de)serialization (e.g. JsonElement → JObject),
+        // so a non-null value on ctx is not a reliable signal that the data is valid.
+        var fromRepo = await _outputsRepository.GetTriggerDataAsync(ctx.RunId).ConfigureAwait(false);
+        if (fromRepo is not null)
         {
-            return;
+            ctx.TriggerData = fromRepo;
         }
-
-        if (ctx is ITriggerContext triggerContext && triggerContext.Trigger is not null)
+        else if (ctx.TriggerData is null)
         {
-            ctx.TriggerData = triggerContext.Trigger.Data;
-            if (ctx.TriggerData is not null)
+            if (ctx is ITriggerContext triggerContext && triggerContext.Trigger is not null)
             {
-                return;
+                ctx.TriggerData = triggerContext.Trigger.Data;
             }
         }
 
-        ctx.TriggerData = await _outputsRepository.GetTriggerDataAsync(ctx.RunId).ConfigureAwait(false);
+        if (ctx.TriggerHeaders is null)
+        {
+            ctx.TriggerHeaders = await _outputsRepository.GetTriggerHeadersAsync(ctx.RunId).ConfigureAwait(false);
+        }
     }
 
     public async ValueTask<object?> TriggerAsync(ITriggerContext triggerContext, PerformContext? performContext = null)
     {
         triggerContext.RunId = triggerContext.RunId == Guid.Empty ? Guid.NewGuid() : triggerContext.RunId;
         triggerContext.TriggerData = triggerContext.Trigger.Data;
+        triggerContext.TriggerHeaders = triggerContext.Trigger.Headers;
         _contextAccessor.CurrentContext = triggerContext;
 
         try

--- a/src/FlowOrchestrator.SqlServer/FlowOrchestrator.SqlServer.csproj
+++ b/src/FlowOrchestrator.SqlServer/FlowOrchestrator.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/tests/FlowOrchestrator.Core.Tests/Execution/FlowExecutorTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Execution/FlowExecutorTests.cs
@@ -24,9 +24,9 @@ public class FlowExecutorTests
         return flow;
     }
 
-    private static ITriggerContext CreateTriggerContext(IFlowDefinition flow)
+    private static ITriggerContext CreateTriggerContext(IFlowDefinition flow, IReadOnlyDictionary<string, string>? headers = null)
     {
-        var trigger = new Trigger("manual", "Manual", new { source = "test" });
+        var trigger = new Trigger("manual", "Manual", new { source = "test" }, headers);
         return new TriggerContext
         {
             RunId = Guid.NewGuid(),
@@ -38,6 +38,10 @@ public class FlowExecutorTests
     [Fact]
     public async Task TriggerFlow_FindsEntryStep_WithNoRunAfter()
     {
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["X-Correlation-Id"] = "corr-1"
+        };
         var steps = new StepCollection
         {
             ["step1"] = new StepMetadata { Type = "LogMessage", RunAfter = new RunAfterCollection() },
@@ -48,7 +52,7 @@ public class FlowExecutorTests
             }
         };
         var flow = CreateFlow(steps);
-        var ctx = CreateTriggerContext(flow);
+        var ctx = CreateTriggerContext(flow, headers);
 
         var result = await _sut.TriggerFlow(ctx);
 
@@ -56,8 +60,11 @@ public class FlowExecutorTests
         result.Type.Should().Be("LogMessage");
         result.RunId.Should().Be(ctx.RunId);
         ctx.TriggerData.Should().BeSameAs(ctx.Trigger.Data);
+        ctx.TriggerHeaders.Should().BeSameAs(headers);
         result.TriggerData.Should().BeSameAs(ctx.TriggerData);
+        result.TriggerHeaders.Should().BeSameAs(headers);
         await _outputsRepo.Received(1).SaveTriggerDataAsync(ctx, flow, ctx.Trigger);
+        await _outputsRepo.Received(1).SaveTriggerHeadersAsync(ctx, flow, ctx.Trigger);
     }
 
     [Fact]
@@ -95,7 +102,11 @@ public class FlowExecutorTests
         };
         var flow = CreateFlow(steps);
         var triggerData = new { source = "trigger" };
-        var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid(), TriggerData = triggerData };
+        var triggerHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["X-Request-Id"] = "req-123"
+        };
+        var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid(), TriggerData = triggerData, TriggerHeaders = triggerHeaders };
         var currentStep = new StepInstance("step1", "A") { RunId = ctx.RunId };
         var result = new StepResult { Key = "step1", Status = StepStatus.Succeeded };
 
@@ -106,6 +117,7 @@ public class FlowExecutorTests
         next.Type.Should().Be("B");
         next.RunId.Should().Be(ctx.RunId);
         next.TriggerData.Should().BeSameAs(triggerData);
+        next.TriggerHeaders.Should().BeSameAs(triggerHeaders);
     }
 
     [Fact]

--- a/tests/FlowOrchestrator.Core.Tests/FlowOrchestrator.Core.Tests.csproj
+++ b/tests/FlowOrchestrator.Core.Tests/FlowOrchestrator.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/FlowOrchestrator.Core.Tests/Storage/InMemoryOutputsRepositoryTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Storage/InMemoryOutputsRepositoryTests.cs
@@ -40,6 +40,26 @@ public class InMemoryOutputsRepositoryTests
     }
 
     [Fact]
+    public async Task SaveAndGetTriggerHeaders_RoundTrip()
+    {
+        var flow = CreateFlow();
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["X-Correlation-Id"] = "corr-123",
+            ["Content-Type"] = "application/json"
+        };
+        var trigger = new Trigger("manual", "Manual", new { foo = "bar" }, headers);
+        var ctx = new TriggerContext { RunId = Guid.NewGuid(), Flow = flow, Trigger = trigger };
+
+        await _sut.SaveTriggerHeadersAsync(ctx, flow, trigger);
+        var result = await _sut.GetTriggerHeadersAsync(ctx.RunId);
+
+        result.Should().NotBeNull();
+        result!["X-Correlation-Id"].Should().Be("corr-123");
+        result["content-type"].Should().Be("application/json");
+    }
+
+    [Fact]
     public async Task SaveAndGetStepOutput_RoundTrip()
     {
         var flow = CreateFlow();

--- a/tests/FlowOrchestrator.Hangfire.Tests/DefaultStepExecutorTests.cs
+++ b/tests/FlowOrchestrator.Hangfire.Tests/DefaultStepExecutorTests.cs
@@ -193,4 +193,78 @@ public class DefaultStepExecutorTests
         var payload = (JsonElement)step.Inputs["payload"]!;
         payload.GetProperty("orderId").GetString().Should().Be("ORD-2");
     }
+
+    [Fact]
+    public async Task ExecuteAsync_ResolvesTriggerHeadersExpression_ForSpecificHeader()
+    {
+        var steps = new StepCollection
+        {
+            ["step1"] = new StepMetadata { Type = "LogMessage" }
+        };
+        var flow = CreateFlow(steps);
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["X-Request-Id"] = "req-42"
+        };
+        var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid(), TriggerHeaders = headers };
+        var step = new StepInstance("step1", "LogMessage")
+        {
+            RunId = ctx.RunId,
+            Inputs = new Dictionary<string, object?>
+            {
+                ["requestId"] = "@triggerHeaders()['X-Request-Id']"
+            }
+        };
+
+        var handlerMeta = Substitute.For<IStepHandlerMetadata>();
+        handlerMeta.Type.Returns("LogMessage");
+        handlerMeta.ExecuteAsync(default!, default!, default!, default!)
+            .ReturnsForAnyArgs(new StepResult { Key = "step1", Status = StepStatus.Succeeded });
+
+        var executor = CreateExecutor(handlerMeta);
+
+        await executor.ExecuteAsync(ctx, flow, step);
+
+        step.Inputs["requestId"].Should().Be("req-42");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ResolvesTriggerHeadersExpression_ForAllHeaders()
+    {
+        var steps = new StepCollection
+        {
+            ["step1"] = new StepMetadata { Type = "LogMessage" }
+        };
+        var flow = CreateFlow(steps);
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["X-Correlation-Id"] = "corr-1",
+            ["Content-Type"] = "application/json"
+        };
+        var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid(), TriggerHeaders = headers };
+        var step = new StepInstance("step1", "LogMessage")
+        {
+            RunId = ctx.RunId,
+            Inputs = new Dictionary<string, object?>
+            {
+                ["headers"] = JsonSerializer.Deserialize<JsonElement>("\"@triggerHeaders()\"")
+            }
+        };
+
+        var handlerMeta = Substitute.For<IStepHandlerMetadata>();
+        handlerMeta.Type.Returns("LogMessage");
+        handlerMeta.ExecuteAsync(default!, default!, default!, default!)
+            .ReturnsForAnyArgs(new StepResult { Key = "step1", Status = StepStatus.Succeeded });
+
+        var executor = CreateExecutor(handlerMeta);
+
+        await executor.ExecuteAsync(ctx, flow, step);
+
+        step.Inputs["headers"].Should().BeOfType<JsonElement>();
+        var headersElement = (JsonElement)step.Inputs["headers"]!;
+        var headerMap = headersElement.EnumerateObject()
+            .ToDictionary(p => p.Name, p => p.Value.GetString(), StringComparer.OrdinalIgnoreCase);
+        headerMap["X-Correlation-Id"].Should().Be("corr-1");
+        headerMap["Content-Type"].Should().Be("application/json");
+    }
 }

--- a/tests/FlowOrchestrator.Hangfire.Tests/FlowOrchestrator.Hangfire.Tests.csproj
+++ b/tests/FlowOrchestrator.Hangfire.Tests/FlowOrchestrator.Hangfire.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/FlowOrchestrator.Hangfire.Tests/HangfireFlowOrchestratorTests.cs
+++ b/tests/FlowOrchestrator.Hangfire.Tests/HangfireFlowOrchestratorTests.cs
@@ -205,6 +205,34 @@ public class HangfireFlowOrchestratorTests
     }
 
     [Fact]
+    public async Task RunStepAsync_LoadsTriggerHeadersFromRepository_WhenMissingOnContext()
+    {
+        var sut = CreateSut();
+        var flow = CreateFlow();
+        var runId = Guid.NewGuid();
+        var triggerHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["X-Request-Id"] = "req-777"
+        };
+        var ctx = new Core.Execution.ExecutionContext { RunId = runId };
+        var step = new StepInstance("step1", "LogMessage") { RunId = runId };
+        IExecutionContext? capturedContext = null;
+
+        _outputsRepo.GetTriggerDataAsync(runId).Returns((object?)null);
+        _outputsRepo.GetTriggerHeadersAsync(runId).Returns(triggerHeaders);
+
+        var stepResult = new StepResult { Key = "step1", Status = StepStatus.Succeeded };
+        _stepExecutor.ExecuteAsync(Arg.Do<IExecutionContext>(c => capturedContext = c), flow, step).Returns(stepResult);
+        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns((IStepInstance?)null);
+
+        await sut.RunStepAsync(ctx, flow, step);
+
+        await _outputsRepo.Received(1).GetTriggerHeadersAsync(runId);
+        capturedContext.Should().NotBeNull();
+        capturedContext!.TriggerHeaders.Should().BeSameAs(triggerHeaders);
+    }
+
+    [Fact]
     public async Task RunStepAsync_CompletesRunWhenNoNextStep()
     {
         var sut = CreateSut();


### PR DESCRIPTION
- Updated CI and publish workflows to include .NET 10.0 support.
- Incremented version prefix in Directory.Build.props to 1.3.1.
- Enhanced README with compatibility information for .NET 10.0.
- Modified execution context to capture trigger headers.
- Updated various classes and interfaces to handle trigger headers.
- Implemented logic to save and retrieve trigger headers in the outputs repository.
- Enhanced step execution to resolve trigger headers in input expressions.
- Added tests for trigger headers functionality in executor and repository.