### PR TITLE
feat: Add support for step attempt tracking and polling mechanism

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <RepositoryUrl>https://github.com/hoangsnowy/FlowOrchestrator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/hoangsnowy/FlowOrchestrator</PackageProjectUrl>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
@@ -15,6 +15,13 @@
     <FlowOrchestratorTargetFrameworks Condition="'$(NETCoreSdkVersion)' == ''">net8.0</FlowOrchestratorTargetFrameworks>
     <FlowOrchestratorTargetFrameworks Condition="$([System.String]::Copy('$(NETCoreSdkVersion)').StartsWith('8.'))">net8.0</FlowOrchestratorTargetFrameworks>
     <FlowOrchestratorTargetFrameworks Condition="$([System.String]::Copy('$(NETCoreSdkVersion)').StartsWith('9.'))">net8.0;net9.0</FlowOrchestratorTargetFrameworks>
+
+    <FlowOrchestratorSampleTargetFramework>net10.0</FlowOrchestratorSampleTargetFramework>
+    <FlowOrchestratorSampleTargetFramework Condition="'$(NETCoreSdkVersion)' == ''">net8.0</FlowOrchestratorSampleTargetFramework>
+    <FlowOrchestratorSampleTargetFramework Condition="$([System.String]::Copy('$(NETCoreSdkVersion)').StartsWith('8.'))">net8.0</FlowOrchestratorSampleTargetFramework>
+    <FlowOrchestratorSampleTargetFramework Condition="$([System.String]::Copy('$(NETCoreSdkVersion)').StartsWith('9.'))">net9.0</FlowOrchestratorSampleTargetFramework>
+
+    <DefaultItemExcludes>$(DefaultItemExcludes);**/artifacts/**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsPackable)' == 'true'">

--- a/FlowOrchestrator.AppHost/FlowOrchestrator.AppHost.csproj
+++ b/FlowOrchestrator.AppHost/FlowOrchestrator.AppHost.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.1.2">
+<Project Sdk="Aspire.AppHost.Sdk/13.1.3">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(FlowOrchestratorSampleTargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>floworchestrator-apphost</UserSecretsId>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.1.2" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -156,14 +156,50 @@ Manual trigger and webhook endpoints capture request body plus non-sensitive hea
 2. Click the **Trigger** button.
 3. Switch to the **Runs** page to monitor execution.
 
+### Reusable polling step handler
+
+`FlowOrchestrator.Core` provides a reusable polling abstraction for step handlers:
+- `PollableStepHandler<TInput>` handles retry scheduling (`Pending` + `DelayNextStep`), timeout, min-attempt checks, and poll-state reset.
+- `IPollableInput` defines polling contract fields used by the base handler.
+
+```csharp
+public sealed class CheckJobStatusStep : PollableStepHandler<CheckJobStatusInput>
+{
+    protected override async ValueTask<(JsonElement Result, bool IsJson)> FetchAsync(
+        IExecutionContext ctx, IFlowDefinition flow, IStepInstance<CheckJobStatusInput> step)
+    {
+        var payload = await CallExternalServiceAsync(step.Inputs.JobId);
+        return (payload, true);
+    }
+}
+
+public sealed class CheckJobStatusInput : IPollableInput
+{
+    public string JobId { get; set; } = string.Empty;
+    public bool PollEnabled { get; set; }
+    public int PollIntervalSeconds { get; set; } = 10;
+    public int PollTimeoutSeconds { get; set; } = 300;
+    public int PollMinAttempts { get; set; } = 1;
+    public string? PollConditionPath { get; set; }
+    public object? PollConditionEquals { get; set; }
+
+    [JsonPropertyName("__pollStartedAtUtc")]
+    public string? PollStartedAtUtc { get; set; }
+
+    [JsonPropertyName("__pollAttempt")]
+    public int? PollAttempt { get; set; }
+}
+```
+
 ### Polling demo flow
 
-`PollingDemoFlow` (`00000000-0000-0000-0000-000000000003`) demonstrates real polling behavior using `CallExternalApi`:
+`PollingDemoFlow` (`00000000-0000-0000-0000-000000000003`) demonstrates this abstraction through `CallExternalApiStep : PollableStepHandler<CallExternalApiStepInput>`:
 - `pollEnabled = true`
 - `pollMinAttempts = 3` (forces at least 3 poll attempts before success)
 - `pollIntervalSeconds = 5`
 
 This lets you observe **Pending -> Pending -> Succeeded** progression in the Runs timeline.
+Run detail also shows an attempt badge (for retries/polls) and a `Step Attempts` panel with per-attempt input/output/status history.
 
 ### Retrying a failed step
 

--- a/samples/FlowOrchestrator.SampleApp/FlowOrchestrator.SampleApp.csproj
+++ b/samples/FlowOrchestrator.SampleApp/FlowOrchestrator.SampleApp.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(FlowOrchestratorSampleTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.16" />
-    <PackageReference Include="Hangfire.SqlServer" Version="1.8.16" />
-    <PackageReference Include="Dapper" Version="2.1.35" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.23" />
+    <PackageReference Include="Hangfire.SqlServer" Version="1.8.23" />
+    <PackageReference Include="Dapper" Version="2.1.72" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/FlowOrchestrator.SampleApp/Steps/CallExternalApiStep.cs
+++ b/samples/FlowOrchestrator.SampleApp/Steps/CallExternalApiStep.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using FlowOrchestrator.Core.Abstractions;
@@ -12,7 +11,7 @@ namespace FlowOrchestrator.SampleApp.Steps;
 /// Poll inputs (optional): pollEnabled, pollIntervalSeconds, pollTimeoutSeconds, pollConditionPath, pollConditionEquals, pollMinAttempts
 /// Output: deserialized JSON response
 /// </summary>
-public sealed class CallExternalApiStep : IStepHandler<CallExternalApiStepInput>
+public sealed class CallExternalApiStep : PollableStepHandler<CallExternalApiStepInput>
 {
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<CallExternalApiStep> _logger;
@@ -23,7 +22,8 @@ public sealed class CallExternalApiStep : IStepHandler<CallExternalApiStepInput>
         _logger = logger;
     }
 
-    public async ValueTask<object?> ExecuteAsync(IExecutionContext ctx, IFlowDefinition flow, IStepInstance<CallExternalApiStepInput> step)
+    protected override async ValueTask<(JsonElement Result, bool IsJson)> FetchAsync(
+        IExecutionContext ctx, IFlowDefinition flow, IStepInstance<CallExternalApiStepInput> step)
     {
         var input = step.Inputs;
         var method = string.IsNullOrWhiteSpace(input.Method) ? "GET" : input.Method;
@@ -56,101 +56,7 @@ public sealed class CallExternalApiStep : IStepHandler<CallExternalApiStepInput>
                 GetBodyPreview(responseBody));
         }
 
-        if (!input.PollEnabled)
-        {
-            return new StepResult<JsonElement>
-            {
-                Key = step.Key,
-                Value = result
-            };
-        }
-
-        if (!parsedAsJson && !string.IsNullOrWhiteSpace(input.PollConditionPath))
-        {
-            ResetPollState(input);
-            return new StepResult<JsonElement>
-            {
-                Key = step.Key,
-                Status = StepStatus.Failed,
-                FailedReason = "Polling with 'pollConditionPath' requires JSON response body, but API returned non-JSON content.",
-                Value = result
-            };
-        }
-
-        var intervalSeconds = Math.Max(1, input.PollIntervalSeconds);
-        var timeoutSeconds = Math.Max(intervalSeconds, input.PollTimeoutSeconds);
-        var minAttempts = Math.Max(1, input.PollMinAttempts);
-        var pollStartedAt = GetPollStartedAt(input);
-        var currentAttempt = IncrementPollAttempt(input);
-
-        if (currentAttempt >= minAttempts && PollConditionEvaluator.IsMatched(result, input.PollConditionPath, input.PollConditionEquals))
-        {
-            ResetPollState(input);
-            _logger.LogInformation(
-                "[CallExternalApi] RunId={RunId} Polling condition matched at attempt {Attempt}. Continue flow.",
-                ctx.RunId,
-                currentAttempt);
-            return new StepResult<JsonElement>
-            {
-                Key = step.Key,
-                Value = result
-            };
-        }
-
-        var elapsed = DateTimeOffset.UtcNow - pollStartedAt;
-        if (elapsed >= TimeSpan.FromSeconds(timeoutSeconds))
-        {
-            ResetPollState(input);
-            return new StepResult<JsonElement>
-            {
-                Key = step.Key,
-                Status = StepStatus.Failed,
-                FailedReason = $"Polling timed out after {timeoutSeconds} seconds.",
-                Value = result
-            };
-        }
-
-        _logger.LogInformation(
-            "[CallExternalApi] RunId={RunId} Polling condition not met at attempt {Attempt}/{MinAttempts}. Retry in {Delay}s.",
-            ctx.RunId,
-            currentAttempt,
-            minAttempts,
-            intervalSeconds);
-
-        return new StepResult<JsonElement>
-        {
-            Key = step.Key,
-            Status = StepStatus.Pending,
-            DelayNextStep = TimeSpan.FromSeconds(intervalSeconds),
-            Value = result
-        };
-    }
-
-    private static DateTimeOffset GetPollStartedAt(CallExternalApiStepInput input)
-    {
-        if (!string.IsNullOrWhiteSpace(input.PollStartedAtUtc)
-            && DateTimeOffset.TryParse(input.PollStartedAtUtc, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
-        {
-            return parsed;
-        }
-
-        var now = DateTimeOffset.UtcNow;
-        input.PollStartedAtUtc = now.ToString("O", CultureInfo.InvariantCulture);
-        return now;
-    }
-
-    private static int IncrementPollAttempt(CallExternalApiStepInput input)
-    {
-        var next = (input.PollAttempt ?? 0) + 1;
-        input.PollAttempt = next;
-
-        return next;
-    }
-
-    private static void ResetPollState(CallExternalApiStepInput input)
-    {
-        input.PollStartedAtUtc = null;
-        input.PollAttempt = null;
+        return (result, parsedAsJson);
     }
 
     private static JsonElement ParseResponsePayload(string responseBody, string? mediaType, out bool parsedAsJson)
@@ -222,7 +128,7 @@ public sealed class CallExternalApiStep : IStepHandler<CallExternalApiStepInput>
     }
 }
 
-public sealed class CallExternalApiStepInput
+public sealed class CallExternalApiStepInput : IPollableInput
 {
     public string Method { get; set; } = "GET";
     public string Path { get; set; } = "/";
@@ -232,6 +138,7 @@ public sealed class CallExternalApiStepInput
     public int PollIntervalSeconds { get; set; } = 10;
     public int PollTimeoutSeconds { get; set; } = 300;
     public int PollMinAttempts { get; set; } = 1;
+
     public string? PollConditionPath { get; set; }
     public object? PollConditionEquals { get; set; }
 

--- a/src/FlowOrchestrator.Core/Execution/IPollableInput.cs
+++ b/src/FlowOrchestrator.Core/Execution/IPollableInput.cs
@@ -1,0 +1,14 @@
+namespace FlowOrchestrator.Core.Execution;
+
+public interface IPollableInput
+{
+    bool PollEnabled { get; }
+    int PollIntervalSeconds { get; }
+    int PollTimeoutSeconds { get; }
+    int PollMinAttempts { get; }
+    string? PollConditionPath { get; }
+    object? PollConditionEquals { get; }
+
+    string? PollStartedAtUtc { get; set; }
+    int? PollAttempt { get; set; }
+}

--- a/src/FlowOrchestrator.Core/Execution/PollConditionEvaluator.cs
+++ b/src/FlowOrchestrator.Core/Execution/PollConditionEvaluator.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using System.Text.Json;
 
-namespace FlowOrchestrator.SampleApp.Steps;
+namespace FlowOrchestrator.Core.Execution;
 
 internal static class PollConditionEvaluator
 {
@@ -74,7 +74,6 @@ internal static class PollConditionEvaluator
         JsonValueKind.String => value.GetString() ?? string.Empty,
         JsonValueKind.True => bool.TrueString,
         JsonValueKind.False => bool.FalseString,
-        JsonValueKind.Number => value.GetRawText(),
         _ => value.GetRawText()
     };
 }

--- a/src/FlowOrchestrator.Core/Execution/PollableStepHandler.cs
+++ b/src/FlowOrchestrator.Core/Execution/PollableStepHandler.cs
@@ -1,0 +1,104 @@
+using System.Globalization;
+using System.Text.Json;
+using FlowOrchestrator.Core.Abstractions;
+
+namespace FlowOrchestrator.Core.Execution;
+
+/// <summary>
+/// Base class for step handlers that support polling via Hangfire delayed jobs.
+/// Subclasses implement <see cref="FetchAsync"/>; poll state tracking and retry scheduling are handled here.
+/// </summary>
+public abstract class PollableStepHandler<TInput> : IStepHandler<TInput>
+    where TInput : IPollableInput
+{
+    public async ValueTask<object?> ExecuteAsync(
+        IExecutionContext ctx, IFlowDefinition flow, IStepInstance<TInput> step)
+    {
+        var input = step.Inputs;
+        var (result, parsedAsJson) = await FetchAsync(ctx, flow, step).ConfigureAwait(false);
+
+        if (!input.PollEnabled)
+        {
+            return new StepResult<JsonElement> { Key = step.Key, Value = result };
+        }
+
+        if (!parsedAsJson && !string.IsNullOrWhiteSpace(input.PollConditionPath))
+        {
+            ResetPollState(input);
+            return new StepResult<JsonElement>
+            {
+                Key = step.Key,
+                Status = StepStatus.Failed,
+                FailedReason = "Polling with 'pollConditionPath' requires a JSON response body.",
+                Value = result
+            };
+        }
+
+        var intervalSeconds = Math.Max(1, input.PollIntervalSeconds);
+        var timeoutSeconds = Math.Max(intervalSeconds, input.PollTimeoutSeconds);
+        var minAttempts = Math.Max(1, input.PollMinAttempts);
+        var pollStartedAt = GetPollStartedAt(input);
+        var currentAttempt = IncrementPollAttempt(input);
+
+        if (currentAttempt >= minAttempts
+            && PollConditionEvaluator.IsMatched(result, input.PollConditionPath, input.PollConditionEquals))
+        {
+            ResetPollState(input);
+            return new StepResult<JsonElement> { Key = step.Key, Value = result };
+        }
+
+        var elapsed = DateTimeOffset.UtcNow - pollStartedAt;
+        if (elapsed >= TimeSpan.FromSeconds(timeoutSeconds))
+        {
+            ResetPollState(input);
+            return new StepResult<JsonElement>
+            {
+                Key = step.Key,
+                Status = StepStatus.Failed,
+                FailedReason = $"Polling timed out after {timeoutSeconds} seconds.",
+                Value = result
+            };
+        }
+
+        return new StepResult<JsonElement>
+        {
+            Key = step.Key,
+            Status = StepStatus.Pending,
+            DelayNextStep = TimeSpan.FromSeconds(intervalSeconds),
+            Value = result
+        };
+    }
+
+    /// <summary>
+    /// Perform the actual data fetch. Returns the payload and whether it was parsed as JSON.
+    /// </summary>
+    protected abstract ValueTask<(JsonElement Result, bool IsJson)> FetchAsync(
+        IExecutionContext ctx, IFlowDefinition flow, IStepInstance<TInput> step);
+
+    private static DateTimeOffset GetPollStartedAt(TInput input)
+    {
+        if (!string.IsNullOrWhiteSpace(input.PollStartedAtUtc)
+            && DateTimeOffset.TryParse(input.PollStartedAtUtc, CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind, out var parsed))
+        {
+            return parsed;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        input.PollStartedAtUtc = now.ToString("O", CultureInfo.InvariantCulture);
+        return now;
+    }
+
+    private static int IncrementPollAttempt(TInput input)
+    {
+        var next = (input.PollAttempt ?? 0) + 1;
+        input.PollAttempt = next;
+        return next;
+    }
+
+    private static void ResetPollState(TInput input)
+    {
+        input.PollStartedAtUtc = null;
+        input.PollAttempt = null;
+    }
+}

--- a/src/FlowOrchestrator.Core/FlowOrchestrator.Core.csproj
+++ b/src/FlowOrchestrator.Core/FlowOrchestrator.Core.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageReference Include="System.Text.Json" Version="10.0.5" />
   </ItemGroup>
 
 </Project>

--- a/src/FlowOrchestrator.Core/Storage/FlowStepAttemptRecord.cs
+++ b/src/FlowOrchestrator.Core/Storage/FlowStepAttemptRecord.cs
@@ -1,9 +1,10 @@
 namespace FlowOrchestrator.Core.Storage;
 
-public sealed class FlowStepRecord
+public sealed class FlowStepAttemptRecord
 {
     public Guid RunId { get; set; }
     public string StepKey { get; set; } = default!;
+    public int Attempt { get; set; }
     public string StepType { get; set; } = default!;
     public string Status { get; set; } = default!;
     public string? InputJson { get; set; }
@@ -12,6 +13,4 @@ public sealed class FlowStepRecord
     public string? JobId { get; set; }
     public DateTimeOffset StartedAt { get; set; }
     public DateTimeOffset? CompletedAt { get; set; }
-    public int AttemptCount { get; set; }
-    public IReadOnlyList<FlowStepAttemptRecord>? Attempts { get; set; }
 }

--- a/src/FlowOrchestrator.Core/Storage/InMemoryFlowRunStore.cs
+++ b/src/FlowOrchestrator.Core/Storage/InMemoryFlowRunStore.cs
@@ -6,6 +6,8 @@ public sealed class InMemoryFlowRunStore : IFlowRunStore
 {
     private readonly ConcurrentDictionary<Guid, FlowRunRecord> _runs = new();
     private readonly ConcurrentDictionary<(Guid RunId, string StepKey), FlowStepRecord> _steps = new();
+    private readonly ConcurrentDictionary<(Guid RunId, string StepKey, int Attempt), FlowStepAttemptRecord> _stepAttempts = new();
+    private readonly ConcurrentDictionary<(Guid RunId, string StepKey), int> _stepAttemptCounters = new();
 
     public Task<FlowRunRecord> StartRunAsync(Guid flowId, string flowName, Guid runId, string triggerKey, string? triggerData, string? jobId)
     {
@@ -26,28 +28,65 @@ public sealed class InMemoryFlowRunStore : IFlowRunStore
 
     public Task RecordStepStartAsync(Guid runId, string stepKey, string stepType, string? inputJson, string? jobId)
     {
-        _steps[(runId, stepKey)] = new FlowStepRecord
+        var key = (runId, stepKey);
+        var attempt = _stepAttemptCounters.AddOrUpdate(key, 1, static (_, current) => current + 1);
+        var startedAt = DateTimeOffset.UtcNow;
+
+        _stepAttempts[(runId, stepKey, attempt)] = new FlowStepAttemptRecord
+        {
+            RunId = runId,
+            StepKey = stepKey,
+            Attempt = attempt,
+            StepType = stepType,
+            Status = "Running",
+            InputJson = inputJson,
+            JobId = jobId,
+            StartedAt = startedAt
+        };
+
+        _steps[key] = new FlowStepRecord
         {
             RunId = runId,
             StepKey = stepKey,
             StepType = stepType,
             InputJson = inputJson,
+            OutputJson = null,
+            ErrorMessage = null,
             JobId = jobId,
             Status = "Running",
-            StartedAt = DateTimeOffset.UtcNow
+            StartedAt = startedAt,
+            CompletedAt = null,
+            AttemptCount = attempt
         };
+
         return Task.CompletedTask;
     }
 
     public Task RecordStepCompleteAsync(Guid runId, string stepKey, string status, string? outputJson, string? errorMessage)
     {
+        var completedAt = DateTimeOffset.UtcNow;
+
         if (_steps.TryGetValue((runId, stepKey), out var step))
         {
             step.Status = status;
             step.OutputJson = outputJson;
             step.ErrorMessage = errorMessage;
-            step.CompletedAt = DateTimeOffset.UtcNow;
+            step.CompletedAt = completedAt;
         }
+
+        var latestAttempt = _stepAttempts.Values
+            .Where(a => a.RunId == runId && string.Equals(a.StepKey, stepKey, StringComparison.Ordinal))
+            .OrderByDescending(a => a.Attempt)
+            .FirstOrDefault();
+
+        if (latestAttempt is not null)
+        {
+            latestAttempt.Status = status;
+            latestAttempt.OutputJson = outputJson;
+            latestAttempt.ErrorMessage = errorMessage;
+            latestAttempt.CompletedAt = completedAt;
+        }
+
         return Task.CompletedTask;
     }
 
@@ -91,7 +130,30 @@ public sealed class InMemoryFlowRunStore : IFlowRunStore
         var steps = _steps.Values
             .Where(s => s.RunId == runId)
             .OrderBy(s => s.StartedAt)
+            .Select(CloneStepRecord)
             .ToList();
+
+        var attempts = _stepAttempts.Values
+            .Where(a => a.RunId == runId)
+            .OrderBy(a => a.StartedAt)
+            .ThenBy(a => a.Attempt)
+            .Select(CloneStepAttemptRecord)
+            .ToList();
+
+        var attemptsLookup = attempts
+            .GroupBy(a => a.StepKey, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<FlowStepAttemptRecord>)g.OrderBy(a => a.Attempt).ToList(), StringComparer.Ordinal);
+
+        foreach (var step in steps)
+        {
+            if (!attemptsLookup.TryGetValue(step.StepKey, out var stepAttempts) || stepAttempts.Count == 0)
+            {
+                stepAttempts = [CreateSyntheticAttempt(step)];
+            }
+
+            step.Attempts = stepAttempts;
+            step.AttemptCount = stepAttempts.Count;
+        }
 
         run.Steps = steps;
         return Task.FromResult<FlowRunRecord?>(run);
@@ -168,15 +230,80 @@ public sealed class InMemoryFlowRunStore : IFlowRunStore
             return true;
         }
 
-        return _steps.Values.Any(s =>
+        var stepMatch = _steps.Values.Any(s =>
             s.RunId == run.Id
             && (ContainsIgnoreCase(s.StepKey, search)
                 || ContainsIgnoreCase(s.ErrorMessage, search)
                 || ContainsIgnoreCase(s.OutputJson, search)));
+
+        if (stepMatch)
+        {
+            return true;
+        }
+
+        return _stepAttempts.Values.Any(a =>
+            a.RunId == run.Id
+            && (ContainsIgnoreCase(a.StepKey, search)
+                || ContainsIgnoreCase(a.ErrorMessage, search)
+                || ContainsIgnoreCase(a.OutputJson, search)));
     }
 
     private static bool ContainsIgnoreCase(string? value, string search)
     {
         return !string.IsNullOrEmpty(value) && value.Contains(search, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static FlowStepRecord CloneStepRecord(FlowStepRecord step)
+    {
+        return new FlowStepRecord
+        {
+            RunId = step.RunId,
+            StepKey = step.StepKey,
+            StepType = step.StepType,
+            Status = step.Status,
+            InputJson = step.InputJson,
+            OutputJson = step.OutputJson,
+            ErrorMessage = step.ErrorMessage,
+            JobId = step.JobId,
+            StartedAt = step.StartedAt,
+            CompletedAt = step.CompletedAt,
+            AttemptCount = step.AttemptCount
+        };
+    }
+
+    private static FlowStepAttemptRecord CloneStepAttemptRecord(FlowStepAttemptRecord attempt)
+    {
+        return new FlowStepAttemptRecord
+        {
+            RunId = attempt.RunId,
+            StepKey = attempt.StepKey,
+            Attempt = attempt.Attempt,
+            StepType = attempt.StepType,
+            Status = attempt.Status,
+            InputJson = attempt.InputJson,
+            OutputJson = attempt.OutputJson,
+            ErrorMessage = attempt.ErrorMessage,
+            JobId = attempt.JobId,
+            StartedAt = attempt.StartedAt,
+            CompletedAt = attempt.CompletedAt
+        };
+    }
+
+    private static FlowStepAttemptRecord CreateSyntheticAttempt(FlowStepRecord step)
+    {
+        return new FlowStepAttemptRecord
+        {
+            RunId = step.RunId,
+            StepKey = step.StepKey,
+            Attempt = 1,
+            StepType = step.StepType,
+            Status = step.Status,
+            InputJson = step.InputJson,
+            OutputJson = step.OutputJson,
+            ErrorMessage = step.ErrorMessage,
+            JobId = step.JobId,
+            StartedAt = step.StartedAt,
+            CompletedAt = step.CompletedAt
+        };
     }
 }

--- a/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
@@ -447,11 +447,26 @@ function renderRunTriggerPanels(run) {
 
   return '<div style="margin-bottom:10px">' + dataPanel + headersPanel + '</div>';
 }
+function getStepAttemptCount(step) {
+  if (typeof step.attemptCount === 'number' && Number.isFinite(step.attemptCount) && step.attemptCount > 0) {
+    return step.attemptCount;
+  }
+
+  if (Array.isArray(step.attempts) && step.attempts.length > 0) {
+    return step.attempts.length;
+  }
+
+  return 1;
+}
 function renderStepDebugPanels(step) {
+  const attemptCount = getStepAttemptCount(step);
+  const attemptsPanel = attemptCount > 1
+    ? renderDetailPanel('Step Attempts', step.attempts, false, null)
+    : '';
   const inputPanel = renderDetailPanel('Step Input', step.inputJson, false, null);
   const outputPanel = renderDetailPanel('Step Output', step.outputJson, false, null);
   const errorPanel = renderDetailPanel('Step Error', step.errorMessage, step.status === 'Failed', 'error');
-  return inputPanel + outputPanel + errorPanel;
+  return attemptsPanel + inputPanel + outputPanel + errorPanel;
 }
 function statusBadge(s) { return '<span class="badge badge-'+s.toLowerCase()+'">'+s+'</span>'; }
 
@@ -997,12 +1012,14 @@ function renderTimeline(steps, runId) {
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i], last = i===steps.length-1;
     const icon = ({Succeeded:'\u2713',Failed:'\u2715',Running:'\u25cf'})[s.status]||'\u25cb';
+    const attemptCount = getStepAttemptCount(s);
     html += '<div class="step-node"><div class="step-connector">'
       +'<div class="step-circle '+s.status+'">'+icon+'</div>'
       +'<div class="step-line '+(s.status==='Succeeded'?'done':'')+' '+(last?'last':'')+'"></div></div>'
       +'<div class="step-card '+s.status+'">'
       +'<div class="step-card-header"><div><div class="step-key">'+esc(s.stepKey)+'</div><div class="step-type">'+esc(s.stepType)+'</div></div>'
       +'<div style="display:flex;align-items:center;gap:6px"><span class="step-badge '+s.status+'">'+s.status+'</span>'
+      +(attemptCount>1?'<span class="step-badge Pending">x'+attemptCount+' attempts</span>':'')
       +(s.status==='Failed'?'<button class="btn-retry" onclick="retryStep(\''+runId+'\',\''+esc(s.stepKey)+'\')">&#8635; Retry</button>':'')
       +'</div></div>'
       +'<div class="step-timing"><span>Start: '+fmt(s.startedAt)+'</span><span>End: '+fmt(s.completedAt)+'</span><span>Duration: '+duration(s.startedAt,s.completedAt)+'</span></div>'

--- a/src/FlowOrchestrator.Hangfire/FlowOrchestrator.Hangfire.csproj
+++ b/src/FlowOrchestrator.Hangfire/FlowOrchestrator.Hangfire.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.Core" Version="1.8.16" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.23" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FlowOrchestrator.SqlServer/FlowOrchestrator.SqlServer.csproj
+++ b/src/FlowOrchestrator.SqlServer/FlowOrchestrator.SqlServer.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.1.35" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Dapper" Version="2.1.72" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FlowOrchestrator.SqlServer/FlowOrchestratorSqlMigrator.cs
+++ b/src/FlowOrchestrator.SqlServer/FlowOrchestratorSqlMigrator.cs
@@ -84,6 +84,24 @@ public sealed class FlowOrchestratorSqlMigrator : IHostedService
             );
         END
 
+        IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'FlowStepAttempts')
+        BEGIN
+            CREATE TABLE [FlowStepAttempts] (
+                [RunId]        UNIQUEIDENTIFIER NOT NULL,
+                [StepKey]      NVARCHAR(256)    NOT NULL,
+                [AttemptNo]    INT              NOT NULL,
+                [StepType]     NVARCHAR(256)    NOT NULL,
+                [Status]       NVARCHAR(64)     NOT NULL,
+                [InputJson]    NVARCHAR(MAX)    NULL,
+                [OutputJson]   NVARCHAR(MAX)    NULL,
+                [ErrorMessage] NVARCHAR(MAX)    NULL,
+                [JobId]        NVARCHAR(128)    NULL,
+                [StartedAt]    DATETIMEOFFSET   NOT NULL DEFAULT SYSDATETIMEOFFSET(),
+                [CompletedAt]  DATETIMEOFFSET   NULL,
+                CONSTRAINT PK_FlowStepAttempts PRIMARY KEY ([RunId], [StepKey], [AttemptNo])
+            );
+        END
+
         IF EXISTS (SELECT * FROM sys.tables WHERE name = 'FlowRuns')
         BEGIN
             IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_FlowRuns_FlowId' AND object_id = OBJECT_ID(N'[FlowRuns]'))
@@ -109,6 +127,16 @@ public sealed class FlowOrchestratorSqlMigrator : IHostedService
 
             IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_FlowSteps_StepKey_RunId' AND object_id = OBJECT_ID(N'[FlowSteps]'))
                 CREATE INDEX IX_FlowSteps_StepKey_RunId ON [FlowSteps]([StepKey], [RunId]);
+        END
+
+        IF EXISTS (SELECT * FROM sys.tables WHERE name = 'FlowStepAttempts')
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_FlowStepAttempts_RunId_StartedAt' AND object_id = OBJECT_ID(N'[FlowStepAttempts]'))
+                CREATE INDEX IX_FlowStepAttempts_RunId_StartedAt ON [FlowStepAttempts]([RunId], [StartedAt])
+                INCLUDE ([StepKey], [AttemptNo], [StepType], [Status], [JobId], [CompletedAt]);
+
+            IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_FlowStepAttempts_RunId_StepKey_AttemptNo' AND object_id = OBJECT_ID(N'[FlowStepAttempts]'))
+                CREATE INDEX IX_FlowStepAttempts_RunId_StepKey_AttemptNo ON [FlowStepAttempts]([RunId], [StepKey], [AttemptNo]);
         END
         """;
 }

--- a/src/FlowOrchestrator.SqlServer/SqlFlowRunStore.cs
+++ b/src/FlowOrchestrator.SqlServer/SqlFlowRunStore.cs
@@ -28,14 +28,34 @@ public sealed class SqlFlowRunStore : IFlowRunStore
     {
         await using var conn = new SqlConnection(_connectionString);
         await conn.ExecuteAsync("""
+            BEGIN TRANSACTION;
+
+            DECLARE @AttemptNo INT;
+            SELECT @AttemptNo = ISNULL(MAX(AttemptNo), 0) + 1
+            FROM FlowStepAttempts WITH (UPDLOCK, HOLDLOCK)
+            WHERE RunId = @RunId AND StepKey = @StepKey;
+
+            INSERT INTO FlowStepAttempts (RunId, StepKey, AttemptNo, StepType, Status, InputJson, JobId, StartedAt)
+            VALUES (@RunId, @StepKey, @AttemptNo, @StepType, 'Running', @InputJson, @JobId, SYSDATETIMEOFFSET());
+
             MERGE FlowSteps AS target
             USING (SELECT @RunId AS RunId, @StepKey AS StepKey) AS source
             ON target.RunId = source.RunId AND target.StepKey = source.StepKey
             WHEN MATCHED THEN
-                UPDATE SET StepType = @StepType, InputJson = @InputJson, JobId = @JobId, Status = 'Running', StartedAt = SYSDATETIMEOFFSET(), CompletedAt = NULL
+                UPDATE SET
+                    StepType = @StepType,
+                    InputJson = @InputJson,
+                    OutputJson = NULL,
+                    ErrorMessage = NULL,
+                    JobId = @JobId,
+                    Status = 'Running',
+                    StartedAt = SYSDATETIMEOFFSET(),
+                    CompletedAt = NULL
             WHEN NOT MATCHED THEN
                 INSERT (RunId, StepKey, StepType, Status, InputJson, JobId, StartedAt)
                 VALUES (@RunId, @StepKey, @StepType, 'Running', @InputJson, @JobId, SYSDATETIMEOFFSET());
+
+            COMMIT TRANSACTION;
             """, new { RunId = runId, StepKey = stepKey, StepType = stepType, InputJson = inputJson, JobId = jobId });
     }
 
@@ -43,9 +63,26 @@ public sealed class SqlFlowRunStore : IFlowRunStore
     {
         await using var conn = new SqlConnection(_connectionString);
         await conn.ExecuteAsync("""
+            BEGIN TRANSACTION;
+
             UPDATE FlowSteps
             SET Status = @Status, OutputJson = @OutputJson, ErrorMessage = @ErrorMessage, CompletedAt = SYSDATETIMEOFFSET()
             WHERE RunId = @RunId AND StepKey = @StepKey
+
+            UPDATE attempts
+            SET Status = @Status, OutputJson = @OutputJson, ErrorMessage = @ErrorMessage, CompletedAt = SYSDATETIMEOFFSET()
+            FROM FlowStepAttempts AS attempts
+            INNER JOIN (
+                SELECT TOP (1) RunId, StepKey, AttemptNo
+                FROM FlowStepAttempts
+                WHERE RunId = @RunId AND StepKey = @StepKey
+                ORDER BY AttemptNo DESC
+            ) AS latest
+                ON latest.RunId = attempts.RunId
+               AND latest.StepKey = attempts.StepKey
+               AND latest.AttemptNo = attempts.AttemptNo
+
+            COMMIT TRANSACTION;
             """, new { RunId = runId, StepKey = stepKey, Status = status, OutputJson = outputJson, ErrorMessage = errorMessage });
     }
 
@@ -97,6 +134,16 @@ public sealed class SqlFlowRunStore : IFlowRunStore
                                 OR ISNULL(fs.OutputJson, '') LIKE @SearchLike ESCAPE '\'
                               )
                     )
+                    OR EXISTS (
+                        SELECT 1
+                        FROM FlowStepAttempts AS fsa
+                        WHERE fsa.RunId = fr.Id
+                          AND (
+                                ISNULL(fsa.StepKey, '') LIKE @SearchLike ESCAPE '\'
+                                OR ISNULL(fsa.ErrorMessage, '') LIKE @SearchLike ESCAPE '\'
+                                OR ISNULL(fsa.OutputJson, '') LIKE @SearchLike ESCAPE '\'
+                              )
+                    )
                 )
                 """);
         }
@@ -120,10 +167,18 @@ public sealed class SqlFlowRunStore : IFlowRunStore
         var run = await GetRunCoreAsync(conn, runId);
         if (run is null) return null;
 
-        var steps = await conn.QueryAsync<FlowStepRecord>(
+        var steps = (await conn.QueryAsync<FlowStepRecord>(
             "SELECT RunId, StepKey, StepType, Status, InputJson, OutputJson, ErrorMessage, JobId, StartedAt, CompletedAt FROM FlowSteps WHERE RunId = @RunId ORDER BY StartedAt",
-            new { RunId = runId });
-        run.Steps = steps.AsList();
+            new { RunId = runId }))
+            .AsList();
+
+        var attempts = (await conn.QueryAsync<FlowStepAttemptRecord>(
+            "SELECT RunId, StepKey, AttemptNo AS Attempt, StepType, Status, InputJson, OutputJson, ErrorMessage, JobId, StartedAt, CompletedAt FROM FlowStepAttempts WHERE RunId = @RunId ORDER BY StepKey, AttemptNo",
+            new { RunId = runId })
+            ).AsList();
+
+        PopulateStepAttempts(steps, attempts);
+        run.Steps = steps;
         return run;
     }
 
@@ -167,6 +222,42 @@ public sealed class SqlFlowRunStore : IFlowRunStore
         return await conn.QuerySingleOrDefaultAsync<FlowRunRecord>(
             "SELECT Id, FlowId, FlowName, Status, TriggerKey, TriggerDataJson, BackgroundJobId, StartedAt, CompletedAt FROM FlowRuns WHERE Id = @Id",
             new { Id = runId });
+    }
+
+    private static void PopulateStepAttempts(IReadOnlyList<FlowStepRecord> steps, IReadOnlyList<FlowStepAttemptRecord> attempts)
+    {
+        var attemptsLookup = attempts
+            .GroupBy(a => a.StepKey, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<FlowStepAttemptRecord>)g.OrderBy(a => a.Attempt).ToList(), StringComparer.Ordinal);
+
+        foreach (var step in steps)
+        {
+            if (!attemptsLookup.TryGetValue(step.StepKey, out var stepAttempts) || stepAttempts.Count == 0)
+            {
+                stepAttempts = [CreateSyntheticAttempt(step)];
+            }
+
+            step.Attempts = stepAttempts;
+            step.AttemptCount = stepAttempts.Count;
+        }
+    }
+
+    private static FlowStepAttemptRecord CreateSyntheticAttempt(FlowStepRecord step)
+    {
+        return new FlowStepAttemptRecord
+        {
+            RunId = step.RunId,
+            StepKey = step.StepKey,
+            Attempt = 1,
+            StepType = step.StepType,
+            Status = step.Status,
+            InputJson = step.InputJson,
+            OutputJson = step.OutputJson,
+            ErrorMessage = step.ErrorMessage,
+            JobId = step.JobId,
+            StartedAt = step.StartedAt,
+            CompletedAt = step.CompletedAt
+        };
     }
 
     private static string EscapeLikePattern(string value)

--- a/tests/FlowOrchestrator.Core.Tests/Execution/PollableStepHandlerTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Execution/PollableStepHandlerTests.cs
@@ -1,0 +1,196 @@
+using System.Text.Json;
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Execution;
+using FluentAssertions;
+
+namespace FlowOrchestrator.Core.Tests.Execution;
+
+public class PollableStepHandlerTests
+{
+    [Fact]
+    public async Task ExecuteAsync_PollDisabled_ReturnsSucceeded()
+    {
+        var input = new TestPollableInput { PollEnabled = false };
+        var step = new TestStepInstance("step1", "Pollable", input);
+        var handler = new TestPollableHandler(() => (ParseJson("{\"status\":\"processing\"}"), true));
+
+        var result = await handler.ExecuteAsync(CreateContext(), CreateFlow(), step);
+        var typedResult = result.Should().BeOfType<StepResult<JsonElement>>().Subject;
+
+        typedResult.Status.Should().Be(StepStatus.Succeeded);
+        typedResult.DelayNextStep.Should().BeNull();
+        input.PollAttempt.Should().BeNull();
+        input.PollStartedAtUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ConditionNotMatched_ReturnsPending()
+    {
+        var input = new TestPollableInput
+        {
+            PollEnabled = true,
+            PollIntervalSeconds = 7,
+            PollTimeoutSeconds = 60,
+            PollConditionPath = "status",
+            PollConditionEquals = "completed"
+        };
+        var step = new TestStepInstance("step1", "Pollable", input);
+        var handler = new TestPollableHandler(() => (ParseJson("{\"status\":\"processing\"}"), true));
+
+        var result = await handler.ExecuteAsync(CreateContext(), CreateFlow(), step);
+        var typedResult = result.Should().BeOfType<StepResult<JsonElement>>().Subject;
+
+        typedResult.Status.Should().Be(StepStatus.Pending);
+        typedResult.DelayNextStep.Should().Be(TimeSpan.FromSeconds(7));
+        input.PollAttempt.Should().Be(1);
+        input.PollStartedAtUtc.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MatchAfterMinimumAttempts_ReturnsSucceededAndResetsState()
+    {
+        var input = new TestPollableInput
+        {
+            PollEnabled = true,
+            PollIntervalSeconds = 3,
+            PollTimeoutSeconds = 120,
+            PollMinAttempts = 2,
+            PollConditionPath = "status",
+            PollConditionEquals = "completed"
+        };
+        var step = new TestStepInstance("step1", "Pollable", input);
+        var handler = new TestPollableHandler(() => (ParseJson("{\"status\":\"completed\"}"), true));
+
+        var first = await handler.ExecuteAsync(CreateContext(), CreateFlow(), step);
+        var firstResult = first.Should().BeOfType<StepResult<JsonElement>>().Subject;
+        firstResult.Status.Should().Be(StepStatus.Pending);
+        firstResult.DelayNextStep.Should().Be(TimeSpan.FromSeconds(3));
+        input.PollAttempt.Should().Be(1);
+        input.PollStartedAtUtc.Should().NotBeNullOrWhiteSpace();
+
+        var second = await handler.ExecuteAsync(CreateContext(), CreateFlow(), step);
+        var secondResult = second.Should().BeOfType<StepResult<JsonElement>>().Subject;
+        secondResult.Status.Should().Be(StepStatus.Succeeded);
+        secondResult.DelayNextStep.Should().BeNull();
+        input.PollAttempt.Should().BeNull();
+        input.PollStartedAtUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TimeoutExceeded_ReturnsFailedAndResetsState()
+    {
+        var input = new TestPollableInput
+        {
+            PollEnabled = true,
+            PollIntervalSeconds = 3,
+            PollTimeoutSeconds = 10,
+            PollConditionPath = "status",
+            PollConditionEquals = "completed",
+            PollStartedAtUtc = DateTimeOffset.UtcNow.AddSeconds(-30).ToString("O"),
+            PollAttempt = 2
+        };
+        var step = new TestStepInstance("step1", "Pollable", input);
+        var handler = new TestPollableHandler(() => (ParseJson("{\"status\":\"processing\"}"), true));
+
+        var result = await handler.ExecuteAsync(CreateContext(), CreateFlow(), step);
+        var typedResult = result.Should().BeOfType<StepResult<JsonElement>>().Subject;
+
+        typedResult.Status.Should().Be(StepStatus.Failed);
+        typedResult.FailedReason.Should().Contain("Polling timed out after 10 seconds.");
+        input.PollAttempt.Should().BeNull();
+        input.PollStartedAtUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonJsonWithConditionPath_ReturnsFailedAndResetsState()
+    {
+        var input = new TestPollableInput
+        {
+            PollEnabled = true,
+            PollConditionPath = "status",
+            PollStartedAtUtc = DateTimeOffset.UtcNow.AddSeconds(-15).ToString("O"),
+            PollAttempt = 4
+        };
+        var step = new TestStepInstance("step1", "Pollable", input);
+        var handler = new TestPollableHandler(() => (JsonSerializer.SerializeToElement("plain-response"), false));
+
+        var result = await handler.ExecuteAsync(CreateContext(), CreateFlow(), step);
+        var typedResult = result.Should().BeOfType<StepResult<JsonElement>>().Subject;
+
+        typedResult.Status.Should().Be(StepStatus.Failed);
+        typedResult.FailedReason.Should().Contain("requires a JSON response body");
+        input.PollAttempt.Should().BeNull();
+        input.PollStartedAtUtc.Should().BeNull();
+    }
+
+    private static IExecutionContext CreateContext()
+    {
+        return new Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
+    }
+
+    private static IFlowDefinition CreateFlow()
+    {
+        return new TestFlowDefinition();
+    }
+
+    private static JsonElement ParseJson(string json)
+    {
+        return JsonSerializer.Deserialize<JsonElement>(json);
+    }
+
+    private sealed class TestPollableHandler : PollableStepHandler<TestPollableInput>
+    {
+        private readonly Func<(JsonElement Result, bool IsJson)> _fetch;
+
+        public TestPollableHandler(Func<(JsonElement Result, bool IsJson)> fetch)
+        {
+            _fetch = fetch;
+        }
+
+        protected override ValueTask<(JsonElement Result, bool IsJson)> FetchAsync(
+            IExecutionContext ctx, IFlowDefinition flow, IStepInstance<TestPollableInput> step)
+        {
+            return ValueTask.FromResult(_fetch());
+        }
+    }
+
+    private sealed class TestPollableInput : IPollableInput
+    {
+        public bool PollEnabled { get; set; }
+        public int PollIntervalSeconds { get; set; } = 10;
+        public int PollTimeoutSeconds { get; set; } = 300;
+        public int PollMinAttempts { get; set; } = 1;
+        public string? PollConditionPath { get; set; }
+        public object? PollConditionEquals { get; set; }
+        public string? PollStartedAtUtc { get; set; }
+        public int? PollAttempt { get; set; }
+    }
+
+    private sealed class TestFlowDefinition : IFlowDefinition
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+        public string Version => "1.0";
+        public FlowManifest Manifest { get; set; } = new();
+    }
+
+    private sealed class TestStepInstance : IStepInstance<TestPollableInput>
+    {
+        public TestStepInstance(string key, string type, TestPollableInput inputs)
+        {
+            Key = key;
+            Type = type;
+            Inputs = inputs;
+        }
+
+        public Guid RunId { get; set; }
+        public string? PrincipalId { get; set; }
+        public object? TriggerData { get; set; }
+        public IReadOnlyDictionary<string, string>? TriggerHeaders { get; set; }
+        public DateTimeOffset ScheduledTime { get; set; }
+        public string Type { get; set; }
+        public string Key { get; }
+        public TestPollableInput Inputs { get; set; }
+        public int Index { get; set; }
+        public bool ScopeMoveNext { get; set; }
+    }
+}

--- a/tests/FlowOrchestrator.Core.Tests/FlowOrchestrator.Core.Tests.csproj
+++ b/tests/FlowOrchestrator.Core.Tests/FlowOrchestrator.Core.Tests.csproj
@@ -8,15 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.0.1" />
+    <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/FlowOrchestrator.Core.Tests/Storage/InMemoryFlowRunStoreTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Storage/InMemoryFlowRunStoreTests.cs
@@ -32,6 +32,9 @@ public class InMemoryFlowRunStoreTests
         detail!.Steps.Should().HaveCount(1);
         detail.Steps![0].StepKey.Should().Be("step1");
         detail.Steps[0].Status.Should().Be("Running");
+        detail.Steps[0].AttemptCount.Should().Be(1);
+        detail.Steps[0].Attempts.Should().HaveCount(1);
+        detail.Steps[0].Attempts![0].Attempt.Should().Be(1);
     }
 
     [Fact]
@@ -47,6 +50,32 @@ public class InMemoryFlowRunStoreTests
         detail!.Steps![0].Status.Should().Be("Succeeded");
         detail.Steps[0].OutputJson.Should().Be("{\"result\":1}");
         detail.Steps[0].CompletedAt.Should().NotBeNull();
+        detail.Steps[0].AttemptCount.Should().Be(1);
+        detail.Steps[0].Attempts.Should().HaveCount(1);
+        detail.Steps[0].Attempts![0].Status.Should().Be("Succeeded");
+    }
+
+    [Fact]
+    public async Task RecordStepStartAsync_MultipleStarts_CreatesAttemptHistory()
+    {
+        var runId = Guid.NewGuid();
+        await _sut.StartRunAsync(Guid.NewGuid(), "TestFlow", runId, "manual", null, null);
+
+        await _sut.RecordStepStartAsync(runId, "step1", "CallExternalApi", "{\"attempt\":1}", "job-1");
+        await _sut.RecordStepCompleteAsync(runId, "step1", "Pending", "{\"status\":\"processing\"}", null);
+        await _sut.RecordStepStartAsync(runId, "step1", "CallExternalApi", "{\"attempt\":2}", "job-2");
+        await _sut.RecordStepCompleteAsync(runId, "step1", "Succeeded", "{\"status\":\"done\"}", null);
+
+        var detail = await _sut.GetRunDetailAsync(runId);
+        detail!.Steps.Should().ContainSingle();
+        detail.Steps![0].Status.Should().Be("Succeeded");
+        detail.Steps[0].AttemptCount.Should().Be(2);
+        detail.Steps[0].Attempts.Should().HaveCount(2);
+        var attempts = detail.Steps[0].Attempts!;
+        attempts[0].Attempt.Should().Be(1);
+        attempts[0].Status.Should().Be("Pending");
+        attempts[1].Attempt.Should().Be(2);
+        attempts[1].Status.Should().Be("Succeeded");
     }
 
     [Fact]
@@ -165,6 +194,23 @@ public class InMemoryFlowRunStoreTests
         page.TotalCount.Should().Be(1);
         page.Runs.Should().ContainSingle();
         page.Runs[0].Id.Should().Be(runId1);
+    }
+
+    [Fact]
+    public async Task GetRunsPageAsync_SearchesByAttemptHistoryErrorMessage()
+    {
+        var runId = Guid.NewGuid();
+        await _sut.StartRunAsync(Guid.NewGuid(), "Flow1", runId, "manual", null, null);
+        await _sut.RecordStepStartAsync(runId, "payment", "Payment", null, null);
+        await _sut.RecordStepCompleteAsync(runId, "payment", "Pending", null, "Gateway timeout on first attempt");
+        await _sut.RecordStepStartAsync(runId, "payment", "Payment", null, null);
+        await _sut.RecordStepCompleteAsync(runId, "payment", "Succeeded", "{\"ok\":true}", null);
+
+        var page = await _sut.GetRunsPageAsync(search: "timeout on first");
+
+        page.TotalCount.Should().Be(1);
+        page.Runs.Should().ContainSingle();
+        page.Runs[0].Id.Should().Be(runId);
     }
 
     [Fact]

--- a/tests/FlowOrchestrator.Hangfire.Tests/DefaultStepExecutorTests.cs
+++ b/tests/FlowOrchestrator.Hangfire.Tests/DefaultStepExecutorTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using FlowOrchestrator.Core.Abstractions;
@@ -341,6 +342,43 @@ public class DefaultStepExecutorTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_GenericHandler_SyncsMutatedInputsBackToStep()
+    {
+        var services = new ServiceCollection();
+        services.AddStepHandler<PollStateMutatingHandler>("PollStateMutatingHandler");
+        var serviceProvider = services.BuildServiceProvider();
+
+        var flow = CreateFlow(new StepCollection
+        {
+            ["step1"] = new StepMetadata { Type = "PollStateMutatingHandler" }
+        });
+
+        var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
+        var step = new StepInstance("step1", "PollStateMutatingHandler")
+        {
+            RunId = ctx.RunId,
+            Inputs = new Dictionary<string, object?>
+            {
+                ["pollEnabled"] = true,
+                ["pollIntervalSeconds"] = 5,
+                ["pollTimeoutSeconds"] = 30,
+                ["pollMinAttempts"] = 1
+            }
+        };
+
+        var metadata = serviceProvider.GetServices<IStepHandlerMetadata>();
+        var executor = new DefaultStepExecutor(metadata, serviceProvider, _outputsRepo);
+
+        var result = await executor.ExecuteAsync(ctx, flow, step);
+
+        result.Status.Should().Be(StepStatus.Pending);
+        step.Inputs.Should().ContainKey("__pollAttempt");
+        step.Inputs.Should().ContainKey("__pollStartedAtUtc");
+        ReadInt(step.Inputs["__pollAttempt"]).Should().Be(5);
+        ReadString(step.Inputs["__pollStartedAtUtc"]).Should().Be(PollStateMutatingHandler.NextStartedAtUtc);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_GenericHandler_BindsStrongTypedInput()
     {
         GenericTypedHandler.Reset();
@@ -462,5 +500,58 @@ public class DefaultStepExecutorTests
 
         [JsonPropertyName("__pollAttempt")]
         public int? PollAttempt { get; set; }
+    }
+
+    private sealed class PollStateMutatingHandler : IStepHandler<PollStateMutatingInput>
+    {
+        internal const string NextStartedAtUtc = "2026-01-02T03:04:05.0000000+00:00";
+
+        public ValueTask<object?> ExecuteAsync(IExecutionContext context, IFlowDefinition flow, IStepInstance<PollStateMutatingInput> step)
+        {
+            step.Inputs.PollAttempt = 5;
+            step.Inputs.PollStartedAtUtc = NextStartedAtUtc;
+            return ValueTask.FromResult<object?>(new StepResult
+            {
+                Key = step.Key,
+                Status = StepStatus.Pending,
+                DelayNextStep = TimeSpan.FromSeconds(5)
+            });
+        }
+    }
+
+    private sealed class PollStateMutatingInput
+    {
+        public bool PollEnabled { get; set; }
+        public int PollIntervalSeconds { get; set; }
+        public int PollTimeoutSeconds { get; set; }
+        public int PollMinAttempts { get; set; }
+
+        [JsonPropertyName("__pollStartedAtUtc")]
+        public string? PollStartedAtUtc { get; set; }
+
+        [JsonPropertyName("__pollAttempt")]
+        public int? PollAttempt { get; set; }
+    }
+
+    private static int ReadInt(object? value)
+    {
+        return value switch
+        {
+            int i => i,
+            JsonElement { ValueKind: JsonValueKind.Number } json => json.GetInt32(),
+            JsonElement { ValueKind: JsonValueKind.String } json => int.Parse(json.GetString()!, CultureInfo.InvariantCulture),
+            _ => throw new InvalidOperationException($"Cannot convert value '{value}' to int.")
+        };
+    }
+
+    private static string? ReadString(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            string text => text,
+            JsonElement { ValueKind: JsonValueKind.String } json => json.GetString(),
+            _ => throw new InvalidOperationException($"Cannot convert value '{value}' to string.")
+        };
     }
 }

--- a/tests/FlowOrchestrator.Hangfire.Tests/FlowOrchestrator.Hangfire.Tests.csproj
+++ b/tests/FlowOrchestrator.Hangfire.Tests/FlowOrchestrator.Hangfire.Tests.csproj
@@ -8,16 +8,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.0.1" />
+    <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- Introduced a new table `FlowStepAttempts` to store step execution attempts.
- Updated `SqlFlowRunStore` to record step attempts during execution.
- Enhanced `renderStepDebugPanels` to display step attempts in the dashboard.
- Implemented polling functionality in `PollableStepHandler` for steps that require repeated checks.
- Added `IPollableInput` interface to standardize polling inputs.
- Created `PollConditionEvaluator` to evaluate conditions based on JSON responses.
- Added tests for new polling behavior and step attempt tracking.
- Updated dependencies to latest versions for improved stability and features.