### PR TITLE
feat: Skipped step & run-level status support with demo flows

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,35 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "AppHost — Aspire (http :18888)",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": ["run", "--project", "FlowOrchestrator.AppHost/FlowOrchestrator.AppHost.csproj", "--launch-profile", "http"],
+      "port": 18888
+    },
+    {
+      "name": "AppHost — Aspire (https :17225)",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": ["run", "--project", "FlowOrchestrator.AppHost/FlowOrchestrator.AppHost.csproj", "--launch-profile", "https"],
+      "port": 17225
+    },
+    {
+      "name": "flow-inmemory (Aspire-managed :5103)",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": ["run", "--project", "samples/FlowOrchestrator.SampleApp/FlowOrchestrator.SampleApp.csproj", "--launch-profile", "http", "--", "--urls", "http://localhost:5103"],
+      "port": 5103
+    },
+    {
+      "name": "SampleApp — standalone (http :5201)",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": ["run", "--project", "samples/FlowOrchestrator.SampleApp/FlowOrchestrator.SampleApp.csproj", "--launch-profile", "http"],
+      "port": 5201
+    },
+    {
+      "name": "SampleApp — standalone (https :7177)",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": ["run", "--project", "samples/FlowOrchestrator.SampleApp/FlowOrchestrator.SampleApp.csproj", "--launch-profile", "https"],
+      "port": 7177
+    }
+  ]
+}

--- a/samples/FlowOrchestrator.SampleApp/Flows/ConditionalSkipDemoFlow.cs
+++ b/samples/FlowOrchestrator.SampleApp/Flows/ConditionalSkipDemoFlow.cs
@@ -1,0 +1,109 @@
+using FlowOrchestrator.Core.Abstractions;
+
+namespace FlowOrchestrator.SampleApp.Flows;
+
+/// <summary>
+/// ConditionalSkipDemoFlow — Demonstrates the <see cref="StepStatus.Skipped"/> status.
+///
+/// This flow models a payment authorisation scenario where validation intentionally fails,
+/// causing the "happy path" branch to be skipped while the "fallback" branch runs instead.
+///
+/// DAG:
+///   start
+///     └─► validate_payment         (SimulatedFailure → always fails)
+///           ├─► charge_customer     (RunAfter: validate_payment=[Succeeded]) → SKIPPED
+///           └─► handle_decline      (RunAfter: validate_payment=[Failed])    → runs
+///                 └─► send_receipt  (RunAfter: charge_customer=[Succeeded|Skipped],
+///                                             handle_decline=[Succeeded|Skipped]) → always runs
+///
+/// Expected run result:
+///   start              Succeeded
+///   validate_payment   Failed
+///   charge_customer    Skipped   ← the step whose CSS / badge this demo exercises
+///   handle_decline     Succeeded
+///   send_receipt       Succeeded
+/// </summary>
+public sealed class ConditionalSkipDemoFlow : IFlowDefinition
+{
+    public Guid Id { get; } = new Guid("00000000-0000-0000-0000-000000000008");
+    public string Version => "1.0";
+    public FlowManifest Manifest { get; set; } = new FlowManifest
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            // ── Entry ──────────────────────────────────────────────────────────
+            ["start"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "ConditionalSkipDemo — initiating payment authorisation..."
+                }
+            },
+
+            // ── Simulated failure ──────────────────────────────────────────────
+            // Always throws → status becomes Failed → triggers the skip below.
+            ["validate_payment"] = new StepMetadata
+            {
+                Type = "SimulatedFailure",
+                RunAfter = new RunAfterCollection
+                {
+                    ["start"] = [StepStatus.Succeeded]
+                },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["reason"] = "Payment gateway returned: card declined (insufficient funds)."
+                }
+            },
+
+            // ── Happy path (will be SKIPPED) ───────────────────────────────────
+            // validate_payment failed, so this condition can never be satisfied.
+            ["charge_customer"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                RunAfter = new RunAfterCollection
+                {
+                    ["validate_payment"] = [StepStatus.Succeeded]
+                },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "Charging customer — authorisation approved."
+                }
+            },
+
+            // ── Fallback path (runs because validate_payment Failed) ────────────
+            ["handle_decline"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                RunAfter = new RunAfterCollection
+                {
+                    ["validate_payment"] = [StepStatus.Failed]
+                },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "Payment declined — notifying customer and logging event."
+                }
+            },
+
+            // ── Always runs regardless of which branch executed ─────────────────
+            // Accepts Succeeded OR Skipped from both branches so it always fires.
+            ["send_receipt"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                RunAfter = new RunAfterCollection
+                {
+                    ["charge_customer"] = [StepStatus.Succeeded, StepStatus.Skipped],
+                    ["handle_decline"]  = [StepStatus.Succeeded, StepStatus.Skipped]
+                },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "Receipt dispatched — payment flow complete."
+                }
+            }
+        }
+    };
+}

--- a/samples/FlowOrchestrator.SampleApp/Flows/DeadEndSkipDemoFlow.cs
+++ b/samples/FlowOrchestrator.SampleApp/Flows/DeadEndSkipDemoFlow.cs
@@ -1,0 +1,66 @@
+using FlowOrchestrator.Core.Abstractions;
+
+namespace FlowOrchestrator.SampleApp.Flows;
+
+/// <summary>
+/// DeadEndSkipDemoFlow — Produces a run-level <c>Skipped</c> status.
+///
+/// The entry step always fails and all downstream steps require <c>Succeeded</c>,
+/// so skip propagates to every leaf — nothing useful runs — and the run is recorded
+/// as <c>Skipped</c> rather than <c>Failed</c> or <c>Succeeded</c>.
+///
+/// DAG:
+///   validate_input  (SimulatedFailure → always fails)
+///       └─► enrich_data   (RunAfter: validate_input=[Succeeded]) → Skipped
+///                 └─► save_result (RunAfter: enrich_data=[Succeeded])   → Skipped ← leaf
+///
+/// Expected run result:
+///   validate_input   Failed
+///   enrich_data      Skipped
+///   save_result      Skipped  ← only leaf, all leaves Skipped → run = Skipped
+/// </summary>
+public sealed class DeadEndSkipDemoFlow : IFlowDefinition
+{
+    public Guid Id { get; } = new Guid("00000000-0000-0000-0000-000000000010");
+    public string Version => "1.0";
+    public FlowManifest Manifest { get; set; } = new FlowManifest
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            ["validate_input"] = new StepMetadata
+            {
+                Type = "SimulatedFailure",
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["reason"] = "Input validation failed — required fields missing."
+                }
+            },
+
+            ["enrich_data"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                RunAfter = new RunAfterCollection
+                {
+                    ["validate_input"] = [StepStatus.Succeeded]
+                },
+                Inputs = new Dictionary<string, object?> { ["message"] = "Enriching data from external source." }
+            },
+
+            // Leaf step — only Succeeded is accepted, so skip propagates here.
+            // All leaves Skipped → run-level = Skipped.
+            ["save_result"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                RunAfter = new RunAfterCollection
+                {
+                    ["enrich_data"] = [StepStatus.Succeeded]
+                },
+                Inputs = new Dictionary<string, object?> { ["message"] = "Saving enriched result to store." }
+            }
+        }
+    };
+}

--- a/samples/FlowOrchestrator.SampleApp/Flows/SkipVariantsDemoFlow.cs
+++ b/samples/FlowOrchestrator.SampleApp/Flows/SkipVariantsDemoFlow.cs
@@ -1,0 +1,125 @@
+using FlowOrchestrator.Core.Abstractions;
+
+namespace FlowOrchestrator.SampleApp.Flows;
+
+/// <summary>
+/// SkipVariantsDemoFlow — Demonstrates two distinct Skipped step scenarios in a single run.
+///
+/// DAG:
+///   start
+///     └─► check_subscription    (SimulatedFailure → always fails)
+///           ├─► apply_discount   (RunAfter: check_subscription=[Succeeded]) → SKIPPED (middle)
+///           │     └─► send_confirmation (RunAfter: apply_discount=[Succeeded])  → SKIPPED (end)
+///           │
+///           └─► log_check_failed (RunAfter: check_subscription=[Failed])     → Succeeded
+///                 └─► finalize   (RunAfter: apply_discount=[Succeeded|Skipped],
+///                                           log_check_failed=[Succeeded|Skipped]) → Succeeded
+///
+/// Expected run result:
+///   start                Succeeded
+///   check_subscription   Failed
+///   apply_discount       Skipped  ← MIDDLE skip: chain tiếp tục qua nhánh khác
+///   send_confirmation    Skipped  ← END skip: dead-end, không có gì chạy sau
+///   log_check_failed     Succeeded
+///   finalize             Succeeded
+/// </summary>
+public sealed class SkipVariantsDemoFlow : IFlowDefinition
+{
+    public Guid Id { get; } = new Guid("00000000-0000-0000-0000-000000000009");
+    public string Version => "1.0";
+    public FlowManifest Manifest { get; set; } = new FlowManifest
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            // ── Entry ──────────────────────────────────────────────────────────
+            ["start"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "SkipVariantsDemo — verifying subscription status..."
+                }
+            },
+
+            // ── Intentional failure ────────────────────────────────────────────
+            ["check_subscription"] = new StepMetadata
+            {
+                Type = "SimulatedFailure",
+                RunAfter = new RunAfterCollection
+                {
+                    ["start"] = [StepStatus.Succeeded]
+                },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["reason"] = "Subscription not found for this account."
+                }
+            },
+
+            // ── MIDDLE skip ────────────────────────────────────────────────────
+            // Skipped because check_subscription Failed.
+            // Flow does NOT stop here — finalize still runs via log_check_failed.
+            ["apply_discount"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                RunAfter = new RunAfterCollection
+                {
+                    ["check_subscription"] = [StepStatus.Succeeded]
+                },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "Applying loyalty discount to order."
+                }
+            },
+
+            // ── END skip (dead-end) ────────────────────────────────────────────
+            // Skipped because apply_discount was Skipped.
+            // Nothing depends on this step → this is the terminal Skipped node.
+            ["send_confirmation"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                RunAfter = new RunAfterCollection
+                {
+                    ["apply_discount"] = [StepStatus.Succeeded]
+                },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "Sending discount confirmation email to customer."
+                }
+            },
+
+            // ── Fallback path ──────────────────────────────────────────────────
+            ["log_check_failed"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                RunAfter = new RunAfterCollection
+                {
+                    ["check_subscription"] = [StepStatus.Failed]
+                },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "Subscription check failed — proceeding without discount."
+                }
+            },
+
+            // ── Always runs ────────────────────────────────────────────────────
+            // Accepts Skipped from apply_discount and Succeeded from log_check_failed.
+            ["finalize"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                RunAfter = new RunAfterCollection
+                {
+                    ["apply_discount"]   = [StepStatus.Succeeded, StepStatus.Skipped],
+                    ["log_check_failed"] = [StepStatus.Succeeded, StepStatus.Skipped]
+                },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "Order finalized — flow complete."
+                }
+            }
+        }
+    };
+}

--- a/samples/FlowOrchestrator.SampleApp/Program.cs
+++ b/samples/FlowOrchestrator.SampleApp/Program.cs
@@ -111,6 +111,16 @@ builder.Services.AddFlowOrchestrator(options =>
     // M1.1 Parallel fan-out + M1.2 All-of join + M1.3 Validation demo.
     options.AddFlow<ParallelHealthCheckFlow>();
 
+    // Skipped-step visual demo — a payment flow where validate_payment always fails,
+    // charge_customer gets Skipped, handle_decline runs, send_receipt always runs.
+    options.AddFlow<ConditionalSkipDemoFlow>();
+
+    // Skip variants demo — shows both a middle skip (chain continues) and an end skip (dead-end).
+    options.AddFlow<SkipVariantsDemoFlow>();
+
+    // Dead-end skip demo — all leaf steps end as Skipped → run-level status = Skipped.
+    options.AddFlow<DeadEndSkipDemoFlow>();
+
     if (storageBackend == "sqlserver")
         options.AddFlow<OrderFulfillmentFlow>();
 });
@@ -119,6 +129,8 @@ builder.Services.AddFlowOrchestrator(options =>
 builder.Services.AddStepHandler<LogMessageStepHandler>("LogMessage");
 builder.Services.AddStepHandler<CallExternalApiStep>("CallExternalApi");
 builder.Services.AddStepHandler<SerializeProbeStep>("SerializeProbe");
+
+builder.Services.AddStepHandler<SimulatedFailureStep>("SimulatedFailure");
 
 // M1.4 ForEach child handler — processes a single order item per loop iteration.
 // Reads __loopItem (order ID) and __loopIndex injected by ForEachStepHandler at runtime.

--- a/samples/FlowOrchestrator.SampleApp/Steps/SimulatedFailureStep.cs
+++ b/samples/FlowOrchestrator.SampleApp/Steps/SimulatedFailureStep.cs
@@ -1,0 +1,42 @@
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Execution;
+
+namespace FlowOrchestrator.SampleApp.Steps;
+
+/// <summary>
+/// A demo-only step handler that always throws an exception, causing the step to transition
+/// to <see cref="StepStatus.Failed"/>. Used by <c>ConditionalSkipDemoFlow</c> to reliably
+/// trigger the skip behaviour in downstream steps whose <c>runAfter</c> condition requires
+/// <see cref="StepStatus.Succeeded"/>.
+/// </summary>
+public sealed class SimulatedFailureStep : IStepHandler<SimulatedFailureStepInput>
+{
+    private readonly ILogger<SimulatedFailureStep> _logger;
+
+    /// <summary>Initializes a new instance of <see cref="SimulatedFailureStep"/>.</summary>
+    public SimulatedFailureStep(ILogger<SimulatedFailureStep> logger) => _logger = logger;
+
+    /// <summary>
+    /// Always throws <see cref="InvalidOperationException"/> so the step is recorded as
+    /// <see cref="StepStatus.Failed"/>, causing any downstream step that requires
+    /// <see cref="StepStatus.Succeeded"/> to be skipped.
+    /// </summary>
+    public ValueTask<object?> ExecuteAsync(
+        IExecutionContext ctx,
+        IFlowDefinition flow,
+        IStepInstance<SimulatedFailureStepInput> step)
+    {
+        _logger.LogWarning(
+            "[SimulatedFailure] RunId={RunId} Step={StepKey} — intentionally failing: {Reason}",
+            ctx.RunId, step.Key, step.Inputs.Reason);
+
+        throw new InvalidOperationException(step.Inputs.Reason ?? "Simulated failure for demo purposes.");
+    }
+}
+
+/// <summary>Input for <see cref="SimulatedFailureStep"/>.</summary>
+public sealed class SimulatedFailureStepInput
+{
+    /// <summary>Human-readable reason included in the thrown exception message.</summary>
+    public string? Reason { get; set; }
+}

--- a/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
@@ -83,6 +83,10 @@ internal static class DashboardHtml
   --success-bg:#eaf5ef;
   --success-border:#b5d9c5;
   --success-text:#1b4435;
+  --skip:#87867f;          /* Stone Gray — intentional bypass */
+  --skip-bg:#f5f4ed;       /* Parchment — warm neutral background */
+  --skip-border:#d1cfc5;   /* Ring Warm */
+  --skip-text:#5e5d59;     /* Olive Gray */
   --muted:#87867f;         /* Stone Gray */
   --text:#141413;          /* Anthropic Near Black */
   --text-dim:#5e5d59;      /* Olive Gray */
@@ -161,6 +165,7 @@ button{font-family:inherit;cursor:pointer;border:none;outline:none}
 .badge-running{background:var(--warn-bg);color:var(--warn-text);border:1px solid var(--warn-border)}
 .badge-succeeded{background:var(--success-bg);color:var(--success-text);border:1px solid var(--success-border)}
 .badge-failed{background:var(--danger-bg);color:var(--danger-text);border:1px solid var(--danger-border)}
+.badge-skipped{background:var(--skip-bg);color:var(--skip-text);border:1px solid var(--skip-border)}
 
 .flow-detail-panel{display:none;flex-direction:column;flex:1;overflow:hidden}
 .flow-detail-panel.show{display:flex}
@@ -226,7 +231,7 @@ button{font-family:inherit;cursor:pointer;border:none;outline:none}
 .run-trigger-cell{font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--text-dim);max-width:160px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .run-status-badge{font-size:10px;font-weight:700;padding:3px 8px;border-radius:100px;text-transform:uppercase;flex-shrink:0;letter-spacing:.3px}
 .status-dot{width:8px;height:8px;border-radius:50%;display:inline-block;flex-shrink:0;vertical-align:middle;margin-right:6px}
-.status-dot.Running{background:var(--warn);animation:pulse 1.5s infinite}.status-dot.Succeeded{background:var(--success)}.status-dot.Failed{background:var(--danger)}
+.status-dot.Running{background:var(--warn);animation:pulse 1.5s infinite}.status-dot.Succeeded{background:var(--success)}.status-dot.Failed{background:var(--danger)}.status-dot.Skipped{background:var(--skip)}
 
 .detail-empty{display:flex;align-items:center;justify-content:center;flex-direction:column;gap:8px;color:var(--text-dim);min-height:300px}.detail-empty .icon{font-size:40px;opacity:.25}
 .detail-header{padding:16px 20px;border-bottom:1px solid var(--border);background:var(--surface)}
@@ -239,15 +244,15 @@ button{font-family:inherit;cursor:pointer;border:none;outline:none}
 .step-circle.Running{border-color:var(--warn);color:var(--warn);animation:pulse 1.5s infinite}
 .step-circle.Succeeded{border-color:var(--success);color:var(--success);background:var(--success-bg)}
 .step-circle.Failed{border-color:var(--danger);color:var(--danger);background:var(--danger-bg)}
-.step-circle.Pending{border-color:var(--text-light);color:var(--text-light)}
+.step-circle.Pending{border-color:var(--text-light);color:var(--text-light)}.step-circle.Skipped{border-color:var(--skip);color:var(--skip);background:var(--skip-bg)}
 .step-line{width:2px;flex:1;min-height:12px;background:var(--border)}.step-line.done{background:var(--success)}.step-line.last{display:none}
 .step-card{flex:1;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:12px 16px;margin-bottom:10px;margin-left:8px}
-.step-card.Running{border-left:3px solid var(--warn)}.step-card.Succeeded{border-left:3px solid var(--success)}.step-card.Failed{border-left:3px solid var(--danger)}
+.step-card.Running{border-left:3px solid var(--warn)}.step-card.Succeeded{border-left:3px solid var(--success)}.step-card.Failed{border-left:3px solid var(--danger)}.step-card.Skipped{border-left:3px dashed var(--skip);opacity:.8}
 .step-card.step-target{outline:2px solid var(--accent);outline-offset:2px;background:var(--accent-light)}
 .step-card-header{display:flex;align-items:center;justify-content:space-between}
 .step-key{font-family:'JetBrains Mono',monospace;font-size:13px;font-weight:600;color:var(--text)}.step-type{font-size:12px;color:var(--text-dim);margin-top:1px}
 .step-badge{font-size:10px;font-weight:700;padding:2px 8px;border-radius:100px;text-transform:uppercase;letter-spacing:.3px}
-.step-badge.Running{background:var(--warn-bg);color:var(--warn-text);border:1px solid var(--warn-border)}.step-badge.Succeeded{background:var(--success-bg);color:var(--success-text);border:1px solid var(--success-border)}.step-badge.Failed{background:var(--danger-bg);color:var(--danger-text);border:1px solid var(--danger-border)}.step-badge.Pending{background:var(--surface2);color:var(--text-light);border:1px solid var(--border)}
+.step-badge.Running{background:var(--warn-bg);color:var(--warn-text);border:1px solid var(--warn-border)}.step-badge.Succeeded{background:var(--success-bg);color:var(--success-text);border:1px solid var(--success-border)}.step-badge.Failed{background:var(--danger-bg);color:var(--danger-text);border:1px solid var(--danger-border)}.step-badge.Pending{background:var(--surface2);color:var(--text-light);border:1px solid var(--border)}.step-badge.Skipped{background:var(--skip-bg);color:var(--skip-text);border:1px solid var(--skip-border)}
 .step-timing{margin-top:6px;font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--text-dim);display:flex;gap:14px;flex-wrap:wrap}
 .step-error{margin-top:6px;padding:8px 10px;background:var(--danger-bg);border:1px solid var(--danger-border);border-radius:var(--radius);font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--danger-text);word-break:break-all}
 .step-output{margin-top:6px;padding:8px 10px;background:var(--surface2);border:1px solid var(--border);border-radius:var(--radius);font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--text);word-break:break-all;max-height:80px;overflow-y:auto}
@@ -410,6 +415,7 @@ button{font-family:inherit;cursor:pointer;border:none;outline:none}
             <option value="">All Statuses</option>
             <option value="Running">Running</option>
             <option value="Succeeded">Succeeded</option>
+            <option value="Skipped">Skipped</option>
             <option value="Failed">Failed</option>
           </select>
         </div>
@@ -517,7 +523,9 @@ function renderStepDebugPanels(step) {
     : '';
   const inputPanel = renderDetailPanel('Step Input', step.inputJson, false, null);
   const outputPanel = renderDetailPanel('Step Output', step.outputJson, false, null);
-  const errorPanel = renderDetailPanel('Step Error', step.errorMessage, step.status === 'Failed', 'error');
+  const errorPanel = step.status === 'Skipped'
+    ? renderDetailPanel('Skip Reason', step.errorMessage, false, null)
+    : renderDetailPanel('Step Error', step.errorMessage, step.status === 'Failed', 'error');
   return attemptsPanel + inputPanel + outputPanel + errorPanel;
 }
 function statusBadge(s) { return '<span class="badge badge-'+s.toLowerCase()+'">'+s+'</span>'; }
@@ -1137,7 +1145,7 @@ function renderTimeline(steps, runId) {
   let html = '<div class="timeline">';
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i], last = i===steps.length-1;
-    const icon = ({Succeeded:'\u2713',Failed:'\u2715',Running:'\u25cf'})[s.status]||'\u25cb';
+    const icon = ({Succeeded:'\u2713',Failed:'\u2715',Running:'\u25cf',Skipped:'\u2298'})[s.status]||'\u25cb';
     const attemptCount = getStepAttemptCount(s);
     html += '<div class="step-node" data-step-key="'+esc(s.stepKey)+'"><div class="step-connector">'
       +'<div class="step-circle '+s.status+'">'+icon+'</div>'
@@ -1177,6 +1185,7 @@ function scheduleBadge(state) {
   const s = state.toLowerCase();
   if (s === 'succeeded') return '<span class="badge badge-succeeded">'+state+'</span>';
   if (s === 'failed') return '<span class="badge badge-failed">'+state+'</span>';
+  if (s === 'skipped') return '<span class="badge badge-skipped">'+state+'</span>';
   if (s === 'processing' || s === 'enqueued') return '<span class="badge badge-running">'+state+'</span>';
   return '<span class="badge badge-paused">'+state+'</span>';
 }

--- a/src/FlowOrchestrator.Hangfire/HangfireFlowOrchestrator.cs
+++ b/src/FlowOrchestrator.Hangfire/HangfireFlowOrchestrator.cs
@@ -517,8 +517,39 @@ public sealed class HangfireFlowOrchestrator : IHangfireFlowTrigger, IHangfireSt
 
         if (termination is null)
         {
-            var hasFailed = statuses.Values.Any(x => x == StepStatus.Failed);
-            termination = hasFailed ? StepStatus.Failed.ToString() : StepStatus.Succeeded.ToString();
+            // Determine run-level status.
+            //
+            // Key question: did any step actually Succeed?
+            //
+            // No Succeeded + has Skipped → Skipped
+            //   Skip propagation dead-ended the whole workflow — nothing useful ran.
+            //
+            // No Succeeded + no Skipped → Failed
+            //   Pure crash with no conditional paths involved.
+            //
+            // Has Succeeded → check whether any failure was left unhandled:
+            //   Unhandled = a Failed step with no downstream that Succeeded.
+            //   Handled   = a Failed step followed by a fallback that Succeeded.
+            //   → Failed if unhandled failure exists, Succeeded otherwise.
+            var anySucceeded = statuses.Values.Any(x => x == StepStatus.Succeeded);
+
+            if (!anySucceeded)
+            {
+                var anySkipped = statuses.Values.Any(x => x == StepStatus.Skipped);
+                termination = anySkipped
+                    ? StepStatus.Skipped.ToString()
+                    : StepStatus.Failed.ToString();
+            }
+            else
+            {
+                var hasUnhandledFailure = statuses.Any(kvp =>
+                    kvp.Value == StepStatus.Failed &&
+                    !IsFailureHandled(kvp.Key, flow.Manifest.Steps, statuses));
+
+                termination = hasUnhandledFailure
+                    ? StepStatus.Failed.ToString()
+                    : StepStatus.Succeeded.ToString();
+            }
         }
 
         await TryCompleteRunAsync(ctx.RunId, termination).ConfigureAwait(false);
@@ -574,6 +605,21 @@ public sealed class HangfireFlowOrchestrator : IHangfireFlowTrigger, IHangfireSt
             _logger.LogWarning(ex, "Failed to mark step {StepKey} as skipped due to terminal run status.", step.Key);
         }
     }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when a failed step has at least one downstream step
+    /// (a step that lists <paramref name="failedStepKey"/> in its <c>RunAfter</c>) that ran
+    /// and <see cref="StepStatus.Succeeded"/>. This indicates the flow author explicitly
+    /// designed a recovery path that executed successfully, so the failure is considered handled.
+    /// </summary>
+    private static bool IsFailureHandled(
+        string failedStepKey,
+        StepCollection manifestSteps,
+        IReadOnlyDictionary<string, StepStatus> statuses) =>
+        manifestSteps.Any(kvp =>
+            kvp.Value.RunAfter?.ContainsKey(failedStepKey) == true &&
+            statuses.TryGetValue(kvp.Key, out var s) &&
+            s == StepStatus.Succeeded);
 
     private async Task TryCompleteRunAsync(Guid runId, string status)
     {


### PR DESCRIPTION
Dashboard (DashboardHtml.cs):
- Add --skip-* CSS tokens (warm stone palette, consistent with DESIGN.md)
- Add .step-circle.Skipped, .step-card.Skipped (dashed left border + opacity), .step-badge.Skipped, .badge-skipped, .status-dot.Skipped
- Map ⊘ icon (U+2298) for Skipped in renderTimeline()
- Show "Skip Reason" panel (neutral styling) instead of hiding errorMessage behind the Failed guard in renderStepDebugPanels()
- Add scheduleBadge() branch for skipped Hangfire jobs
- Add "Skipped" option to the Runs status filter dropdown

Engine (HangfireFlowOrchestrator.cs):
- Add IsFailureHandled() helper: a Failed step is considered handled when at least one downstream step (listed in its RunAfter) ran and Succeeded
- Run-level status logic: no Succeeded + has Skipped → Skipped; no Succeeded + no Skipped → Failed; has Succeeded + unhandled failure → Failed; has Succeeded + all failures handled → Succeeded

Sample app:
- SimulatedFailureStep: always-fail step handler for deterministic demo runs
- ConditionalSkipDemoFlow: payment flow — validate fails, charge skipped, decline handler runs, receipt always runs → run = Succeeded
- SkipVariantsDemoFlow: shows middle skip (chain continues) and end skip (dead-end)
- DeadEndSkipDemoFlow: all downstream skip after entry failure → run = Skipped
- .claude/launch.json: dev server configs for http/https profiles of AppHost + SampleApp