### PR TITLE
fix: per-TFM CI matrix, solution filter, and version bump to 1.10.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,12 @@ on:
 
 jobs:
   build-and-test:
+    name: Build & Test (${{ matrix.tfm }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tfm: [net8.0, net9.0, net10.0]
 
     steps:
       - uses: actions/checkout@v4
@@ -22,18 +27,18 @@ jobs:
             10.0.x
 
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore FlowOrchestrator.Libraries.slnf
 
       - name: Build
-        run: dotnet build --no-restore --configuration Release
+        run: dotnet build FlowOrchestrator.Libraries.slnf --no-restore --configuration Release -p:TargetFramework=${{ matrix.tfm }}
 
       - name: Test
-        run: dotnet test --no-build --configuration Release --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./test-results
+        run: dotnet test FlowOrchestrator.Libraries.slnf --no-build --configuration Release -p:TargetFramework=${{ matrix.tfm }} --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./test-results
 
       - name: Upload coverage reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-reports
+          name: coverage-reports-${{ matrix.tfm }}
           path: ./test-results/**/coverage.cobertura.xml
           retention-days: 14

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <RepositoryUrl>https://github.com/hoangsnowy/FlowOrchestrator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/hoangsnowy/FlowOrchestrator</PackageProjectUrl>
-    <VersionPrefix>1.9.0</VersionPrefix>
+    <VersionPrefix>1.10.0</VersionPrefix>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>

--- a/FlowOrchestrator.Libraries.slnf
+++ b/FlowOrchestrator.Libraries.slnf
@@ -1,0 +1,19 @@
+{
+  "solution": {
+    "path": "FlowOrchestrator.sln",
+    "projects": [
+      "src\\FlowOrchestrator.Core\\FlowOrchestrator.Core.csproj",
+      "src\\FlowOrchestrator.Hangfire\\FlowOrchestrator.Hangfire.csproj",
+      "src\\FlowOrchestrator.Dashboard\\FlowOrchestrator.Dashboard.csproj",
+      "src\\FlowOrchestrator.SqlServer\\FlowOrchestrator.SqlServer.csproj",
+      "src\\FlowOrchestrator.PostgreSQL\\FlowOrchestrator.PostgreSQL.csproj",
+      "src\\FlowOrchestrator.InMemory\\FlowOrchestrator.InMemory.csproj",
+      "tests\\FlowOrchestrator.Core.Tests\\FlowOrchestrator.Core.Tests.csproj",
+      "tests\\FlowOrchestrator.Hangfire.Tests\\FlowOrchestrator.Hangfire.Tests.csproj",
+      "tests\\FlowOrchestrator.Dashboard.Tests\\FlowOrchestrator.Dashboard.Tests.csproj",
+      "tests\\FlowOrchestrator.SqlServer.Tests\\FlowOrchestrator.SqlServer.Tests.csproj",
+      "tests\\FlowOrchestrator.PostgreSQL.Tests\\FlowOrchestrator.PostgreSQL.Tests.csproj",
+      "tests\\FlowOrchestrator.InMemory.Tests\\FlowOrchestrator.InMemory.Tests.csproj"
+    ]
+  }
+}

--- a/src/FlowOrchestrator.Core/Execution/IPollableInput.cs
+++ b/src/FlowOrchestrator.Core/Execution/IPollableInput.cs
@@ -18,7 +18,7 @@ public interface IPollableInput
     int PollIntervalSeconds { get; }
 
     /// <summary>
-    /// Maximum total seconds to keep polling before the step is marked <see cref="StepStatus.Failed"/>.
+    /// Maximum total seconds to keep polling before the step is marked <see cref="FlowOrchestrator.Core.Abstractions.StepStatus.Failed"/>.
     /// Must be greater than or equal to <see cref="PollIntervalSeconds"/>.
     /// </summary>
     int PollTimeoutSeconds { get; }


### PR DESCRIPTION
- Add FlowOrchestrator.Libraries.slnf to exclude SampleApp and AppHost (which only target net10.0) from framework-specific builds, fixing NETSDK1005 errors when building with -p:TargetFramework=net8.0
- Update CI to a 3-way matrix (net8.0 / net9.0 / net10.0) using the solution filter for restore, build, and test steps
- Fix CS1574 cref warning in IPollableInput.cs by fully qualifying StepStatus.Failed to FlowOrchestrator.Core.Abstractions.StepStatus.Failed
- Bump VersionPrefix from 1.9.0 to 1.10.0