### PR TITLE
feat(dashboard): run-detail redesign — 4 tabs, Gantt, Events, run-level status fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <RepositoryUrl>https://github.com/hoangsnowy/FlowOrchestrator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/hoangsnowy/FlowOrchestrator</PackageProjectUrl>
-    <VersionPrefix>1.10.0</VersionPrefix>
+    <VersionPrefix>1.11.0</VersionPrefix>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ FlowOrchestrator is an open-source .NET library for orchestrating **multi-step b
 - `PollableStepHandler<T>` — built-in retry-with-backoff for steps that wait on external systems
 - `ForEach` loop steps — iterate over collections and fan out parallel/sequential child steps
 - Full run history — step-by-step timeline, input/output capture, attempt tracking
+- Run detail with **four views**: Timeline, DAG (interactive graph), Gantt (time-axis SVG), Events (raw event stream)
 - Retry button — re-enqueue any failed step from the dashboard without restarting the whole run
+- **Re-run all** — replay a completed run with the original trigger payload via `POST /api/runs/{id}/rerun`
 - Run control — cooperative cancel + timeout support per run
 - Idempotent triggers via `Idempotency-Key` header
 - Scheduler durability — pause/cron override state persists across restarts
@@ -233,7 +235,14 @@ Each trigger generates a new `RunId` (GUID). All trigger data, step inputs, outp
 
 ### Run statuses
 
-Common run statuses include `Running`, `Succeeded`, `Failed`, plus control-plane statuses `Cancelled` (cooperative cancel requested) and `TimedOut` (timeout threshold reached).
+| Status | Meaning |
+|--------|---------|
+| `Running` | One or more steps are currently executing |
+| `Succeeded` | All leaf steps (terminal steps with no dependents) completed successfully |
+| `Skipped` | All leaf steps were Skipped — the run ended via conditional branches with no crash |
+| `Failed` | At least one step failed with no downstream fallback that Succeeded |
+| `Cancelled` | Cooperative cancel was requested and honoured |
+| `TimedOut` | Run exceeded the configured timeout threshold |
 
 ---
 
@@ -467,7 +476,7 @@ Non-matching strings are passed through as-is.
 
 ## 8. Running the Sample App
 
-The sample app (`samples/FlowOrchestrator.SampleApp`) demonstrates an e-commerce **OrderHub** scenario with four flows:
+The sample app (`samples/FlowOrchestrator.SampleApp`) demonstrates an e-commerce **OrderHub** scenario plus several DAG and run-status demos:
 
 | Flow | Triggers | Demonstrates |
 |---|---|---|
@@ -475,6 +484,11 @@ The sample app (`samples/FlowOrchestrator.SampleApp`) demonstrates an e-commerce
 | `OrderFulfillmentFlow` | Manual, Webhook `/order-fulfillment` | DB query → polling API → save result |
 | `ShipmentTrackingFlow` | Manual | Polling pattern (Pending → Pending → Succeeded) |
 | `PaymentEventFlow` | Webhook `/payment-event` | `@triggerBody()` expression extraction |
+| `ParallelHealthCheckFlow` | Manual | Fan-out parallel steps, fan-in join |
+| `ConditionalSkipDemoFlow` | Manual | Conditional branching — one branch Skipped, fallback runs → run = **Succeeded** |
+| `SkipVariantsDemoFlow` | Manual | Middle skip + dead-end skip — run = **Succeeded** |
+| `DeadEndSkipDemoFlow` | Manual | Entry step crashes, all downstream Blocked → run = **Failed** |
+| `FinalStepSkipDemoFlow` | Manual | Happy path completes, final error-handler leaf Skipped → run = **Skipped** |
 
 ### Option A — Via .NET Aspire (recommended, requires Docker Desktop)
 
@@ -544,7 +558,14 @@ Open `http://localhost:5201/flows` (or your configured base path).
 - Raw JSON manifest viewer
 - **Enable/Disable** toggle and **Trigger** button
 
-**Runs** — Filterable run list (by flow, status, or free-text search). Search matches run fields (`id`, `flowName`, `status`, `triggerKey`) and step trace fields (`stepKey`, `errorMessage`, `outputJson`). Click a run to see the step-by-step timeline with timing, inputs, outputs, and errors. Failed steps show a **Retry** button. You can also request cooperative **Cancel**, inspect run **Control** state (timeout/cancel/idempotency), and query run **Events**.
+**Runs** — Filterable run list (by flow, status, or free-text search). Search matches run fields (`id`, `flowName`, `status`, `triggerKey`) and step trace fields (`stepKey`, `errorMessage`, `outputJson`). Click a run to open the detail view with four tabs:
+
+- **Timeline** — vertical step cards with timing, inputs, outputs, errors, and attempt history. Trigger Data and Trigger Headers panels are shown here. Failed steps show a **Retry** button.
+- **DAG** — interactive SVG dependency graph. Click any node to select it and see a step inspector strip below. Blocked (Skipped) steps render with a dashed border.
+- **Gantt** — SVG bars on a relative time axis showing step parallelism. Skipped steps render as dim placeholders. Click a bar to select the step.
+- **Events** — raw `FlowEventRecord` stream grouped by step (requires `IFlowEventReader` to be registered; shows an empty-state message otherwise).
+
+Step selection is URL-synced (`?view=timeline|dag|gantt|events`). The run header shows a live progress bar and pulsing dot while the run is active. Actions available from the header: **Cancel run** (Running only), **Retry failed steps**, **Re-run all** (replays the original trigger payload via `POST /api/runs/{id}/rerun`).
 
 **Scheduled** — Hangfire recurring jobs: flow name, trigger key, cron expression, next/last execution. Actions: trigger immediately, pause, resume, edit cron expression inline.
 
@@ -608,6 +629,7 @@ All endpoints are under the base path configured in `MapFlowDashboard(basePath)`
 | `GET` | `/flows/api/runs/{runId}/control` | Run control state (timeout/cancel/idempotency) |
 | `POST` | `/flows/api/runs/{runId}/cancel` | Request cooperative run cancellation |
 | `POST` | `/flows/api/runs/{runId}/steps/{stepKey}/retry` | Retry a failed step |
+| `POST` | `/flows/api/runs/{runId}/rerun` | Start a new run replaying the original trigger payload |
 | `GET` | `/flows/api/schedules` | List recurring jobs with status |
 | `POST` | `/flows/api/schedules/{jobId}/trigger` | Trigger a recurring job immediately |
 | `POST` | `/flows/api/schedules/{jobId}/pause` | Pause a recurring job |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## FlowOrchestrator
 
+**[📖 Documentation](https://hoangsnowy.github.io/FlowOrchestrator/)** · **[NuGet](https://www.nuget.org/packages/FlowOrchestrator.Core)** · **[GitHub](https://github.com/hoangsnowy/FlowOrchestrator)**
+
 FlowOrchestrator is an open-source .NET library for orchestrating **multi-step background workflows** — defined as code-first C# manifests, executed by **Hangfire**, persisted in **SQL Server**, **PostgreSQL**, or **in-memory**, and monitored via a **built-in dashboard**.
 
 **Features at a glance:**

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,59 @@
+# API Reference
+
+Full XML-documentation reference for all public types and members in FlowOrchestrator.
+
+## Packages
+
+| Package | Namespace | Description |
+|---|---|---|
+| `FlowOrchestrator.Core` | `FlowOrchestrator.Core.*` | Abstractions, execution engine, storage contracts |
+| `FlowOrchestrator.Hangfire` | `FlowOrchestrator.Hangfire.*` | Hangfire bridge, DI extensions, built-in step handlers |
+| `FlowOrchestrator.InMemory` | `FlowOrchestrator.InMemory.*` | In-process storage backend (dev/testing) |
+| `FlowOrchestrator.SqlServer` | `FlowOrchestrator.SqlServer.*` | SQL Server persistence (Dapper) |
+| `FlowOrchestrator.PostgreSQL` | `FlowOrchestrator.PostgreSQL.*` | PostgreSQL persistence (Npgsql) |
+| `FlowOrchestrator.Dashboard` | `FlowOrchestrator.Dashboard.*` | REST API and embedded SPA |
+
+## Key Types
+
+### Defining Flows
+
+| Type | Description |
+|---|---|
+| [`IFlowDefinition`](FlowOrchestrator.Core.Abstractions.IFlowDefinition.yml) | Contract for a flow definition class |
+| [`FlowManifest`](FlowOrchestrator.Core.Abstractions.FlowManifest.yml) | Holds triggers and steps for a flow |
+| [`StepMetadata`](FlowOrchestrator.Core.Abstractions.StepMetadata.yml) | Declares a step's type, inputs, and `runAfter` dependencies |
+| [`LoopStepMetadata`](FlowOrchestrator.Core.Abstractions.LoopStepMetadata.yml) | ForEach loop step definition |
+| [`TriggerMetadata`](FlowOrchestrator.Core.Abstractions.TriggerMetadata.yml) | Declares a trigger (manual, cron, or webhook) |
+| [`RunAfterCollection`](FlowOrchestrator.Core.Abstractions.RunAfterCollection.yml) | Maps predecessor step keys to required statuses |
+| [`StepStatus`](FlowOrchestrator.Core.Abstractions.StepStatus.yml) | Enum: `Pending`, `Running`, `Succeeded`, `Failed`, `Skipped` |
+
+### Implementing Step Handlers
+
+| Type | Description |
+|---|---|
+| [`IStepHandler<TInput>`](FlowOrchestrator.Core.Abstractions.IStepHandler-1.yml) | Main interface for custom step logic |
+| [`PollableStepHandler<TInput>`](FlowOrchestrator.Core.Abstractions.PollableStepHandler-1.yml) | Base class for steps that poll an external system |
+| [`IPollableInput`](FlowOrchestrator.Core.Abstractions.IPollableInput.yml) | Input contract for pollable steps |
+| [`IExecutionContext`](FlowOrchestrator.Core.Abstractions.IExecutionContext.yml) | Run-scoped context passed to every handler |
+| [`IExecutionContextAccessor`](FlowOrchestrator.Core.Abstractions.IExecutionContextAccessor.yml) | DI-injectable accessor for the current execution context |
+
+### Storage Abstractions
+
+| Type | Description |
+|---|---|
+| [`IFlowStore`](FlowOrchestrator.Core.Storage.IFlowStore.yml) | Persists flow definitions |
+| [`IFlowRunStore`](FlowOrchestrator.Core.Storage.IFlowRunStore.yml) | Persists run state and step records |
+| [`IOutputsRepository`](FlowOrchestrator.Core.Storage.IOutputsRepository.yml) | Stores and retrieves per-step outputs keyed by `RunId` |
+
+### DI Registration
+
+| Type | Description |
+|---|---|
+| [`FlowOrchestratorBuilder`](FlowOrchestrator.Core.Configuration.FlowOrchestratorBuilder.yml) | Returned by `AddFlowOrchestrator()` — configure storage, Hangfire, and flows |
+
+## See Also
+
+- [Getting Started](../articles/getting-started.md) — install and first flow
+- [Core Concepts](../articles/core-concepts.md) — DAG semantics, statuses, RunId
+- [Step Handlers](../articles/step-handlers.md) — writing `IStepHandler<T>` and `PollableStepHandler<T>`
+- [Storage Backends](../articles/storage.md) — swap SQL Server, PostgreSQL, or InMemory

--- a/docs/articles/core-concepts.md
+++ b/docs/articles/core-concepts.md
@@ -143,7 +143,7 @@ When multiple predecessors are listed, **all** must reach one of their declared 
 | `Running` | Hangfire job is executing |
 | `Succeeded` | Handler returned without error |
 | `Failed` | Handler threw an exception, or returned `StepStatus.Failed` |
-| `Skipped` | All paths to this step resulted in statuses not listed in `RunAfter` |
+| `Skipped` | All paths to this step ended in statuses not listed in its `RunAfter`. The dashboard displays this as **Blocked**. |
 
 ---
 

--- a/docs/articles/dashboard.md
+++ b/docs/articles/dashboard.md
@@ -90,7 +90,7 @@ Filter parameters:
 - Search (free text)
 
 Click a run to open the **run timeline**:
-- Step-by-step execution timeline with status badges
+- Step-by-step execution timeline with status badges (`Succeeded`, `Failed`, `Running`, `Pending`, **`Blocked`** — step could not run because a dependency did not meet its `runAfter` condition)
 - Input/output JSON for each step
 - Retry button on failed steps
 - Cancel button for running steps

--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -92,6 +92,11 @@ a:hover {
   letter-spacing: -0.01em;
 }
 
+.navbar-brand img {
+  height: 28px;
+  width: auto;
+}
+
 .navbar-nav .nav-link {
   color: var(--fo-olive) !important;
   font-size: 0.9375rem;

--- a/samples/FlowOrchestrator.SampleApp/Flows/DeadEndSkipDemoFlow.cs
+++ b/samples/FlowOrchestrator.SampleApp/Flows/DeadEndSkipDemoFlow.cs
@@ -3,21 +3,23 @@ using FlowOrchestrator.Core.Abstractions;
 namespace FlowOrchestrator.SampleApp.Flows;
 
 /// <summary>
-/// DeadEndSkipDemoFlow — Produces a run-level <c>Skipped</c> status.
+/// DeadEndSkipDemoFlow — Demonstrates run-level <c>Failed</c> status when an entry step crashes
+/// and all downstream steps become Blocked (Skipped) because their <c>runAfter</c> conditions
+/// can never be satisfied.
 ///
-/// The entry step always fails and all downstream steps require <c>Succeeded</c>,
-/// so skip propagates to every leaf — nothing useful runs — and the run is recorded
-/// as <c>Skipped</c> rather than <c>Failed</c> or <c>Succeeded</c>.
+/// A real step crash (<c>validate_input</c> → Failed) is never masked by downstream skip
+/// propagation. The run is recorded as <c>Failed</c> even though every other step is Skipped.
 ///
 /// DAG:
-///   validate_input  (SimulatedFailure → always fails)
-///       └─► enrich_data   (RunAfter: validate_input=[Succeeded]) → Skipped
-///                 └─► save_result (RunAfter: enrich_data=[Succeeded])   → Skipped ← leaf
+///   validate_input  (SimulatedFailure → always crashes)
+///       └─► enrich_data   (RunAfter: validate_input=[Succeeded]) → Blocked
+///                 └─► save_result (RunAfter: enrich_data=[Succeeded])  → Blocked
 ///
 /// Expected run result:
-///   validate_input   Failed
-///   enrich_data      Skipped
-///   save_result      Skipped  ← only leaf, all leaves Skipped → run = Skipped
+///   validate_input   Failed   ← real crash
+///   enrich_data      Skipped  ← Blocked because validate_input did not Succeed
+///   save_result      Skipped  ← Blocked because enrich_data did not Succeed
+///   → run status = Failed  (crash takes precedence over downstream blocking)
 /// </summary>
 public sealed class DeadEndSkipDemoFlow : IFlowDefinition
 {
@@ -50,8 +52,8 @@ public sealed class DeadEndSkipDemoFlow : IFlowDefinition
                 Inputs = new Dictionary<string, object?> { ["message"] = "Enriching data from external source." }
             },
 
-            // Leaf step — only Succeeded is accepted, so skip propagates here.
-            // All leaves Skipped → run-level = Skipped.
+            // Leaf step — only Succeeded is accepted, so Blocked propagates here.
+            // All downstream Skipped + entry Failed → run-level = Failed.
             ["save_result"] = new StepMetadata
             {
                 Type = "LogMessage",

--- a/samples/FlowOrchestrator.SampleApp/Flows/FinalStepSkipDemoFlow.cs
+++ b/samples/FlowOrchestrator.SampleApp/Flows/FinalStepSkipDemoFlow.cs
@@ -1,0 +1,94 @@
+using FlowOrchestrator.Core.Abstractions;
+
+namespace FlowOrchestrator.SampleApp.Flows;
+
+/// <summary>
+/// FinalStepSkipDemoFlow — Demonstrates a <c>Succeeded</c> run where the very last step
+/// in a linear chain is <c>Skipped</c> because it is an error-handler that was never needed.
+///
+/// This is the "happy path with optional final fallback" pattern: the main linear chain
+/// completes successfully, so the final step — which only fires when the step directly
+/// before it fails — is Skipped. The run still reports <c>Succeeded</c> because no
+/// unhandled failure exists.
+///
+/// DAG (linear chain — no branching):
+///   check_inventory ──► reserve_stock ──► confirm_order ──► notify_ops_on_failure
+///                                                              RunAfter: confirm_order=[Failed]
+///                                                              (Skipped — confirm_order Succeeded)
+///
+/// Expected run result:
+///   check_inventory         Succeeded
+///   reserve_stock           Succeeded
+///   confirm_order           Succeeded
+///   notify_ops_on_failure   Skipped  ← truly final step, error handler at end of chain
+///   → run status = Succeeded  (skip at the end is normal; no unhandled failure exists)
+/// </summary>
+public sealed class FinalStepSkipDemoFlow : IFlowDefinition
+{
+    public Guid Id { get; } = new Guid("00000000-0000-0000-0000-000000000011");
+    public string Version => "1.0";
+    public FlowManifest Manifest { get; set; } = new FlowManifest
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            // ── Step 1 — Entry ────────────────────────────────────────────────────
+            ["check_inventory"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "FinalStepSkipDemo — checking inventory availability..."
+                }
+            },
+
+            // ── Step 2 ────────────────────────────────────────────────────────────
+            ["reserve_stock"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                RunAfter = new RunAfterCollection
+                {
+                    ["check_inventory"] = [StepStatus.Succeeded]
+                },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "Stock reserved successfully."
+                }
+            },
+
+            // ── Step 3 ────────────────────────────────────────────────────────────
+            ["confirm_order"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                RunAfter = new RunAfterCollection
+                {
+                    ["reserve_stock"] = [StepStatus.Succeeded]
+                },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "Order confirmed and dispatched to fulfilment."
+                }
+            },
+
+            // ── Step 4 — FINAL LEAF (will be SKIPPED) ────────────────────────────
+            // Sits at the very end of the linear chain. Only fires when confirm_order
+            // fails. Because confirm_order Succeeded, this condition is never met →
+            // step is Skipped → run is still Succeeded.
+            ["notify_ops_on_failure"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                RunAfter = new RunAfterCollection
+                {
+                    ["confirm_order"] = [StepStatus.Failed]
+                },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "ALERT: order confirmation failed — ops team notified."
+                }
+            }
+        }
+    };
+}

--- a/samples/FlowOrchestrator.SampleApp/Program.cs
+++ b/samples/FlowOrchestrator.SampleApp/Program.cs
@@ -118,8 +118,12 @@ builder.Services.AddFlowOrchestrator(options =>
     // Skip variants demo — shows both a middle skip (chain continues) and an end skip (dead-end).
     options.AddFlow<SkipVariantsDemoFlow>();
 
-    // Dead-end skip demo — all leaf steps end as Skipped → run-level status = Skipped.
+    // Dead-end skip demo — entry crashes, all downstream Skipped → run-level status = Failed.
     options.AddFlow<DeadEndSkipDemoFlow>();
+
+    // Final-step skip demo — happy path succeeds; the final error-handler leaf is Skipped
+    // because it was never needed → run-level status = Succeeded.
+    options.AddFlow<FinalStepSkipDemoFlow>();
 
     if (storageBackend == "sqlserver")
         options.AddFlow<OrderFulfillmentFlow>();

--- a/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
@@ -247,7 +247,7 @@ button{font-family:inherit;cursor:pointer;border:none;outline:none}
 .step-circle.Pending{border-color:var(--text-light);color:var(--text-light)}.step-circle.Skipped{border-color:var(--skip);color:var(--skip);background:var(--skip-bg)}
 .step-line{width:2px;flex:1;min-height:12px;background:var(--border)}.step-line.done{background:var(--success)}.step-line.last{display:none}
 .step-card{flex:1;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:12px 16px;margin-bottom:10px;margin-left:8px}
-.step-card.Running{border-left:3px solid var(--warn)}.step-card.Succeeded{border-left:3px solid var(--success)}.step-card.Failed{border-left:3px solid var(--danger)}.step-card.Skipped{border-left:3px dashed var(--skip);opacity:.8}
+.step-card.Running{border-left:3px solid var(--warn)}.step-card.Succeeded{border-left:3px solid var(--success)}.step-card.Failed{border-left:3px solid var(--danger)}.step-card.Skipped{border-left:2px dashed var(--border-dark);opacity:.6;background:transparent}
 .step-card.step-target{outline:2px solid var(--accent);outline-offset:2px;background:var(--accent-light)}
 .step-card-header{display:flex;align-items:center;justify-content:space-between}
 .step-key{font-family:'JetBrains Mono',monospace;font-size:13px;font-weight:600;color:var(--text)}.step-type{font-size:12px;color:var(--text-dim);margin-top:1px}
@@ -530,15 +530,19 @@ function getStepAttemptCount(step) {
   return 1;
 }
 function renderStepDebugPanels(step) {
+  // Blocked steps never executed — no input/output/error panels to show
+  if (step.status === 'Skipped') {
+    return '<div style="margin-top:5px;font-size:11px;color:var(--skip-text);font-style:italic">'
+      + 'Not executed \u2014 retry the failed step above to resume this flow.'
+      + '</div>';
+  }
   const attemptCount = getStepAttemptCount(step);
   const attemptsPanel = attemptCount > 1
     ? renderDetailPanel('Step Attempts', step.attempts, false, null)
     : '';
   const inputPanel = renderDetailPanel('Step Input', step.inputJson, false, null);
   const outputPanel = renderDetailPanel('Step Output', step.outputJson, false, null);
-  const errorPanel = step.status === 'Skipped'
-    ? renderDetailPanel('Blocked Reason', step.errorMessage, false, null)
-    : renderDetailPanel('Step Error', step.errorMessage, step.status === 'Failed', 'error');
+  const errorPanel = renderDetailPanel('Step Error', step.errorMessage, step.status === 'Failed', 'error');
   return attemptsPanel + inputPanel + outputPanel + errorPanel;
 }
 function stepStatusLabel(s) { return s === 'Skipped' ? 'Blocked' : s; }
@@ -1306,9 +1310,9 @@ function renderTimeline(steps, runId) {
       +'<div style="display:flex;align-items:center;gap:6px"><span class="step-badge '+s.status+'">'+stepStatusLabel(s.status)+'</span>'
       +(attemptCount>1?'<span class="step-badge Pending">x'+attemptCount+' attempts</span>':'')
       +(s.status==='Failed'?'<button class="btn-retry" onclick="retryStep(\''+runId+'\',\''+esc(s.stepKey)+'\')">&#8635; Retry</button>':'')
-      +'<button class="btn-copy-icon" onclick="copyStepLink(\''+runId+'\',\''+esc(s.stepKey)+'\')" title="Copy step link"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>'
+      +(s.status!=='Skipped'?'<button class="btn-copy-icon" onclick="copyStepLink(\''+runId+'\',\''+esc(s.stepKey)+'\')" title="Copy step link"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>':'')
       +'</div></div>'
-      +'<div class="step-timing"><span>Start: '+fmt(s.startedAt)+'</span><span>End: '+fmt(s.completedAt)+'</span><span>Duration: '+duration(s.startedAt,s.completedAt)+'</span></div>'
+      +(s.status==='Skipped'?'':('<div class="step-timing"><span>Start: '+fmt(s.startedAt)+'</span><span>End: '+fmt(s.completedAt)+'</span><span>Duration: '+duration(s.startedAt,s.completedAt)+'</span></div>'))
       +renderStepDebugPanels(s)
       +'</div></div>';
   }

--- a/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
@@ -293,6 +293,19 @@ button{font-family:inherit;cursor:pointer;border:none;outline:none}
 
 .dag-svg{width:100%;overflow:auto}
 .dag-svg svg text{font-family:'JetBrains Mono',monospace;font-size:11px}
+
+/* Run detail — Timeline / DAG toggle */
+.run-view-toggle{display:flex;align-items:center;gap:0;padding:10px 18px;border-bottom:1px solid var(--border);background:var(--surface)}
+.run-view-btn{font-size:11px;font-weight:600;padding:5px 16px;border:1px solid var(--border-dark);background:transparent;color:var(--text-dim);cursor:pointer;transition:all .15s;line-height:1.5}
+.run-view-btn:first-child{border-radius:6px 0 0 6px}
+.run-view-btn:last-child{border-radius:0 6px 6px 0;margin-left:-1px}
+.run-view-btn.active{background:var(--accent);color:#faf9f5;border-color:var(--accent);position:relative;z-index:1}
+.run-view-btn:not(.active):hover{border-color:var(--accent);color:var(--accent)}
+
+/* Live DAG in run detail */
+.run-dag-wrap{padding:16px 18px;overflow:auto}
+@keyframes dag-pulse{0%,100%{opacity:1}50%{opacity:.45}}
+.dag-node-running rect{animation:dag-pulse 1.5s infinite}
 </style>
 </head>
 <body>
@@ -892,6 +905,125 @@ function renderDAG(manifest) {
   container.innerHTML = svg;
 }
 
+function renderRunDAG(steps, manifest) {
+  if (!manifest || !manifest.steps || Object.keys(manifest.steps).length === 0) {
+    return '<div class="empty-msg">No DAG available — flow manifest not loaded.</div>';
+  }
+
+  // Build status lookup from runtime steps
+  const statusMap = {};
+  for (const s of steps) statusMap[s.stepKey] = s.status;
+
+  const mSteps = manifest.steps;
+  const keys = Object.keys(mSteps);
+  const nodeW = 200, nodeH = 58, padX = 90, padY = 22;
+
+  // Compute DAG levels (same algorithm as renderDAG)
+  const levels = {};
+  function getLevel(key) {
+    if (levels[key] !== undefined) return levels[key];
+    const step = mSteps[key];
+    if (!step.runAfter || Object.keys(step.runAfter).length === 0) return (levels[key] = 0);
+    let max = 0;
+    for (const dep of Object.keys(step.runAfter)) {
+      if (mSteps[dep]) max = Math.max(max, getLevel(dep) + 1);
+    }
+    return (levels[key] = max);
+  }
+  keys.forEach(k => getLevel(k));
+
+  const byLevel = {};
+  keys.forEach(k => { const l = levels[k]; (byLevel[l] = byLevel[l] || []).push(k); });
+  const maxLevel = Math.max(...Object.keys(byLevel).map(Number));
+
+  const positions = {};
+  for (let l = 0; l <= maxLevel; l++) {
+    (byLevel[l] || []).forEach((k, i) => {
+      positions[k] = { x: l * (nodeW + padX) + 20, y: i * (nodeH + padY) + 20 };
+    });
+  }
+
+  const svgW = (maxLevel + 1) * (nodeW + padX) + 40;
+  const maxNodes = Math.max(...Object.values(byLevel).map(g => g.length));
+  const svgH = maxNodes * (nodeH + padY) + 40;
+
+  // Status → visual tokens
+  function nodeStyle(status) {
+    switch (status) {
+      case 'Succeeded': return { fill:'#eaf5ef', stroke:'#2d6a4f', text:'#1b4435', dimText:'#2d6a4f', label:'✓ Succeeded', cls:'' };
+      case 'Failed':    return { fill:'#fdf0ee', stroke:'#b53333', text:'#7a1e1e', dimText:'#b53333', label:'✗ Failed',    cls:'' };
+      case 'Running':   return { fill:'#fef4e8', stroke:'#c8803a', text:'#7a3f08', dimText:'#c8803a', label:'◉ Running',   cls:'dag-node-running' };
+      case 'Skipped':   return { fill:'#f5f4ed', stroke:'#87867f', text:'#5e5d59', dimText:'#87867f', label:'⊘ Blocked',   cls:'' };
+      case 'Pending':   return { fill:'#faf9f5', stroke:'#d1cfc5', text:'#87867f', dimText:'#b0aea5', label:'○ Pending',   cls:'' };
+      default:          return { fill:'#faf9f5', stroke:'#e8e6dc', text:'#87867f', dimText:'#b0aea5', label:'○ Pending',   cls:'' };
+    }
+  }
+
+  // Edge color based on source status
+  function edgeStroke(status) {
+    switch (status) {
+      case 'Succeeded': return { color:'#b5d9c5', marker:'dag-arr-ok'   };
+      case 'Failed':    return { color:'#f5c6c0', marker:'dag-arr-fail' };
+      case 'Running':   return { color:'#f6d8b3', marker:'dag-arr-run'  };
+      default:          return { color:'#d1cfc5', marker:'dag-arr-def'  };
+    }
+  }
+
+  let svg = '<div class="dag-svg" style="min-height:160px"><svg width="'+svgW+'" height="'+svgH+'" xmlns="http://www.w3.org/2000/svg">';
+
+  // Arrow markers
+  svg += '<defs>';
+  [['dag-arr-ok','#b5d9c5'],['dag-arr-fail','#f5c6c0'],['dag-arr-run','#f6d8b3'],['dag-arr-def','#d1cfc5']].forEach(([id,col]) => {
+    svg += '<marker id="'+id+'" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="'+col+'"/></marker>';
+  });
+  svg += '</defs>';
+
+  // Draw edges
+  for (const [key, step] of Object.entries(mSteps)) {
+    if (!step.runAfter) continue;
+    for (const dep of Object.keys(step.runAfter)) {
+      if (!positions[dep] || !positions[key]) continue;
+      const from = positions[dep], to = positions[key];
+      const { color, marker } = edgeStroke(statusMap[dep]);
+      svg += '<line'
+        +' x1="'+(from.x+nodeW)+'" y1="'+(from.y+nodeH/2)+'"'
+        +' x2="'+to.x+'" y2="'+(to.y+nodeH/2)+'"'
+        +' stroke="'+color+'" stroke-width="2"'
+        +' marker-end="url(#'+marker+')"/>';
+    }
+  }
+
+  // Draw nodes — clicking switches to timeline and scrolls to that step
+  for (const [key, step] of Object.entries(mSteps)) {
+    if (!positions[key]) continue;
+    const p = positions[key];
+    const status = statusMap[key] || 'Pending';
+    const ns = nodeStyle(status);
+    const safeKey = key.replace(/'/g, "\\'");
+    svg += '<g class="'+ns.cls+'" transform="translate('+p.x+','+p.y+')"'
+      +' onclick="switchRunView(\'timeline\');scrollToStep(\''+safeKey+'\')"'
+      +' style="cursor:pointer">'
+      +'<rect width="'+nodeW+'" height="'+nodeH+'" rx="6"'
+      +' fill="'+ns.fill+'" stroke="'+ns.stroke+'" stroke-width="1.5"/>'
+      // step key (monospace, top)
+      +'<text x="10" y="20" fill="'+ns.text+'"'
+      +' font-weight="600" font-size="12"'
+      +' font-family="JetBrains Mono,monospace">'+esc(key)+'</text>'
+      // step type (terracotta, middle)
+      +'<text x="10" y="36" fill="#c96442"'
+      +' font-size="10" font-family="Inter,sans-serif">'+esc(step.type||'')+'</text>'
+      // status label (bottom-right pill)
+      +'<text x="'+(nodeW-8)+'" y="'+(nodeH-8)+'"'
+      +' fill="'+ns.dimText+'" font-size="9" font-weight="700"'
+      +' text-anchor="end" font-family="Inter,sans-serif"'
+      +' letter-spacing="0.4">'+ns.label+'</text>'
+      +'</g>';
+  }
+
+  svg += '</svg></div>';
+  return svg;
+}
+
 async function toggleFlow(id, enable) {
   try {
     await fetch(BASE+'/flows/'+id+'/'+(enable?'enable':'disable'), {method:'POST'});
@@ -949,6 +1081,17 @@ function scrollToStep(stepKey) {
   if (card) card.classList.add('step-target');
   node.scrollIntoView({ behavior: 'smooth', block: 'center' });
   setTimeout(() => { if (card) card.classList.remove('step-target'); }, 4000);
+}
+
+function switchRunView(view) {
+  const tl = $('run-view-timeline'), dg = $('run-view-dag');
+  const btnTl = $('run-view-btn-timeline'), btnDg = $('run-view-btn-dag');
+  if (!tl || !dg) return;
+  const showDag = view === 'dag';
+  tl.style.display = showDag ? 'none' : '';
+  dg.style.display = showDag ? '' : 'none';
+  if (btnTl) btnTl.classList.toggle('active', !showDag);
+  if (btnDg) btnDg.classList.toggle('active', showDag);
 }
 
 function toggleWebhookSecret(cellId, btn) {
@@ -1132,10 +1275,17 @@ async function selectRun(id, preserveScroll, targetStepKey) {
       +'<span>Started: <b style="color:var(--text)">'+fmtDate(run.startedAt)+'</b></span>'
       +'<span>Duration: <b style="color:var(--text)">'+duration(run.startedAt,run.completedAt)+'</b></span>'
       +'</div></div>'
-      +'<div style="padding:16px 18px">'
+      +'<div class="run-view-toggle">'
+      +'<button class="run-view-btn active" id="run-view-btn-timeline" onclick="switchRunView(\'timeline\')">Timeline</button>'
+      +'<button class="run-view-btn" id="run-view-btn-dag" onclick="switchRunView(\'dag\')">DAG</button>'
+      +'</div>'
+      +'<div id="run-view-timeline" style="padding:16px 18px">'
       +renderRunTriggerPanels(run)
       +'<div style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.5px;color:var(--text-dim);margin-bottom:10px">Step Timeline ('+steps.length+' step'+(steps.length!==1?'s':'')+')</div>'
       +(steps.length===0?'<div class="empty-msg">No steps recorded yet.</div>':renderTimeline(steps, run.id))
+      +'</div>'
+      +'<div id="run-view-dag" class="run-dag-wrap" style="display:none">'
+      +renderRunDAG(steps, (allFlows.find(f=>f.name===run.flowName||f.id===run.flowId)||{}).manifest)
       +'</div>';
     if (preserveScroll) $('runs-detail').scrollTop = detailScrollTop;
     if (selectedStepKey) scrollToStep(selectedStepKey);

--- a/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
@@ -524,10 +524,11 @@ function renderStepDebugPanels(step) {
   const inputPanel = renderDetailPanel('Step Input', step.inputJson, false, null);
   const outputPanel = renderDetailPanel('Step Output', step.outputJson, false, null);
   const errorPanel = step.status === 'Skipped'
-    ? renderDetailPanel('Skip Reason', step.errorMessage, false, null)
+    ? renderDetailPanel('Blocked Reason', step.errorMessage, false, null)
     : renderDetailPanel('Step Error', step.errorMessage, step.status === 'Failed', 'error');
   return attemptsPanel + inputPanel + outputPanel + errorPanel;
 }
+function stepStatusLabel(s) { return s === 'Skipped' ? 'Blocked' : s; }
 function statusBadge(s) { return '<span class="badge badge-'+s.toLowerCase()+'">'+s+'</span>'; }
 
 function normalizeAutoRefreshSeconds(value) {
@@ -1152,7 +1153,7 @@ function renderTimeline(steps, runId) {
       +'<div class="step-line '+(s.status==='Succeeded'?'done':'')+' '+(last?'last':'')+'"></div></div>'
       +'<div class="step-card '+s.status+'">'
       +'<div class="step-card-header"><div><div class="step-key">'+esc(s.stepKey)+'</div><div class="step-type">'+esc(s.stepType)+'</div></div>'
-      +'<div style="display:flex;align-items:center;gap:6px"><span class="step-badge '+s.status+'">'+s.status+'</span>'
+      +'<div style="display:flex;align-items:center;gap:6px"><span class="step-badge '+s.status+'">'+stepStatusLabel(s.status)+'</span>'
       +(attemptCount>1?'<span class="step-badge Pending">x'+attemptCount+' attempts</span>':'')
       +(s.status==='Failed'?'<button class="btn-retry" onclick="retryStep(\''+runId+'\',\''+esc(s.stepKey)+'\')">&#8635; Retry</button>':'')
       +'<button class="btn-copy-icon" onclick="copyStepLink(\''+runId+'\',\''+esc(s.stepKey)+'\')" title="Copy step link"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>'

--- a/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
@@ -428,7 +428,7 @@ button{font-family:inherit;cursor:pointer;border:none;outline:none}
             <option value="">All Statuses</option>
             <option value="Running">Running</option>
             <option value="Succeeded">Succeeded</option>
-            <option value="Skipped">Skipped</option>
+            <option value="Skipped">Blocked</option>
             <option value="Failed">Failed</option>
           </select>
         </div>
@@ -546,7 +546,7 @@ function renderStepDebugPanels(step) {
   return attemptsPanel + inputPanel + outputPanel + errorPanel;
 }
 function stepStatusLabel(s) { return s === 'Skipped' ? 'Blocked' : s; }
-function statusBadge(s) { return '<span class="badge badge-'+s.toLowerCase()+'">'+s+'</span>'; }
+function statusBadge(s) { const label = s === 'Skipped' ? 'Blocked' : s; return '<span class="badge badge-'+s.toLowerCase()+'">'+label+'</span>'; }
 
 function normalizeAutoRefreshSeconds(value) {
   const parsed = Number.parseInt(value, 10);
@@ -1087,6 +1087,19 @@ function scrollToStep(stepKey) {
   setTimeout(() => { if (card) card.classList.remove('step-target'); }, 4000);
 }
 
+async function resolveFlowManifest(run) {
+  // Try allFlows cache first
+  let flow = allFlows.find(f => f.name === run.flowName || f.id === run.flowId);
+  if (flow) return flow.manifest;
+  // Cache miss (e.g. navigated directly to run URL) — fetch on demand
+  try {
+    const flows = await fetchJSON(BASE + '/flows');
+    flow = flows.find(f => f.name === run.flowName || f.id === run.flowId);
+    if (flow) { allFlows = flows; return flow.manifest; }
+  } catch {}
+  return null;
+}
+
 function switchRunView(view) {
   const tl = $('run-view-timeline'), dg = $('run-view-dag');
   const btnTl = $('run-view-btn-timeline'), btnDg = $('run-view-btn-dag');
@@ -1289,7 +1302,7 @@ async function selectRun(id, preserveScroll, targetStepKey) {
       +(steps.length===0?'<div class="empty-msg">No steps recorded yet.</div>':renderTimeline(steps, run.id))
       +'</div>'
       +'<div id="run-view-dag" class="run-dag-wrap" style="display:none">'
-      +renderRunDAG(steps, (allFlows.find(f=>f.name===run.flowName||f.id===run.flowId)||{}).manifest)
+      +renderRunDAG(steps, await resolveFlowManifest(run))
       +'</div>';
     if (preserveScroll) $('runs-detail').scrollTop = detailScrollTop;
     if (selectedStepKey) scrollToStep(selectedStepKey);

--- a/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
@@ -306,6 +306,64 @@ button{font-family:inherit;cursor:pointer;border:none;outline:none}
 .run-dag-wrap{padding:16px 18px;overflow:auto}
 @keyframes dag-pulse{0%,100%{opacity:1}50%{opacity:.45}}
 .dag-node-running rect{animation:dag-pulse 1.5s infinite}
+.dag-node-selected rect.dag-node-bg{stroke:var(--accent) !important;stroke-width:2.5 !important;filter:drop-shadow(0 0 0 2px rgba(201,100,66,.25))}
+.dag-node-blocked rect.dag-node-bg{stroke-dasharray:4 3;fill-opacity:.6}
+
+/* Run detail — Tab strip (replaces run-view-toggle pattern) */
+.tab-strip{display:flex;align-items:center;gap:2px;padding:8px 18px 0;border-bottom:1px solid var(--border);background:var(--surface)}
+.tab-strip .tab{font-size:12px;font-weight:600;padding:8px 16px;border:none;background:transparent;color:var(--text-dim);cursor:pointer;transition:all .15s;border-bottom:2px solid transparent;border-radius:6px 6px 0 0;font-family:inherit}
+.tab-strip .tab:hover{color:var(--accent);background:var(--accent-light)}
+.tab-strip .tab.active{color:var(--accent);border-bottom-color:var(--accent);background:var(--surface)}
+
+/* Run header — progress, live dot, action row */
+.run-header-actions{display:flex;align-items:center;gap:8px;margin-top:10px;flex-wrap:wrap}
+.progress-bar{flex:1;min-width:120px;max-width:260px;height:6px;background:var(--surface2);border:1px solid var(--border);border-radius:100px;overflow:hidden;position:relative}
+.progress-fill{height:100%;background:var(--accent);transition:width .4s ease}
+.progress-label{font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--text-dim);white-space:nowrap}
+.live-dot{display:inline-flex;align-items:center;gap:6px;font-size:11px;font-weight:600;color:var(--warn-text);text-transform:uppercase;letter-spacing:.5px}
+.live-dot::before{content:"";width:8px;height:8px;border-radius:50%;background:var(--warn);animation:pulse 1.5s infinite}
+.btn-action{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;padding:6px 12px;border-radius:6px;background:var(--surface);color:var(--text);border:1px solid var(--border-dark);cursor:pointer;transition:all .15s;font-family:inherit}
+.btn-action:hover:not(:disabled){border-color:var(--accent);color:var(--accent)}
+.btn-action:disabled{opacity:.4;cursor:not-allowed}
+.btn-action.danger{color:var(--danger-text);border-color:var(--danger-border)}
+.btn-action.danger:hover:not(:disabled){background:var(--danger-bg);border-color:var(--danger);color:var(--danger)}
+.btn-action.primary{background:var(--accent);color:#faf9f5;border-color:var(--accent)}
+.btn-action.primary:hover:not(:disabled){background:var(--accent-hover);border-color:var(--accent-hover);color:#faf9f5}
+
+/* Timeline — selected card ring */
+.step-card.selected{box-shadow:0 0 0 2px var(--accent),0 0 0 6px rgba(201,100,66,.12);border-color:var(--accent)}
+
+/* Gantt */
+.gantt-wrap{padding:16px 18px;overflow:auto}
+.gantt-svg text{font-family:'JetBrains Mono',monospace;font-size:11px;fill:var(--text-dim)}
+.gantt-svg .gantt-gutter-label{fill:var(--text);font-weight:600}
+.gantt-svg .gantt-axis line{stroke:var(--border)}
+.gantt-svg .gantt-axis-tick{fill:var(--text-light);font-size:10px}
+.gantt-svg .gantt-bar{cursor:pointer;transition:opacity .15s}
+.gantt-svg .gantt-bar:hover{opacity:.82}
+.gantt-svg .gantt-bar-selected{stroke:var(--accent);stroke-width:2.5}
+.gantt-svg .gantt-duration{fill:var(--text-light);font-size:10px}
+.gantt-empty{padding:32px;text-align:center;color:var(--text-dim);font-size:13px}
+
+/* Events drawer */
+.events-drawer{position:fixed;top:0;right:0;width:460px;max-width:100vw;height:100vh;background:var(--surface);border-left:1px solid var(--border);box-shadow:-4px 0 16px rgba(0,0,0,.06);transform:translateX(100%);transition:transform .25s ease;z-index:900;display:flex;flex-direction:column}
+.events-drawer.open{transform:translateX(0)}
+.events-drawer-header{padding:14px 18px;border-bottom:1px solid var(--border);background:var(--surface2);display:flex;align-items:center;justify-content:space-between;flex-shrink:0}
+.events-drawer-title{font-size:13px;font-weight:700;color:var(--text);text-transform:uppercase;letter-spacing:.5px}
+.events-drawer-close{background:transparent;border:none;cursor:pointer;color:var(--text-dim);font-size:18px;width:28px;height:28px;border-radius:6px;display:inline-flex;align-items:center;justify-content:center}
+.events-drawer-close:hover{background:var(--accent-light);color:var(--accent)}
+.events-drawer-body{flex:1;overflow-y:auto;padding:12px 18px}
+.event-group{margin-bottom:14px}
+.event-group-title{font-family:'JetBrains Mono',monospace;font-size:12px;font-weight:600;color:var(--accent);padding:6px 0;border-bottom:1px solid var(--border);margin-bottom:6px}
+.event-item{display:flex;gap:8px;padding:5px 0;font-size:12px;border-bottom:1px dashed var(--border)}
+.event-item:last-child{border-bottom:none}
+.event-time{font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-light);flex-shrink:0;width:72px}
+.event-kind{font-weight:600;color:var(--text);flex-shrink:0;width:130px;text-transform:uppercase;letter-spacing:.3px;font-size:10px}
+.event-detail{font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--text-dim);word-break:break-word;flex:1}
+
+/* Inspector strip shared by DAG/Gantt */
+.step-inspector{margin-top:16px;padding:14px 16px;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius)}
+.step-inspector-empty{padding:20px;text-align:center;color:var(--text-dim);font-size:12px;border:1px dashed var(--border);border-radius:var(--radius);margin-top:16px}
 </style>
 </head>
 <body>
@@ -471,6 +529,10 @@ const runsPageSize = 20;
 let runsSearchDebounceTimer = null;
 let selectedRunId = null;
 let selectedStepKey = null;
+let currentRunView = 'timeline'; // 'timeline' | 'dag' | 'gantt' | 'events'
+let currentRun = null; // cache of last loaded run for tab re-renders
+let currentRunManifest = null; // cached resolved manifest for DAG/Gantt
+let eventsDrawerOpen = false;
 let runsView = 'list'; // 'list' | 'detail'
 let selectedFlowDetail = null;
 const autoRefreshStorageEnabledKey = 'flow-dashboard:auto-refresh-enabled';
@@ -909,18 +971,19 @@ function renderDAG(manifest) {
   container.innerHTML = svg;
 }
 
-function renderRunDAG(steps, manifest) {
+function renderRunDAG(steps, manifest, selectedKey) {
   if (!manifest || !manifest.steps || Object.keys(manifest.steps).length === 0) {
     return '<div class="empty-msg">No DAG available — flow manifest not loaded.</div>';
   }
 
   // Build status lookup from runtime steps
   const statusMap = {};
-  for (const s of steps) statusMap[s.stepKey] = s.status;
+  const stepMap = {};
+  for (const s of steps) { statusMap[s.stepKey] = s.status; stepMap[s.stepKey] = s; }
 
   const mSteps = manifest.steps;
   const keys = Object.keys(mSteps);
-  const nodeW = 200, nodeH = 58, padX = 90, padY = 22;
+  const nodeW = 220, nodeH = 72, padX = 90, padY = 22;
 
   // Compute DAG levels (same algorithm as renderDAG)
   const levels = {};
@@ -997,25 +1060,48 @@ function renderRunDAG(steps, manifest) {
     }
   }
 
-  // Draw nodes — clicking switches to timeline and scrolls to that step
+  // Find blocked-reason helper
+  function blockedReason(key) {
+    const step = mSteps[key];
+    if (!step || !step.runAfter) return null;
+    for (const dep of Object.keys(step.runAfter)) {
+      const depStatus = statusMap[dep];
+      if (depStatus && depStatus !== 'Succeeded') return dep;
+    }
+    return null;
+  }
+
+  // Draw nodes — clicking selects the step (updates URL + inspector)
   for (const [key, step] of Object.entries(mSteps)) {
     if (!positions[key]) continue;
     const p = positions[key];
     const status = statusMap[key] || 'Pending';
     const ns = nodeStyle(status);
     const safeKey = key.replace(/'/g, "\\'");
-    svg += '<g class="'+ns.cls+'" transform="translate('+p.x+','+p.y+')"'
-      +' onclick="switchRunView(\'timeline\');scrollToStep(\''+safeKey+'\')"'
+    const runtimeStep = stepMap[key];
+    const attemptCount = runtimeStep ? getStepAttemptCount(runtimeStep) : 1;
+    const dur = runtimeStep && runtimeStep.startedAt ? duration(runtimeStep.startedAt, runtimeStep.completedAt) : '\u2014';
+    const metaText = dur + (attemptCount > 1 ? '  \u00b7  \u00d7'+attemptCount+' attempts' : '');
+    const classList = [ns.cls, selectedKey===key ? 'dag-node-selected' : '', status==='Skipped' ? 'dag-node-blocked' : ''].filter(Boolean).join(' ');
+    const blockedOn = status==='Skipped' ? blockedReason(key) : null;
+    const tooltip = esc(key)+'\n'+(step.type||'')+(attemptCount>1?'\n\u00d7'+attemptCount+' attempts':'')
+      + (blockedOn ? '\nBlocked because "'+blockedOn+'" did not succeed.' : '');
+    svg += '<g class="'+classList+'" transform="translate('+p.x+','+p.y+')"'
+      +' onclick="selectStep(\''+safeKey+'\')"'
       +' style="cursor:pointer">'
-      +'<rect width="'+nodeW+'" height="'+nodeH+'" rx="6"'
+      +'<title>'+tooltip+'</title>'
+      +'<rect class="dag-node-bg" width="'+nodeW+'" height="'+nodeH+'" rx="8"'
       +' fill="'+ns.fill+'" stroke="'+ns.stroke+'" stroke-width="1.5"/>'
       // step key (monospace, top)
       +'<text x="10" y="20" fill="'+ns.text+'"'
       +' font-weight="600" font-size="12"'
-      +' font-family="JetBrains Mono,monospace">'+esc(key)+'</text>'
-      // step type (terracotta, middle)
+      +' font-family="JetBrains Mono,monospace">'+esc(key.length>24?key.slice(0,23)+'\u2026':key)+'</text>'
+      // step type (terracotta)
       +'<text x="10" y="36" fill="#c96442"'
-      +' font-size="10" font-family="Inter,sans-serif">'+esc(step.type||'')+'</text>'
+      +' font-size="10" font-family="Inter,sans-serif">'+esc((step.type||'').slice(0,28))+'</text>'
+      // duration · attempts (grey)
+      +'<text x="10" y="52" fill="'+ns.dimText+'"'
+      +' font-size="10" font-family="JetBrains Mono,monospace">'+esc(metaText)+'</text>'
       // status label (bottom-right pill)
       +'<text x="'+(nodeW-8)+'" y="'+(nodeH-8)+'"'
       +' fill="'+ns.dimText+'" font-size="9" font-weight="700"'
@@ -1090,25 +1176,317 @@ function scrollToStep(stepKey) {
 async function resolveFlowManifest(run) {
   // Try allFlows cache first
   let flow = allFlows.find(f => f.name === run.flowName || f.id === run.flowId);
-  if (flow) return flow.manifest;
+  if (flow) return parseManifest(flow.manifestJson);
   // Cache miss (e.g. navigated directly to run URL) — fetch on demand
   try {
     const flows = await fetchJSON(BASE + '/flows');
     flow = flows.find(f => f.name === run.flowName || f.id === run.flowId);
-    if (flow) { allFlows = flows; return flow.manifest; }
+    if (flow) { allFlows = flows; return parseManifest(flow.manifestJson); }
   } catch {}
   return null;
 }
 
 function switchRunView(view) {
-  const tl = $('run-view-timeline'), dg = $('run-view-dag');
-  const btnTl = $('run-view-btn-timeline'), btnDg = $('run-view-btn-dag');
-  if (!tl || !dg) return;
-  const showDag = view === 'dag';
-  tl.style.display = showDag ? 'none' : '';
-  dg.style.display = showDag ? '' : 'none';
-  if (btnTl) btnTl.classList.toggle('active', !showDag);
-  if (btnDg) btnDg.classList.toggle('active', showDag);
+  if (!['timeline','dag','gantt','events'].includes(view)) view = 'timeline';
+  currentRunView = view;
+  if (selectedRunId) setRunRoute(selectedRunId, selectedStepKey, view);
+  const tabsEl = $('run-tabs');
+  if (tabsEl) tabsEl.innerHTML = renderTabs(view);
+  const bodyEl = $('run-tab-body');
+  if (bodyEl && currentRun) {
+    bodyEl.innerHTML = renderActiveTab(currentRun, currentRunManifest, view);
+    if (view === 'timeline' && selectedStepKey) scrollToStep(selectedStepKey);
+  }
+  if (view === 'events') openEventsDrawer(selectedRunId);
+  else closeEventsDrawer();
+}
+
+function renderTabs(activeView) {
+  const tabs = [
+    { key:'timeline', label:'Timeline' },
+    { key:'dag',      label:'DAG' },
+    { key:'gantt',    label:'Gantt' },
+    { key:'events',   label:'Events' }
+  ];
+  return tabs.map(t =>
+    '<button class="tab'+(activeView===t.key?' active':'')+'" onclick="switchRunView(\''+t.key+'\')">'+t.label+'</button>'
+  ).join('');
+}
+
+function renderActiveTab(run, manifest, view) {
+  const steps = run.steps || [];
+  switch (view) {
+    case 'dag':
+      return '<div class="run-dag-wrap">'
+        +renderRunDAG(steps, manifest, selectedStepKey)
+        +renderStepInspector(findStep(steps, selectedStepKey))
+        +'</div>';
+    case 'gantt':
+      return '<div class="gantt-wrap">'
+        +renderGantt(steps, manifest, selectedStepKey)
+        +renderStepInspector(findStep(steps, selectedStepKey))
+        +'</div>';
+    case 'events':
+      return '<div style="padding:16px 18px">'
+        +'<div style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.5px;color:var(--text-dim);margin-bottom:10px">Step Timeline ('+steps.length+' step'+(steps.length!==1?'s':'')+')</div>'
+        +(steps.length===0?'<div class="empty-msg">No steps recorded yet.</div>':renderTimeline(steps, run.id))
+        +'</div>';
+    case 'timeline':
+    default: {
+      const triggerPanels = renderRunTriggerPanels(run);
+      return '<div style="padding:16px 18px">'+triggerPanels
+        +'<div style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.5px;color:var(--text-dim);margin-bottom:10px">Step Timeline ('+steps.length+' step'+(steps.length!==1?'s':'')+')</div>'
+        +(steps.length===0?'<div class="empty-msg">No steps recorded yet.</div>':renderTimeline(steps, run.id))
+        +'</div>';
+    }
+  }
+}
+
+function findStep(steps, key) {
+  if (!key || !steps) return null;
+  return steps.find(s => s.stepKey === key) || null;
+}
+
+function isTerminalStatus(s) { return s === 'Succeeded' || s === 'Failed' || s === 'Cancelled'; }
+
+function renderRunHeader(run, steps) {
+  const total = steps.length;
+  const completed = steps.filter(s => isTerminalStatus(s.status) || s.status === 'Skipped').length;
+  const pct = total ? Math.round((completed / total) * 100) : 0;
+  const isRunning = run.status === 'Running';
+  const failedCount = steps.filter(s => s.status === 'Failed').length;
+  const runId = run.id;
+  const progress = isRunning && total > 0
+    ? '<div class="progress-bar"><div class="progress-fill" style="width:'+pct+'%"></div></div>'
+      +'<span class="progress-label">'+completed+' of '+total+' complete</span>'
+    : '';
+  const liveDot = isRunning ? '<span class="live-dot">Live</span>' : '';
+  const actions = []
+    .concat(isRunning ? ['<button class="btn-action danger" onclick="cancelRun(\''+runId+'\')">Cancel run</button>'] : [])
+    .concat(failedCount > 0 ? ['<button class="btn-action" onclick="retryAllFailed(\''+runId+'\')">Retry failed steps ('+failedCount+')</button>'] : [])
+    .concat(['<button class="btn-action primary" onclick="rerunAll(\''+runId+'\')">Re-run all</button>']);
+  return '<div class="detail-header">'
+    +'<div style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.5px;color:var(--text-dim);margin-bottom:4px;display:flex;align-items:center;justify-content:space-between">'
+    +'<span>Run Detail \u00b7 '+statusBadge(run.status)+'</span>'
+    +'<button class="btn-copy" onclick="copyRunLink(\''+runId+'\')" title="Copy shareable link"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>Copy link</button>'
+    +'</div>'
+    +'<div class="detail-runid">'+runId+'</div>'
+    +'<div style="font-size:12px;color:var(--text-dim);margin-top:6px;display:flex;gap:14px;flex-wrap:wrap">'
+    +'<span>Flow: <b style="color:var(--text)">'+esc(run.flowName||'\u2014')+'</b></span>'
+    +'<span>Trigger: <b style="color:var(--text)">'+esc(run.triggerKey||'\u2014')+'</b></span>'
+    +'<span>Started: <b style="color:var(--text)">'+fmtDate(run.startedAt)+'</b></span>'
+    +'<span>Duration: <b style="color:var(--text)">'+duration(run.startedAt,run.completedAt)+'</b></span>'
+    +'</div>'
+    +(progress || liveDot || actions.length
+      ? '<div class="run-header-actions">'+liveDot+progress+actions.join('')+'</div>'
+      : '')
+    +'</div>';
+}
+
+function renderStepInspector(step) {
+  if (!step) return '<div class="step-inspector-empty">Select a step above to see its details.</div>';
+  const attemptCount = getStepAttemptCount(step);
+  const timing = step.status === 'Skipped' || step.status === 'Pending'
+    ? ''
+    : '<div class="step-timing"><span>Start: '+fmt(step.startedAt)+'</span><span>End: '+fmt(step.completedAt)+'</span><span>Duration: '+duration(step.startedAt,step.completedAt)+'</span></div>';
+  return '<div class="step-inspector">'
+    +'<div class="step-card-header"><div><div class="step-key">'+esc(step.stepKey)+'</div>'
+    +(step.status!=='Skipped'?'<div class="step-type">'+esc(step.stepType||'')+'</div>':'')+'</div>'
+    +'<div style="display:flex;align-items:center;gap:6px"><span class="step-badge '+step.status+'">'+stepStatusLabel(step.status)+'</span>'
+    +(attemptCount>1?'<span class="step-badge Pending">x'+attemptCount+' attempts</span>':'')
+    +'</div></div>'
+    +timing
+    +renderStepDebugPanels(step)
+    +'</div>';
+}
+
+function selectStep(stepKey) {
+  selectedStepKey = stepKey || null;
+  if (selectedRunId) setRunRoute(selectedRunId, selectedStepKey, currentRunView);
+  if (currentRun) {
+    const bodyEl = $('run-tab-body');
+    if (bodyEl) bodyEl.innerHTML = renderActiveTab(currentRun, currentRunManifest, currentRunView);
+    if (currentRunView === 'timeline' && selectedStepKey) scrollToStep(selectedStepKey);
+  }
+}
+
+async function cancelRun(runId) {
+  if (!confirm('Cancel run "'+runId+'"?')) return;
+  try {
+    const res = await fetch(BASE+'/runs/'+runId+'/cancel', { method:'POST' });
+    const data = await res.json();
+    if (!res.ok || data.accepted === false) alert(data.message || data.error || 'Cancel request rejected.');
+    await selectRun(runId, true, selectedStepKey, currentRunView);
+  } catch(e) { alert('Failed to cancel run: '+e.message); }
+}
+
+async function retryAllFailed(runId) {
+  if (!currentRun) return;
+  const failed = (currentRun.steps || []).filter(s => s.status === 'Failed');
+  if (failed.length === 0) { alert('No failed steps to retry.'); return; }
+  if (!confirm('Retry '+failed.length+' failed step'+(failed.length!==1?'s':'')+'?')) return;
+  for (const s of failed) {
+    try {
+      await fetch(BASE+'/runs/'+runId+'/steps/'+encodeURIComponent(s.stepKey)+'/retry', { method:'POST' });
+    } catch(e) { console.error('Retry failed for', s.stepKey, e); }
+  }
+  await selectRun(runId, true, selectedStepKey, currentRunView);
+}
+
+async function rerunAll(runId) {
+  if (!confirm('Re-run this flow with the original trigger payload?')) return;
+  try {
+    const res = await fetch(BASE+'/runs/'+runId+'/rerun', { method:'POST' });
+    const data = await res.json();
+    if (!res.ok || !data.runId) { alert(data.error || 'Re-run failed.'); return; }
+    await selectRun(data.runId, false, null, 'timeline');
+  } catch(e) { alert('Failed to re-run: '+e.message); }
+}
+
+function openEventsDrawer(runId) {
+  if (!runId) return;
+  eventsDrawerOpen = true;
+  let drawer = $('events-drawer');
+  if (!drawer) {
+    drawer = document.createElement('div');
+    drawer.id = 'events-drawer';
+    drawer.className = 'events-drawer';
+    document.body.appendChild(drawer);
+  }
+  drawer.innerHTML =
+    '<div class="events-drawer-header">'
+    +'<span class="events-drawer-title">Event Stream'+(selectedStepKey?' \u00b7 <span style="color:var(--accent);font-family:\'JetBrains Mono\',monospace;font-size:12px">'+esc(selectedStepKey)+'</span>':'')+'</span>'
+    +'<button class="events-drawer-close" onclick="switchRunView(\'timeline\')">\u2715</button>'
+    +'</div>'
+    +'<div class="events-drawer-body" id="events-drawer-body">Loading events\u2026</div>';
+  drawer.classList.add('open');
+  loadEventsIntoDrawer(runId);
+}
+
+function closeEventsDrawer() {
+  eventsDrawerOpen = false;
+  const drawer = $('events-drawer');
+  if (drawer) drawer.classList.remove('open');
+}
+
+async function loadEventsIntoDrawer(runId) {
+  const body = $('events-drawer-body');
+  if (!body) return;
+  try {
+    const events = await fetchJSON(BASE+'/runs/'+runId+'/events?take=500');
+    if (!events || events.length === 0) {
+      body.innerHTML = '<div class="step-inspector-empty">Event stream not enabled on this backend. Configure <code>IFlowEventReader</code> to see the raw event log.</div>';
+      return;
+    }
+    const filtered = selectedStepKey ? events.filter(e => e.stepKey === selectedStepKey) : events;
+    if (filtered.length === 0) {
+      body.innerHTML = '<div class="step-inspector-empty">No events for step '+esc(selectedStepKey||'')+'.</div>';
+      return;
+    }
+    const groups = {};
+    for (const e of filtered) {
+      const k = e.stepKey || '(run)';
+      (groups[k] = groups[k] || []).push(e);
+    }
+    let html = '';
+    for (const k of Object.keys(groups)) {
+      html += '<div class="event-group"><div class="event-group-title">'+esc(k)+'</div>';
+      for (const e of groups[k]) {
+        html += '<div class="event-item">'
+          +'<span class="event-time">'+fmt(e.timestamp)+'</span>'
+          +'<span class="event-kind">'+esc(e.type||'event')+'</span>'
+          +'<span class="event-detail">'+esc(e.message||'')+'</span>'
+          +'</div>';
+      }
+      html += '</div>';
+    }
+    body.innerHTML = html;
+  } catch(err) {
+    body.innerHTML = '<div class="step-inspector-empty">Failed to load events: '+esc(err.message||'unknown')+'</div>';
+  }
+}
+
+function renderGantt(steps, manifest, selectedKey) {
+  if (!steps || steps.length === 0) return '<div class="gantt-empty">No steps to chart.</div>';
+  const executed = steps.filter(s => s.startedAt);
+  if (executed.length === 0) return '<div class="gantt-empty">No step has started yet.</div>';
+  const t0 = Math.min(...executed.map(s => new Date(s.startedAt).getTime()));
+  const now = Date.now();
+  const t1 = Math.max(...executed.map(s => s.completedAt ? new Date(s.completedAt).getTime() : now), t0 + 1);
+  const span = Math.max(t1 - t0, 1);
+
+  // Order by manifest level when available, else by startedAt
+  let ordered = steps.slice();
+  if (manifest && manifest.steps) {
+    const mSteps = manifest.steps;
+    const levels = {};
+    function getLevel(key) {
+      if (levels[key] !== undefined) return levels[key];
+      const step = mSteps[key];
+      if (!step || !step.runAfter || Object.keys(step.runAfter).length === 0) return (levels[key] = 0);
+      let max = 0;
+      for (const dep of Object.keys(step.runAfter)) if (mSteps[dep]) max = Math.max(max, getLevel(dep) + 1);
+      return (levels[key] = max);
+    }
+    Object.keys(mSteps).forEach(k => getLevel(k));
+    ordered.sort((a, b) => (levels[a.stepKey] ?? 99) - (levels[b.stepKey] ?? 99) || new Date(a.startedAt||0) - new Date(b.startedAt||0));
+  } else {
+    ordered.sort((a, b) => new Date(a.startedAt||0) - new Date(b.startedAt||0));
+  }
+
+  const rowH = 26, pad = 6, gutterW = 200, chartW = 640, axisH = 28, bottomPad = 12;
+  const svgW = gutterW + chartW + 24;
+  const svgH = axisH + ordered.length * (rowH + pad) + bottomPad;
+
+  function barColor(status) {
+    switch(status) {
+      case 'Succeeded': return '#7bbf9a';
+      case 'Failed':    return '#d97b6f';
+      case 'Running':   return '#e8a769';
+      case 'Skipped':   return '#c8c6bd';
+      case 'Pending':   return '#d8d6cd';
+      default:          return '#c8c6bd';
+    }
+  }
+
+  let svg = '<div class="gantt-svg"><svg width="'+svgW+'" height="'+svgH+'" xmlns="http://www.w3.org/2000/svg">';
+  svg += '<defs><pattern id="gantt-running-hatch" width="6" height="6" patternUnits="userSpaceOnUse" patternTransform="rotate(45)"><rect width="6" height="6" fill="#e8a769"/><line x1="0" y1="0" x2="0" y2="6" stroke="#faf9f5" stroke-width="2"/></pattern></defs>';
+
+  // Axis ticks
+  for (let i = 0; i <= 5; i++) {
+    const x = gutterW + (i / 5) * chartW;
+    const secs = ((span / 5) * i) / 1000;
+    svg += '<g class="gantt-axis">'
+      +'<line x1="'+x+'" y1="'+axisH+'" x2="'+x+'" y2="'+svgH+'" stroke-dasharray="2 3"/>'
+      +'<text class="gantt-axis-tick" x="'+x+'" y="'+(axisH-8)+'" text-anchor="middle">+'+secs.toFixed(secs<10?1:0)+'s</text>'
+      +'</g>';
+  }
+
+  ordered.forEach((s, idx) => {
+    const y = axisH + idx * (rowH + pad);
+    const started = s.startedAt ? new Date(s.startedAt).getTime() : t0;
+    const ended   = s.completedAt ? new Date(s.completedAt).getTime() : (s.status === 'Running' ? now : started);
+    let x = gutterW + ((started - t0) / span) * chartW;
+    let w = Math.max(((ended - started) / span) * chartW, 2);
+    let fill = barColor(s.status);
+    let opacity = (s.status === 'Pending' || s.status === 'Skipped') ? 0.45 : 1;
+    if (s.status === 'Pending' || s.status === 'Skipped') { x = gutterW; w = Math.max(chartW * 0.02, 6); }
+    if (s.status === 'Running') fill = 'url(#gantt-running-hatch)';
+    const selected = s.stepKey === selectedKey;
+    const safeKey = s.stepKey.replace(/'/g, "\\'");
+    svg += '<g onclick="selectStep(\''+safeKey+'\')" style="cursor:pointer">'
+      +'<text class="gantt-gutter-label" x="10" y="'+(y+rowH*0.65)+'">'+esc(s.stepKey)+'</text>'
+      +'<rect class="gantt-bar'+(selected?' gantt-bar-selected':'')+'" x="'+x+'" y="'+y+'" width="'+w+'" height="'+rowH+'"'
+      +' rx="4" fill="'+fill+'" opacity="'+opacity+'"'
+      +(selected?'':' stroke="rgba(0,0,0,0.04)"')+'>'
+      +'<title>'+esc(s.stepKey)+' \u2014 '+stepStatusLabel(s.status)+' \u00b7 '+duration(s.startedAt, s.completedAt)+'</title>'
+      +'</rect>'
+      +'<text class="gantt-duration" x="'+(x+w+6)+'" y="'+(y+rowH*0.65)+'">'+duration(s.startedAt, s.completedAt)+'</text>'
+      +'</g>';
+  });
+
+  svg += '</svg></div>';
+  return svg;
 }
 
 function toggleWebhookSecret(cellId, btn) {
@@ -1146,6 +1524,9 @@ function showRunsDetailView() {
 async function backToRunsList() {
   selectedRunId = null;
   selectedStepKey = null;
+  currentRun = null;
+  currentRunManifest = null;
+  closeEventsDrawer();
   history.replaceState(null, '', '#/runs');
   showRunsListView();
   if (allRuns.length === 0) await loadRuns();
@@ -1265,47 +1646,34 @@ async function loadRuns(preserveScroll) {
   } catch(e) { console.error('Runs load error', e); }
 }
 
-async function selectRun(id, preserveScroll, targetStepKey) {
-  const newHash = targetStepKey
-    ? '#/runs/'+id+'/steps/'+encodeURIComponent(targetStepKey)
-    : '#/runs/'+id;
-  if (location.hash !== newHash) history.replaceState(null, '', newHash);
-
+async function selectRun(id, preserveScroll, targetStepKey, view) {
   selectedRunId = id;
   selectedStepKey = targetStepKey || null;
+  if (view && ['timeline','dag','gantt','events'].includes(view)) currentRunView = view;
+  setRunRoute(id, selectedStepKey, currentRunView);
+
   showRunsDetailView();
   const detailEl = $('runs-detail');
   const detailScrollTop = preserveScroll && detailEl ? detailEl.scrollTop : 0;
   try {
     const run = await fetchJSON(BASE+'/runs/'+id);
+    currentRun = run;
     const steps = run.steps || [];
+    if (currentRunView === 'dag' || currentRunView === 'gantt') {
+      currentRunManifest = await resolveFlowManifest(run);
+    } else {
+      currentRunManifest = currentRunManifest || null;
+    }
+
     $('runs-detail').innerHTML =
-      '<div class="detail-header">'
-      +'<div style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.5px;color:var(--text-dim);margin-bottom:4px;display:flex;align-items:center;justify-content:space-between">'
-      +'<span>Run Detail \u00b7 '+statusBadge(run.status)+'</span>'
-      +'<button class="btn-copy" onclick="copyRunLink(\''+run.id+'\')" title="Copy shareable link"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>Copy link</button>'
-      +'</div>'
-      +'<div class="detail-runid">'+run.id+'</div>'
-      +'<div style="font-size:12px;color:var(--text-dim);margin-top:6px;display:flex;gap:14px;flex-wrap:wrap">'
-      +'<span>Flow: <b style="color:var(--text)">'+esc(run.flowName||'\u2014')+'</b></span>'
-      +'<span>Trigger: <b style="color:var(--text)">'+esc(run.triggerKey||'\u2014')+'</b></span>'
-      +'<span>Started: <b style="color:var(--text)">'+fmtDate(run.startedAt)+'</b></span>'
-      +'<span>Duration: <b style="color:var(--text)">'+duration(run.startedAt,run.completedAt)+'</b></span>'
-      +'</div></div>'
-      +'<div class="run-view-toggle">'
-      +'<button class="run-view-btn active" id="run-view-btn-timeline" onclick="switchRunView(\'timeline\')">Timeline</button>'
-      +'<button class="run-view-btn" id="run-view-btn-dag" onclick="switchRunView(\'dag\')">DAG</button>'
-      +'</div>'
-      +'<div id="run-view-timeline" style="padding:16px 18px">'
-      +renderRunTriggerPanels(run)
-      +'<div style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.5px;color:var(--text-dim);margin-bottom:10px">Step Timeline ('+steps.length+' step'+(steps.length!==1?'s':'')+')</div>'
-      +(steps.length===0?'<div class="empty-msg">No steps recorded yet.</div>':renderTimeline(steps, run.id))
-      +'</div>'
-      +'<div id="run-view-dag" class="run-dag-wrap" style="display:none">'
-      +renderRunDAG(steps, await resolveFlowManifest(run))
-      +'</div>';
+      renderRunHeader(run, steps)
+      +'<div class="tab-strip" id="run-tabs">'+renderTabs(currentRunView)+'</div>'
+      +'<div id="run-tab-body">'+renderActiveTab(run, currentRunManifest, currentRunView)+'</div>';
+
     if (preserveScroll) $('runs-detail').scrollTop = detailScrollTop;
-    if (selectedStepKey) scrollToStep(selectedStepKey);
+    if (currentRunView === 'timeline' && selectedStepKey) scrollToStep(selectedStepKey);
+    if (currentRunView === 'events') openEventsDrawer(id);
+    else closeEventsDrawer();
   } catch(e) { console.error('Run detail error', e); }
 }
 
@@ -1315,11 +1683,12 @@ function renderTimeline(steps, runId) {
     const s = steps[i], last = i===steps.length-1;
     const icon = ({Succeeded:'\u2713',Failed:'\u2715',Running:'\u25cf',Skipped:'\u2298'})[s.status]||'\u25cb';
     const attemptCount = getStepAttemptCount(s);
+    const sel = selectedStepKey === s.stepKey ? ' selected' : '';
     html += '<div class="step-node" data-step-key="'+esc(s.stepKey)+'"><div class="step-connector">'
       +'<div class="step-circle '+s.status+'">'+icon+'</div>'
       +'<div class="step-line '+(s.status==='Succeeded'?'done':'')+' '+(last?'last':'')+'"></div></div>'
-      +'<div class="step-card '+s.status+'">'
-      +'<div class="step-card-header"><div><div class="step-key">'+esc(s.stepKey)+'</div><div class="step-type">'+esc(s.stepType)+'</div></div>'
+      +'<div class="step-card '+s.status+sel+'">'
+      +'<div class="step-card-header"><div><div class="step-key">'+esc(s.stepKey)+'</div>'+(s.status!=='Skipped'?'<div class="step-type">'+esc(s.stepType)+'</div>':'')+'</div>'
       +'<div style="display:flex;align-items:center;gap:6px"><span class="step-badge '+s.status+'">'+stepStatusLabel(s.status)+'</span>'
       +(attemptCount>1?'<span class="step-badge Pending">x'+attemptCount+' attempts</span>':'')
       +(s.status==='Failed'?'<button class="btn-retry" onclick="retryStep(\''+runId+'\',\''+esc(s.stepKey)+'\')">&#8635; Retry</button>':'')
@@ -1444,7 +1813,7 @@ async function refresh() {
     if (currentPage === 'flows') await loadFlows();
     if (currentPage === 'runs') {
       if (runsView === 'detail' && selectedRunId) {
-        await selectRun(selectedRunId, true, selectedStepKey);
+        await selectRun(selectedRunId, true, selectedStepKey, currentRunView);
       } else if (!isRunsAutoRefreshBlocked()) {
         await loadRuns(true);
       }
@@ -1455,21 +1824,37 @@ async function refresh() {
 
 function parseHash() {
   const hash = location.hash || '';
-  if (!hash || hash === '#' || hash === '#/') return { page: 'overview', runId: null, stepKey: null };
-  const path = hash.startsWith('#/') ? hash.slice(2) : hash.slice(1);
+  if (!hash || hash === '#' || hash === '#/') return { page: 'overview', runId: null, stepKey: null, view: null };
+  const raw = hash.startsWith('#/') ? hash.slice(2) : hash.slice(1);
+  const qIdx = raw.indexOf('?');
+  const path = qIdx >= 0 ? raw.slice(0, qIdx) : raw;
+  const query = qIdx >= 0 ? raw.slice(qIdx + 1) : '';
+  let view = null;
+  if (query) {
+    const params = new URLSearchParams(query);
+    const v = params.get('view');
+    if (['timeline','dag','gantt','events'].includes(v)) view = v;
+  }
   const parts = path.split('/');
   const page = ['overview','flows','runs','scheduled'].includes(parts[0]) ? parts[0] : 'overview';
-  if (page !== 'runs') return { page, runId: null, stepKey: null };
+  if (page !== 'runs') return { page, runId: null, stepKey: null, view: null };
   const runId = parts[1] || null;
   const stepKey = (parts[2] === 'steps' && parts[3]) ? decodeURIComponent(parts[3]) : null;
-  return { page, runId, stepKey };
+  return { page, runId, stepKey, view };
+}
+
+function setRunRoute(runId, stepKey, view) {
+  let hash = '#/runs/' + runId;
+  if (stepKey) hash += '/steps/' + encodeURIComponent(stepKey);
+  if (view && view !== 'timeline') hash += '?view=' + view;
+  if (location.hash !== hash) history.replaceState(null, '', hash);
 }
 
 async function applyRoute(route) {
   _navigate(route.page);
   if (route.page === 'runs') {
     if (route.runId) {
-      await selectRun(route.runId, false, route.stepKey);
+      await selectRun(route.runId, false, route.stepKey, route.view);
     } else {
       showRunsListView();
       await loadRuns(false);

--- a/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
@@ -466,6 +466,42 @@ public static class DashboardServiceCollectionExtensions
             await WriteJsonAsync(http.Response,new { success = true, message = $"Step '{stepKey}' retry enqueued." });
         });
 
+        group.MapPost("/api/runs/{runId:guid}/rerun", async (HttpContext http, IFlowRunStore runStore, IFlowRepository repo, IHangfireFlowTrigger flowTrigger, Guid runId) =>
+        {
+            var run = await runStore.GetRunDetailAsync(runId);
+            if (run is null)
+            {
+                http.Response.StatusCode = StatusCodes.Status404NotFound;
+                await WriteJsonAsync(http.Response, new { error = "Run not found." });
+                return;
+            }
+
+            var flow = (await repo.GetAllFlowsAsync()).FirstOrDefault(f => f.Id == run.FlowId);
+            if (flow is null)
+            {
+                http.Response.StatusCode = StatusCodes.Status404NotFound;
+                await WriteJsonAsync(http.Response, new { error = "Flow for this run is no longer registered." });
+                return;
+            }
+
+            object? data = null;
+            if (!string.IsNullOrWhiteSpace(run.TriggerDataJson))
+            {
+                try { data = JsonDocument.Parse(run.TriggerDataJson).RootElement.Clone(); }
+                catch { data = null; }
+            }
+
+            var triggerKey = string.IsNullOrWhiteSpace(run.TriggerKey) ? "manual" : run.TriggerKey!;
+            var ctx = new TriggerContext
+            {
+                RunId = Guid.NewGuid(),
+                Flow = flow,
+                Trigger = new Trigger(triggerKey, triggerKey, data, run.TriggerHeaders)
+            };
+            await flowTrigger.TriggerAsync(ctx);
+            await WriteJsonAsync(http.Response, new { runId = ctx.RunId, sourceRunId = runId, message = $"Run '{runId}' re-triggered as '{ctx.RunId}'." });
+        });
+
         // ── Schedule management endpoints ──
 
         group.MapGet("/api/schedules", async (HttpContext http, IFlowStore store, IFlowScheduleStateStore scheduleStateStore) =>

--- a/src/FlowOrchestrator.Hangfire/HangfireFlowOrchestrator.cs
+++ b/src/FlowOrchestrator.Hangfire/HangfireFlowOrchestrator.cs
@@ -519,26 +519,34 @@ public sealed class HangfireFlowOrchestrator : IHangfireFlowTrigger, IHangfireSt
         {
             // Determine run-level status.
             //
-            // Key question: did any step actually Succeed?
+            // No Succeeded + has Failed (even alongside Skipped) → Failed
+            //   A step crashed; downstream steps being Blocked does not mask the failure.
             //
-            // No Succeeded + has Skipped → Skipped
-            //   Skip propagation dead-ended the whole workflow — nothing useful ran.
+            // No Succeeded + no Failed + has Skipped → Skipped
+            //   Safety net — entry steps always run, so this path is unreachable in practice.
             //
-            // No Succeeded + no Skipped → Failed
-            //   Pure crash with no conditional paths involved.
+            // No Succeeded + no Failed + no Skipped → Failed  (degenerate — all Pending)
             //
-            // Has Succeeded → check whether any failure was left unhandled:
-            //   Unhandled = a Failed step with no downstream that Succeeded.
-            //   Handled   = a Failed step followed by a fallback that Succeeded.
-            //   → Failed if unhandled failure exists, Succeeded otherwise.
+            // Has Succeeded + unhandled failure → Failed
+            //   A step crashed with no fallback that Succeeded downstream.
+            //
+            // Has Succeeded + no unhandled failure + ALL leaf steps Skipped → Skipped
+            //   The happy path completed but the only terminal step(s) were error-handlers
+            //   that were never needed (e.g. A→B→C→D where D only fires on C's failure).
+            //   The run intentionally "ended with a skip".
+            //
+            // Has Succeeded + no unhandled failure + at least one leaf Succeeded → Succeeded
             var anySucceeded = statuses.Values.Any(x => x == StepStatus.Succeeded);
 
             if (!anySucceeded)
             {
+                var anyFailed  = statuses.Values.Any(x => x == StepStatus.Failed);
                 var anySkipped = statuses.Values.Any(x => x == StepStatus.Skipped);
-                termination = anySkipped
-                    ? StepStatus.Skipped.ToString()
-                    : StepStatus.Failed.ToString();
+                termination = anyFailed
+                    ? StepStatus.Failed.ToString()
+                    : anySkipped
+                        ? StepStatus.Skipped.ToString()
+                        : StepStatus.Failed.ToString();
             }
             else
             {
@@ -546,9 +554,26 @@ public sealed class HangfireFlowOrchestrator : IHangfireFlowTrigger, IHangfireSt
                     kvp.Value == StepStatus.Failed &&
                     !IsFailureHandled(kvp.Key, flow.Manifest.Steps, statuses));
 
-                termination = hasUnhandledFailure
-                    ? StepStatus.Failed.ToString()
-                    : StepStatus.Succeeded.ToString();
+                if (hasUnhandledFailure)
+                {
+                    termination = StepStatus.Failed.ToString();
+                }
+                else
+                {
+                    // A leaf step is one that no other step lists as a runAfter dependency.
+                    var leafKeys = statuses.Keys
+                        .Where(k => !flow.Manifest.Steps.Any(kvp =>
+                            kvp.Value.RunAfter?.ContainsKey(k) == true))
+                        .ToHashSet(StringComparer.Ordinal);
+
+                    var allLeavesSkipped = leafKeys.Count > 0 &&
+                        leafKeys.All(k =>
+                            statuses.TryGetValue(k, out var s) && s == StepStatus.Skipped);
+
+                    termination = allLeavesSkipped
+                        ? StepStatus.Skipped.ToString()
+                        : StepStatus.Succeeded.ToString();
+                }
             }
         }
 

--- a/tests/FlowOrchestrator.Dashboard.Tests/RunEndpointTests.cs
+++ b/tests/FlowOrchestrator.Dashboard.Tests/RunEndpointTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Storage;
 
 namespace FlowOrchestrator.Dashboard.Tests;
@@ -193,6 +195,57 @@ public sealed class RunEndpointTests : IDisposable
         var response = await _client.PostAsync($"/flows/api/runs/{runId}/steps/step1/retry", null);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task POST_rerun_returns_404_when_run_missing()
+    {
+        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
+
+        var response = await _client.PostAsync($"/flows/api/runs/{Guid.NewGuid()}/rerun", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task POST_rerun_returns_404_when_flow_missing_from_repository()
+    {
+        var runId = Guid.NewGuid();
+        var flowId = Guid.NewGuid();
+        _server.FlowRunStore.GetRunDetailAsync(runId)
+            .Returns(new FlowRunRecord { Id = runId, FlowId = flowId, Status = "Failed", TriggerKey = "manual" });
+        _server.FlowRepository.GetAllFlowsAsync().Returns(Array.Empty<IFlowDefinition>());
+
+        var response = await _client.PostAsync($"/flows/api/runs/{runId}/rerun", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task POST_rerun_returns_200_and_triggers_new_run()
+    {
+        var runId = Guid.NewGuid();
+        var flowId = Guid.NewGuid();
+        var flow = Substitute.For<IFlowDefinition>();
+        flow.Id.Returns(flowId);
+        _server.FlowRepository.GetAllFlowsAsync().Returns(new[] { flow });
+        _server.FlowRunStore.GetRunDetailAsync(runId).Returns(new FlowRunRecord
+        {
+            Id = runId,
+            FlowId = flowId,
+            Status = "Failed",
+            TriggerKey = "webhook",
+            TriggerDataJson = "{\"orderId\":42}"
+        });
+
+        var response = await _client.PostAsync($"/flows/api/runs/{runId}/rerun", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("runId");
+        body.Should().Contain("sourceRunId");
+        await _server.FlowTrigger.Received(1).TriggerAsync(Arg.Is<ITriggerContext>(ctx =>
+            ctx.Flow.Id == flowId && ctx.Trigger.Key == "webhook"));
     }
 
     [Fact]

--- a/tests/FlowOrchestrator.Hangfire.Tests/HangfireFlowOrchestratorTests.cs
+++ b/tests/FlowOrchestrator.Hangfire.Tests/HangfireFlowOrchestratorTests.cs
@@ -270,4 +270,180 @@ public class HangfireFlowOrchestratorTests
 
         await _runStore.Received(1).CompleteRunAsync(ctx.RunId, "Cancelled");
     }
+
+    [Fact]
+    public async Task RunStepAsync_RunStatusIsFailed_WhenFailedStepHasBlockedDownstream()
+    {
+        // Arrange: two-step flow where step1 fails and step2 is already Skipped (Blocked).
+        // The run-level status must be "Failed", not "Skipped" — a real step crash should not
+        // be masked by downstream skip propagation.
+        var runtimeStore = Substitute.For<IFlowRunRuntimeStore>();
+        var sut = CreateSut(runtimeStore: runtimeStore);
+
+        var flow = Substitute.For<IFlowDefinition>();
+        flow.Id.Returns(Guid.NewGuid());
+        flow.Manifest.Returns(new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                ["step1"] = new StepMetadata { Type = "SimulatedFailure" },
+                ["step2"] = new StepMetadata
+                {
+                    Type = "LogMessage",
+                    // step2 only runs after step1 Succeeded — so it becomes Blocked when step1 fails
+                    RunAfter = new RunAfterCollection { ["step1"] = [StepStatus.Succeeded] }
+                }
+            }
+        });
+
+        var runId = Guid.NewGuid();
+        var ctx = new Core.Execution.ExecutionContext { RunId = runId };
+        var step = new StepInstance("step1", "SimulatedFailure") { RunId = runId };
+
+        var failedResult = new StepResult { Key = "step1", Status = StepStatus.Failed, FailedReason = "Input validation failed." };
+        _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(failedResult);
+
+        // Both calls to GetStepStatusesAsync return the post-execution state:
+        // step1 = Failed, step2 = Skipped (already recorded by a prior worker call).
+        IReadOnlyDictionary<string, StepStatus> statuses = new Dictionary<string, StepStatus>
+        {
+            ["step1"] = StepStatus.Failed,
+            ["step2"] = StepStatus.Skipped
+        };
+        runtimeStore.GetStepStatusesAsync(runId).Returns(statuses);
+        // No step is still in-flight and no step is claimed but unrecorded.
+        runtimeStore.GetClaimedStepKeysAsync(runId).Returns((IReadOnlyCollection<string>)Array.Empty<string>());
+        // TryClaimStepAsync — step2 is already recorded Skipped so graph evaluation won't put it in BlockedStepKeys;
+        // but if the planner does try to claim it, return false (already done).
+        runtimeStore.TryClaimStepAsync(runId, Arg.Any<string>()).Returns(false);
+        runtimeStore.GetRunStatusAsync(runId).Returns((string?)null);
+
+        // Act
+        await sut.RunStepAsync(ctx, flow, step);
+
+        // Assert: run must complete as Failed, not Skipped
+        await _runStore.Received(1).CompleteRunAsync(runId, "Failed");
+    }
+
+    [Fact]
+    public async Task RunStepAsync_RunStatusIsSkipped_WhenAllLeafStepsAreSkipped()
+    {
+        // Arrange: linear chain A→B→C→D where D only fires on C's failure.
+        // C succeeds → D is Skipped. D is the only leaf (no step depends on it).
+        // ALL leaf steps are Skipped → run-level status must be "Skipped", not "Succeeded".
+        var runtimeStore = Substitute.For<IFlowRunRuntimeStore>();
+        var sut = CreateSut(runtimeStore: runtimeStore);
+
+        var flow = Substitute.For<IFlowDefinition>();
+        flow.Id.Returns(Guid.NewGuid());
+        flow.Manifest.Returns(new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                ["step_a"] = new StepMetadata { Type = "LogMessage" },
+                ["step_b"] = new StepMetadata
+                {
+                    Type = "LogMessage",
+                    RunAfter = new RunAfterCollection { ["step_a"] = [StepStatus.Succeeded] }
+                },
+                ["step_c"] = new StepMetadata
+                {
+                    Type = "LogMessage",
+                    RunAfter = new RunAfterCollection { ["step_b"] = [StepStatus.Succeeded] }
+                },
+                // step_d is the ONLY leaf — it only runs if step_c fails.
+                // Since step_c Succeeded, step_d is Skipped.
+                ["step_d"] = new StepMetadata
+                {
+                    Type = "LogMessage",
+                    RunAfter = new RunAfterCollection { ["step_c"] = [StepStatus.Failed] }
+                }
+            }
+        });
+
+        var runId = Guid.NewGuid();
+        var ctx = new Core.Execution.ExecutionContext { RunId = runId };
+        // step_c is the step completing now (the last Succeeded step before the leaf check)
+        var step = new StepInstance("step_c", "LogMessage") { RunId = runId };
+
+        var succeededResult = new StepResult { Key = "step_c", Status = StepStatus.Succeeded };
+        _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(succeededResult);
+        _flowExecutor.GetNextStep(ctx, flow, step, succeededResult).Returns((IStepInstance?)null);
+
+        // Post-execution statuses: A, B, C all Succeeded; D already Skipped (blocked).
+        IReadOnlyDictionary<string, StepStatus> statuses = new Dictionary<string, StepStatus>
+        {
+            ["step_a"] = StepStatus.Succeeded,
+            ["step_b"] = StepStatus.Succeeded,
+            ["step_c"] = StepStatus.Succeeded,
+            ["step_d"] = StepStatus.Skipped
+        };
+        runtimeStore.GetStepStatusesAsync(runId).Returns(statuses);
+        runtimeStore.GetClaimedStepKeysAsync(runId).Returns((IReadOnlyCollection<string>)Array.Empty<string>());
+        runtimeStore.TryClaimStepAsync(runId, Arg.Any<string>()).Returns(false);
+        runtimeStore.GetRunStatusAsync(runId).Returns((string?)null);
+
+        // Act
+        await sut.RunStepAsync(ctx, flow, step);
+
+        // Assert: all leaves Skipped → run = Skipped, not Succeeded
+        await _runStore.Received(1).CompleteRunAsync(runId, "Skipped");
+    }
+
+    [Fact]
+    public async Task RunStepAsync_RunStatusIsSucceeded_WhenSomeLeafSucceededAndSomeSkipped()
+    {
+        // Arrange: flow with two leaves — one Succeeded, one Skipped.
+        // Rule: only ALL-leaves-skipped triggers run-level Skipped.
+        // Mixed leaves → run = Succeeded.
+        var runtimeStore = Substitute.For<IFlowRunRuntimeStore>();
+        var sut = CreateSut(runtimeStore: runtimeStore);
+
+        var flow = Substitute.For<IFlowDefinition>();
+        flow.Id.Returns(Guid.NewGuid());
+        flow.Manifest.Returns(new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                ["start"] = new StepMetadata { Type = "LogMessage" },
+                // leaf 1 — runs on success (Succeeded)
+                ["happy_path"] = new StepMetadata
+                {
+                    Type = "LogMessage",
+                    RunAfter = new RunAfterCollection { ["start"] = [StepStatus.Succeeded] }
+                },
+                // leaf 2 — only runs on failure (Skipped because start Succeeded)
+                ["error_handler"] = new StepMetadata
+                {
+                    Type = "LogMessage",
+                    RunAfter = new RunAfterCollection { ["start"] = [StepStatus.Failed] }
+                }
+            }
+        });
+
+        var runId = Guid.NewGuid();
+        var ctx = new Core.Execution.ExecutionContext { RunId = runId };
+        var step = new StepInstance("happy_path", "LogMessage") { RunId = runId };
+
+        var succeededResult = new StepResult { Key = "happy_path", Status = StepStatus.Succeeded };
+        _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(succeededResult);
+        _flowExecutor.GetNextStep(ctx, flow, step, succeededResult).Returns((IStepInstance?)null);
+
+        IReadOnlyDictionary<string, StepStatus> statuses = new Dictionary<string, StepStatus>
+        {
+            ["start"]         = StepStatus.Succeeded,
+            ["happy_path"]    = StepStatus.Succeeded,   // leaf — Succeeded
+            ["error_handler"] = StepStatus.Skipped      // leaf — Skipped
+        };
+        runtimeStore.GetStepStatusesAsync(runId).Returns(statuses);
+        runtimeStore.GetClaimedStepKeysAsync(runId).Returns((IReadOnlyCollection<string>)Array.Empty<string>());
+        runtimeStore.TryClaimStepAsync(runId, Arg.Any<string>()).Returns(false);
+        runtimeStore.GetRunStatusAsync(runId).Returns((string?)null);
+
+        // Act
+        await sut.RunStepAsync(ctx, flow, step);
+
+        // Assert: mixed leaves (one Succeeded, one Skipped) → run = Succeeded
+        await _runStore.Received(1).CompleteRunAsync(runId, "Succeeded");
+    }
 }


### PR DESCRIPTION
## Summary

Full redesign of the run-detail view plus two correctness fixes to run-level status determination.

### Dashboard — new features

- **4-tab run-detail**: Timeline · DAG · Gantt · Events — URL-synced (`?view=timeline|dag|gantt|events`)
- **Gantt tab** — SVG bars on a relative time axis, Blocked placeholders, parallel steps overlap visually, click-to-select with inspector strip
- **Events tab** — fetches `/api/runs/{id}/events`, slide-in drawer; empty-state when `IFlowEventReader` not configured
- **Run header upgrade** — progress bar, live dot (Running only), Cancel / Retry failed / Re-run all action buttons
- **`POST /api/runs/{id}/rerun`** — new endpoint that replays the original `triggerKey` + `triggerDataJson`
- **DAG nodes** — upgraded to 220×72 with stepKey, stepType, duration, status glyph, selection ring (terracotta), Blocked dashed border, `<title>` tooltip
- **Trigger Data / Trigger Headers** panels now only visible on the Timeline tab (not DAG/Gantt)

### Dashboard — bug fixes

- **Bug #1** — DAG always showed "No DAG available": `resolveFlowManifest()` was reading `flow.manifest` (undefined); fixed to parse `flow.manifestJson` via the existing `parseManifest()` helper
- **Bug #2** — Blocked step cards still rendered `.step-type` label; now omitted when `status === 'Skipped'`

### Orchestration — run-level status fixes

- **Fix**: crash + blocked downstream was reported as `Skipped` instead of `Failed`
  — `Failed` now always takes priority over downstream `Skipped` steps
- **Fix**: happy-path run where the only leaf step is a Skipped error-handler was reported as `Succeeded`
  — new rule: if **all** leaf steps (steps nothing depends on) are `Skipped`, run = `Skipped`

### Samples

- `DeadEndSkipDemoFlow` — updated comments to reflect corrected run status (`Failed`, not `Skipped`)
- **New** `FinalStepSkipDemoFlow` — linear chain `A→B→C→D` where `D` is an error-handler leaf skipped because `C` succeeded; demonstrates run-level `Skipped` status

### Tests

- 3 new dashboard endpoint tests for `POST /api/runs/{id}/rerun`
- 3 new Hangfire orchestrator tests covering all three new run-status scenarios:
  - `RunStatusIsFailed_WhenFailedStepHasBlockedDownstream`
  - `RunStatusIsSkipped_WhenAllLeafStepsAreSkipped`
  - `RunStatusIsSucceeded_WhenSomeLeafSucceededAndSomeSkipped`

### Version

`VersionPrefix` bumped `1.10.0 → 1.11.0`

## Test plan

- [ ] `dotnet build` — 0 errors, 0 warnings
- [ ] `dotnet test` — all 50 Hangfire tests + all Dashboard tests pass
- [ ] Trigger `FinalStepSkipDemoFlow` from dashboard → run status = **Skipped**, `notify_ops_on_failure` shows ⊘ Blocked
- [ ] Trigger `DeadEndSkipDemoFlow` → run status = **Failed**, all downstream Blocked
- [ ] Switch between Timeline / DAG / Gantt tabs — Trigger Data/Headers absent on DAG+Gantt
- [ ] DAG renders correctly (no "No DAG available" error)
- [ ] Click a step node in DAG → inspector strip updates, URL reflects `?view=dag&step=...`
- [ ] `POST /api/runs/{id}/rerun` returns new `runId` and re-uses original trigger payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)