### PR TITLE
docs: warm palette CSS, remove oversized logo, Google Fonts via <link>

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -20,6 +20,13 @@
       "port": 5103
     },
     {
+      "name": "SampleApp — watch InMemory (:5301)",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": ["watch", "run", "--project", "samples/FlowOrchestrator.SampleApp/FlowOrchestrator.SampleApp.csproj", "--no-hot-reload", "--", "--urls", "http://localhost:5301"],
+      "env": { "FLOW_STORAGE": "inmemory" },
+      "port": 5301
+    },
+    {
       "name": "SampleApp — standalone (http :5201)",
       "runtimeExecutable": "dotnet",
       "runtimeArgs": ["run", "--project", "samples/FlowOrchestrator.SampleApp/FlowOrchestrator.SampleApp.csproj", "--launch-profile", "http"],
@@ -30,6 +37,13 @@
       "runtimeExecutable": "dotnet",
       "runtimeArgs": ["run", "--project", "samples/FlowOrchestrator.SampleApp/FlowOrchestrator.SampleApp.csproj", "--launch-profile", "https"],
       "port": 7177
+    },
+    {
+      "name": "Docs — DocFX (:8080)",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": ["tool", "run", "docfx", "docfx.json", "--serve", "--port", "8080"],
+      "cwd": "docs",
+      "port": 8080
     }
   ]
 }

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -31,11 +31,11 @@ Full XML-documentation reference for all public types and members in FlowOrchest
 
 | Type | Description |
 |---|---|
-| [`IStepHandler<TInput>`](FlowOrchestrator.Core.Abstractions.IStepHandler-1.yml) | Main interface for custom step logic |
-| [`PollableStepHandler<TInput>`](FlowOrchestrator.Core.Abstractions.PollableStepHandler-1.yml) | Base class for steps that poll an external system |
-| [`IPollableInput`](FlowOrchestrator.Core.Abstractions.IPollableInput.yml) | Input contract for pollable steps |
-| [`IExecutionContext`](FlowOrchestrator.Core.Abstractions.IExecutionContext.yml) | Run-scoped context passed to every handler |
-| [`IExecutionContextAccessor`](FlowOrchestrator.Core.Abstractions.IExecutionContextAccessor.yml) | DI-injectable accessor for the current execution context |
+| [`IStepHandler<TInput>`](FlowOrchestrator.Core.Execution.IStepHandler-1.yml) | Main interface for custom step logic |
+| [`PollableStepHandler<TInput>`](FlowOrchestrator.Core.Execution.PollableStepHandler-1.yml) | Base class for steps that poll an external system |
+| [`IPollableInput`](FlowOrchestrator.Core.Execution.IPollableInput.yml) | Input contract for pollable steps |
+| [`IExecutionContext`](FlowOrchestrator.Core.Execution.IExecutionContext.yml) | Run-scoped context passed to every handler |
+| [`IExecutionContextAccessor`](FlowOrchestrator.Core.Execution.IExecutionContextAccessor.yml) | DI-injectable accessor for the current execution context |
 
 ### Storage Abstractions
 
@@ -49,7 +49,7 @@ Full XML-documentation reference for all public types and members in FlowOrchest
 
 | Type | Description |
 |---|---|
-| [`FlowOrchestratorBuilder`](FlowOrchestrator.Core.Configuration.FlowOrchestratorBuilder.yml) | Returned by `AddFlowOrchestrator()` — configure storage, Hangfire, and flows |
+| [`FlowOrchestratorBuilder`](FlowOrchestrator.Hangfire.FlowOrchestratorBuilder.yml) | Returned by `AddFlowOrchestrator()` — configure storage, Hangfire, and flows |
 
 ## See Also
 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -33,16 +33,15 @@
     ],
     "resource": [
       {
-        "files": ["images/**", "styles/**"]
+        "files": ["images/**", "public/**"]
       }
     ],
     "output": "_site",
-    "template": ["default", "modern"],
+    "template": ["default", "modern", "overrides"],
     "globalMetadata": {
       "_appTitle": "FlowOrchestrator",
       "_appName": "FlowOrchestrator",
       "_appFaviconPath": "images/icon.png",
-      "_appLogoPath": "images/icon.png",
       "_enableSearch": true,
       "_disableContribution": false,
       "_gitContribute": {

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,8 @@ _layout: landing
 
 Define multi-step background workflows as plain C# classes. Connect them with `runAfter` dependencies. Run them on SQL Server, PostgreSQL, or in-memory. Monitor everything from a built-in dashboard.
 
-[Get Started](articles/getting-started.md){ .btn .btn-primary .mr-1 }
-[API Reference](api/index.md){ .btn .btn-default }
+<a href="articles/getting-started.md" class="btn btn-primary mr-1">Get Started</a>
+<a href="api/index.md" class="btn btn-default">API Reference</a>
 
 ---
 

--- a/docs/overrides/layout/_master.tmpl
+++ b/docs/overrides/layout/_master.tmpl
@@ -1,0 +1,163 @@
+{{!Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license.}}
+{{!FlowOrchestrator override: adds Google Fonts <link> and pins theme to light}}
+{{!include(/^public/.*/)}}
+{{!include(favicon.ico)}}
+{{!include(logo.svg)}}
+<!DOCTYPE html>
+<html {{#_lang}}lang="{{_lang}}"{{/_lang}}>
+  <head>
+    <meta charset="utf-8">
+    {{#redirect_url}}
+      <meta http-equiv="refresh" content="0;URL='{{redirect_url}}'">
+    {{/redirect_url}}
+    {{^redirect_url}}
+      <title>{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}} {{#_appTitle}}| {{_appTitle}} {{/_appTitle}}</title>
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <meta name="title" content="{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}} {{#_appTitle}}| {{_appTitle}} {{/_appTitle}}">
+      {{#_description}}<meta name="description" content="{{_description}}">{{/_description}}
+      {{#description}}<meta name="description" content="{{description}}">{{/description}}
+      <link rel="icon" href="{{_rel}}{{{_appFaviconPath}}}{{^_appFaviconPath}}favicon.ico{{/_appFaviconPath}}">
+      <link rel="preconnect" href="https://fonts.googleapis.com">
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,400;0,500;0,600;1,400&family=JetBrains+Mono:wght@400;500&display=swap">
+      <link rel="stylesheet" href="{{_rel}}public/docfx.min.css">
+      <link rel="stylesheet" href="{{_rel}}public/main.css">
+      <meta name="docfx:navrel" content="{{_navRel}}">
+      <meta name="docfx:tocrel" content="{{_tocRel}}">
+      {{#_noindex}}<meta name="searchOption" content="noindex">{{/_noindex}}
+      {{#_enableSearch}}<meta name="docfx:rel" content="{{_rel}}">{{/_enableSearch}}
+      {{#_disableNewTab}}<meta name="docfx:disablenewtab" content="true">{{/_disableNewTab}}
+      {{#_disableTocFilter}}<meta name="docfx:disabletocfilter" content="true">{{/_disableTocFilter}}
+      {{#docurl}}<meta name="docfx:docurl" content="{{docurl}}">{{/docurl}}
+      <meta name="loc:inThisArticle" content="{{__global.inThisArticle}}">
+      <meta name="loc:searchResultsCount" content="{{__global.searchResultsCount}}">
+      <meta name="loc:searchNoResults" content="{{__global.searchNoResults}}">
+      <meta name="loc:tocFilter" content="{{__global.tocFilter}}">
+      <meta name="loc:nextArticle" content="{{__global.nextArticle}}">
+      <meta name="loc:prevArticle" content="{{__global.prevArticle}}">
+      <meta name="loc:themeLight" content="{{__global.themeLight}}">
+      <meta name="loc:themeDark" content="{{__global.themeDark}}">
+      <meta name="loc:themeAuto" content="{{__global.themeAuto}}">
+      <meta name="loc:changeTheme" content="{{__global.changeTheme}}">
+      <meta name="loc:copy" content="{{__global.copy}}">
+      <meta name="loc:downloadPdf" content="{{__global.downloadPdf}}">
+
+      <script type="module" src="./{{_rel}}public/docfx.min.js"></script>
+
+      <script>
+        const theme = localStorage.getItem('theme') || 'light'
+        document.documentElement.setAttribute('data-bs-theme', theme === 'auto' ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light') : theme)
+      </script>
+
+      {{#_googleAnalyticsTagId}}
+      <script async src="https://www.googletagmanager.com/gtag/js?id={{_googleAnalyticsTagId}}"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', '{{_googleAnalyticsTagId}}');
+      </script>
+      {{/_googleAnalyticsTagId}}
+    {{/redirect_url}}
+  </head>
+
+  {{^redirect_url}}
+  <body class="tex2jax_ignore" data-layout="{{_layout}}{{layout}}" data-yaml-mime="{{yamlmime}}">
+    <header class="bg-body border-bottom">
+      {{^_disableNavbar}}
+      <nav id="autocollapse" class="navbar navbar-expand-md" role="navigation">
+        <div class="container-xxl flex-nowrap">
+          <a class="navbar-brand" href="{{_appLogoUrl}}{{^_appLogoUrl}}{{_rel}}index.html{{/_appLogoUrl}}">
+            <img id="logo" class="svg" src="{{_rel}}{{{_appLogoPath}}}{{^_appLogoPath}}logo.svg{{/_appLogoPath}}" alt="{{_appName}}" >
+            {{_appName}}
+          </a>
+          <button class="btn btn-lg d-md-none border-0" type="button" data-bs-toggle="collapse" data-bs-target="#navpanel" aria-controls="navpanel" aria-expanded="false" aria-label="Toggle navigation">
+            <i class="bi bi-three-dots"></i>
+          </button>
+          <div class="collapse navbar-collapse" id="navpanel">
+            <div id="navbar">
+              {{#_enableSearch}}
+              <form class="search" role="search" id="search">
+                <i class="bi bi-search"></i>
+                <input class="form-control" id="search-query" type="search" disabled placeholder="{{__global.search}}" autocomplete="off" aria-label="Search">
+              </form>
+              {{/_enableSearch}}
+            </div>
+          </div>
+        </div>
+      </nav>
+      {{/_disableNavbar}}
+    </header>
+
+    <main class="container-xxl">
+      {{^_disableToc}}
+      <div class="toc-offcanvas">
+        <div class="offcanvas-md offcanvas-start" tabindex="-1" id="tocOffcanvas" aria-labelledby="tocOffcanvasLabel">
+          <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="tocOffcanvasLabel">Table of Contents</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" data-bs-target="#tocOffcanvas" aria-label="Close"></button>
+          </div>
+          <div class="offcanvas-body">
+            <nav class="toc" id="toc"></nav>
+          </div>
+        </div>
+      </div>
+      {{/_disableToc}}
+
+      <div class="content">
+        <div class="actionbar">
+          {{^_disableToc}}
+          <button class="btn btn-lg border-0 d-md-none"
+              type="button" data-bs-toggle="offcanvas" data-bs-target="#tocOffcanvas"
+              aria-controls="tocOffcanvas" aria-expanded="false" aria-label="Show table of contents">
+            <i class="bi bi-list"></i>
+          </button>
+          {{/_disableToc}}
+
+          {{^_disableBreadcrumb}}
+          <nav id="breadcrumb"></nav>
+          {{/_disableBreadcrumb}}
+        </div>
+
+        <article data-uid="{{uid}}">
+          {{!body}}
+        </article>
+
+        {{^_disableContribution}}
+        <div class="contribution d-print-none">
+          {{#sourceurl}}
+          <a href="{{sourceurl}}" class="edit-link">{{__global.improveThisDoc}}</a>
+          {{/sourceurl}}
+          {{^sourceurl}}{{#docurl}}
+          <a href="{{docurl}}" class="edit-link">{{__global.improveThisDoc}}</a>
+          {{/docurl}}{{/sourceurl}}
+        </div>
+        {{/_disableContribution}}
+
+        {{^_disableNextArticle}}
+        <div class="next-article d-print-none border-top" id="nextArticle"></div>
+        {{/_disableNextArticle}}
+
+      </div>
+
+      {{^_disableAffix}}
+      <div class="affix">
+        <nav id="affix"></nav>
+      </div>
+      {{/_disableAffix}}
+    </main>
+
+    {{#_enableSearch}}
+    <div class="container-xxl search-results" id="search-results"></div>
+    {{/_enableSearch}}
+
+    <footer class="border-top text-secondary">
+      <div class="container-xxl">
+        <div class="flex-fill">
+          {{{_appFooter}}}{{^_appFooter}}<span>Made with <a href="https://dotnet.github.io/docfx">docfx</a></span>{{/_appFooter}}
+        </div>
+      </div>
+    </footer>
+  </body>
+  {{/redirect_url}}
+</html>

--- a/docs/public/main.css
+++ b/docs/public/main.css
@@ -45,6 +45,8 @@
 }
 
 /* ── Override Bootstrap dark-mode — always render warm light palette ── */
+/* DocFX JS sets data-bs-theme="dark" when the browser prefers dark.    */
+/* We pin the warm palette so it wins regardless of system preference.  */
 [data-bs-theme="dark"] {
   --bs-body-bg:             var(--fo-parchment);
   --bs-body-color:          var(--fo-near-black);
@@ -105,21 +107,11 @@ a:hover {
   letter-spacing: -0.01em;
 }
 
-.navbar-brand img {
-  height: 28px;
-  width: auto;
-}
-
-/* Landing page hero logo — DocFX modern theme renders _appLogoPath large in the hero section.
-   Constrain it to a reasonable size while keeping the navbar logo at 28px (above). */
-.hero-logo,
-.hero-logo img,
-.hero .logo,
-.hero .logo img,
-.landing-banner img,
-.subnav-hero img {
-  max-height: 64px !important;
+.navbar-brand img,
+img#logo {
+  height: 28px !important;
   width: auto !important;
+  max-height: 28px !important;
 }
 
 .navbar-nav .nav-link {

--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -97,6 +97,18 @@ a:hover {
   width: auto;
 }
 
+/* Landing page hero logo — DocFX modern theme renders _appLogoPath large in the hero section.
+   Constrain it to a reasonable size while keeping the navbar logo at 28px (above). */
+.hero-logo,
+.hero-logo img,
+.hero .logo,
+.hero .logo img,
+.landing-banner img,
+.subnav-hero img {
+  max-height: 64px !important;
+  width: auto !important;
+}
+
 .navbar-nav .nav-link {
   color: var(--fo-olive) !important;
   font-size: 0.9375rem;

--- a/samples/FlowOrchestrator.SampleApp/Properties/launchSettings.json
+++ b/samples/FlowOrchestrator.SampleApp/Properties/launchSettings.json
@@ -33,6 +33,16 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    },
+    "inmemory": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5301",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "FLOW_STORAGE": "inmemory"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Remove docs logo** — `_appLogoPath` was rendering the 512×512 favicon as a giant hero image; removed it entirely (favicon still works for the browser tab)
- **Fix CSS loading** — `docs/public/main.css` is the correct path for DocFX modern template; `docs/styles/main.css` was being ignored at runtime
- **Remove blocking `@import`** — Google Fonts `@import` in CSS blocked CSSOM rule parsing while waiting for a network response; moved to `<link rel="stylesheet">` in a template override so it loads in parallel without blocking
- **Template override** (`docs/overrides/layout/_master.tmpl`) — adds `<link rel="preconnect">` + `<link rel="stylesheet">` for Inter & JetBrains Mono; defaults theme to `'light'` so the warm palette renders even in dark-mode browsers
- **Dark mode override** — `[data-bs-theme="dark"]` Bootstrap variables re-mapped to warm palette so the site looks correct regardless of user OS preference
- **Fix API link namespaces** — 6 broken links in `docs/api/index.md` pointed to wrong namespaces; corrected to match actual code
- **Fix landing page buttons** — converted DocFX attribute syntax `{ .btn }` to plain HTML `<a class="btn">` tags that work with the modern template
- **Add `inmemory` launch profile** to SampleApp `launchSettings.json`
- **Add DocFX local preview** to `.claude/launch.json`

## Test plan

- [ ] `dotnet build` — 0 errors, 0 warnings
- [ ] `dotnet test` — all tests pass
- [ ] Docs CI: `docs.yml` workflow passes (DocFX builds with 0 errors/warnings)
- [ ] Docs site preview: landing page shows warm parchment background, terracotta "Get Started" button, no oversized logo, Inter font loaded via Google Fonts CDN
- [ ] API Reference tab links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)