### PR TITLE
chore(tests): remove FluentAssertions, adopt plain xUnit Assert.* + A…

### DIFF
--- a/.claude/skills/add-storage/SKILL.md
+++ b/.claude/skills/add-storage/SKILL.md
@@ -108,7 +108,7 @@ Tests to write:
 - `OutputsRepository`: SaveTriggerDataAsync → GetTriggerDataAsync round-trip; SaveStepOutputAsync → GetStepOutputAsync
 - Edge cases: GetByIdAsync with unknown ID returns null; GetRunsPageAsync pagination respects skip/take
 
-Use xUnit + FluentAssertions. For backends that require external services (Redis, MongoDB), use integration test fixtures or embedded/testcontainer equivalents.
+Use xUnit (`Assert.*`) with the AAA pattern (`// Arrange` / `// Act` / `// Assert`). Do **not** add FluentAssertions or any other fluent-assertion library. For backends that require external services (Redis, MongoDB), use integration test fixtures or embedded/testcontainer equivalents.
 
 ### 5. Register the auto-migrator (if applicable)
 

--- a/.claude/skills/new-flow/SKILL.md
+++ b/.claude/skills/new-flow/SKILL.md
@@ -112,7 +112,7 @@ Test:
 - `runAfter` dependencies are wired correctly
 - For each webhook trigger: `webhookSlug` is set
 
-Use the same xUnit + FluentAssertions + NSubstitute stack as the rest of the test suite.
+Use the same **xUnit + NSubstitute** stack as the rest of the test suite. Write assertions with plain xUnit `Assert.*` and follow the AAA pattern (`// Arrange` / `// Act` / `// Assert`). Do not add FluentAssertions or any other fluent-assertion library.
 
 ### 5. Build and test
 

--- a/.claude/skills/regression-test/SKILL.md
+++ b/.claude/skills/regression-test/SKILL.md
@@ -120,10 +120,15 @@ public async Task DagFanIn_WhenTwoUpstreamsCompleteConcurrently_DownstreamEnqueu
 [Fact]
 public async Task TriggerAsync_WithSameIdempotencyKey_ReturnsSameRunId()
 {
+    // Arrange
     var key = Guid.NewGuid().ToString();
+
+    // Act
     var runId1 = await orchestrator.TriggerAsync(flowId, trigger, headers: new() { ["Idempotency-Key"] = key });
     var runId2 = await orchestrator.TriggerAsync(flowId, trigger, headers: new() { ["Idempotency-Key"] = key });
-    runId1.Should().Be(runId2);
+
+    // Assert
+    Assert.Equal(runId2, runId1);
 }
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Testing
 
-- Tests live in `./tests/`. Framework: xUnit + FluentAssertions + NSubstitute.
+- Tests live in `./tests/`. Framework: **xUnit + NSubstitute**. Use plain xUnit `Assert.*` — do **not** add FluentAssertions, Shouldly, or any fluent-assertion library.
+- **AAA pattern** is mandatory: every `[Fact]`/`[Theory]` body must contain three comment blocks, in order — `// Arrange`, `// Act`, `// Assert`. Shared fixture setup in fields/constructor is allowed and does not count as the body's Arrange (a body block may be empty if there is genuinely nothing to do).
 - After any code change: run `dotnet test` and confirm the test count and pass rate.
 - New tests go in the matching test project (e.g., changes in `FlowOrchestrator.Core` → tests in `FlowOrchestrator.Core.Tests`).
 
@@ -221,4 +222,4 @@ public string? CronOverride { get; set; }
 - **`ValueTask` throughout** — minimizes allocations on the synchronous fast path.
 - **`IExecutionContext`** — thread-scoped context (via `IExecutionContextAccessor`) carrying RunId, trigger data, and principal; resolved from DI during step execution.
 - **Expression resolution happens at step-execution time**, not at definition time, so trigger payload is available dynamically.
-- Tests use **xUnit + FluentAssertions + NSubstitute**.
+- Tests use **xUnit + NSubstitute** with plain xUnit `Assert.*` and the AAA pattern (`// Arrange` / `// Act` / `// Assert`).

--- a/tests/FlowOrchestrator.Core.Tests/Abstractions/FlowManifestTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Abstractions/FlowManifestTests.cs
@@ -1,5 +1,4 @@
 using FlowOrchestrator.Core.Abstractions;
-using FluentAssertions;
 
 namespace FlowOrchestrator.Core.Tests.Abstractions;
 
@@ -8,15 +7,22 @@ public class FlowManifestTests
     [Fact]
     public void DefaultManifest_HasEmptyTriggersAndSteps()
     {
+        // Arrange
+
+        // Act
         var manifest = new FlowManifest();
 
-        manifest.Triggers.Should().BeEmpty();
-        manifest.Steps.Should().BeEmpty();
+        // Assert
+        Assert.Empty(manifest.Triggers);
+        Assert.Empty(manifest.Steps);
     }
 
     [Fact]
     public void Manifest_CanHoldTriggersAndSteps()
     {
+        // Arrange
+
+        // Act
         var manifest = new FlowManifest
         {
             Triggers = new FlowTriggerCollection
@@ -29,26 +35,35 @@ public class FlowManifestTests
             }
         };
 
-        manifest.Triggers.Should().ContainKey("manual");
-        manifest.Steps.Should().ContainKey("step1");
+        // Assert
+        Assert.True(manifest.Triggers.ContainsKey("manual"));
+        Assert.True(manifest.Steps.ContainsKey("step1"));
     }
 
     [Fact]
     public void LoopStepMetadata_DefaultProperties()
     {
+        // Arrange
+
+        // Act
         var loop = new LoopStepMetadata();
 
-        loop.ForEach.Should().BeNull();
-        loop.ConcurrencyLimit.Should().Be(1);
-        loop.Steps.Should().BeEmpty();
+        // Assert
+        Assert.Null(loop.ForEach);
+        Assert.Equal(1, loop.ConcurrencyLimit);
+        Assert.Empty(loop.Steps);
     }
 
     [Fact]
     public void TriggerMetadata_DefaultProperties()
     {
+        // Arrange
+
+        // Act
         var trigger = new TriggerMetadata { Type = TriggerType.Manual };
 
-        trigger.Type.Should().Be(TriggerType.Manual);
-        trigger.Inputs.Should().BeEmpty();
+        // Assert
+        Assert.Equal(TriggerType.Manual, trigger.Type);
+        Assert.Empty(trigger.Inputs);
     }
 }

--- a/tests/FlowOrchestrator.Core.Tests/Abstractions/MetadataInputExtensionsTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Abstractions/MetadataInputExtensionsTests.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using FlowOrchestrator.Core.Abstractions;
-using FluentAssertions;
 
 namespace FlowOrchestrator.Core.Tests.Abstractions;
 
@@ -9,54 +8,66 @@ public class MetadataInputExtensionsTests
     [Fact]
     public void TryGetString_WithJsonElementString_ReturnsTrue()
     {
+        // Arrange
         var inputs = new Dictionary<string, object?>
         {
             ["key"] = JsonSerializer.Deserialize<JsonElement>("\"value\"")
         };
 
+        // Act
         var found = inputs.TryGetString("key", out var value);
 
-        found.Should().BeTrue();
-        value.Should().Be("value");
+        // Assert
+        Assert.True(found);
+        Assert.Equal("value", value);
     }
 
     [Fact]
     public void TryGetInt32_WithStringValue_ReturnsTrue()
     {
+        // Arrange
         var inputs = new Dictionary<string, object?> { ["retry"] = "3" };
 
+        // Act
         var found = inputs.TryGetInt32("retry", out var value);
 
-        found.Should().BeTrue();
-        value.Should().Be(3);
+        // Assert
+        Assert.True(found);
+        Assert.Equal(3, value);
     }
 
     [Fact]
     public void TryGetBoolean_WithJsonElementBool_ReturnsTrue()
     {
+        // Arrange
         var inputs = new Dictionary<string, object?>
         {
             ["enabled"] = JsonSerializer.Deserialize<JsonElement>("true")
         };
 
+        // Act
         var found = inputs.TryGetBoolean("enabled", out var value);
 
-        found.Should().BeTrue();
-        value.Should().BeTrue();
+        // Assert
+        Assert.True(found);
+        Assert.True(value);
     }
 
     [Fact]
     public void TryGetDateTimeOffset_WithRoundTripString_ReturnsTrue()
     {
+        // Arrange
         var now = DateTimeOffset.UtcNow;
         var inputs = new Dictionary<string, object?>
         {
             ["startedAt"] = now.ToString("O")
         };
 
+        // Act
         var found = inputs.TryGetDateTimeOffset("startedAt", out var parsed);
 
-        found.Should().BeTrue();
-        parsed.Should().Be(now);
+        // Assert
+        Assert.True(found);
+        Assert.Equal(now, parsed);
     }
 }

--- a/tests/FlowOrchestrator.Core.Tests/Abstractions/StepCollectionTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Abstractions/StepCollectionTests.cs
@@ -1,5 +1,4 @@
 using FlowOrchestrator.Core.Abstractions;
-using FluentAssertions;
 
 namespace FlowOrchestrator.Core.Tests.Abstractions;
 
@@ -8,23 +7,34 @@ public class StepCollectionTests
     [Fact]
     public void FindStep_DirectKey_ReturnsStep()
     {
+        // Arrange
         var step = new StepMetadata { Type = "LogMessage" };
         var collection = new StepCollection { ["step1"] = step };
 
-        collection.FindStep("step1").Should().BeSameAs(step);
+        // Act
+        var result = collection.FindStep("step1");
+
+        // Assert
+        Assert.Same(step, result);
     }
 
     [Fact]
     public void FindStep_MissingKey_ReturnsNull()
     {
+        // Arrange
         var collection = new StepCollection { ["step1"] = new StepMetadata { Type = "A" } };
 
-        collection.FindStep("missing").Should().BeNull();
+        // Act
+        var result = collection.FindStep("missing");
+
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public void FindStep_NestedKey_ReturnsChildStep()
     {
+        // Arrange
         var child = new StepMetadata { Type = "ChildType" };
         var parent = new LoopStepMetadata
         {
@@ -33,21 +43,31 @@ public class StepCollectionTests
         };
         var collection = new StepCollection { ["parent"] = parent };
 
-        collection.FindStep("parent.child").Should().BeSameAs(child);
+        // Act
+        var result = collection.FindStep("parent.child");
+
+        // Assert
+        Assert.Same(child, result);
     }
 
     [Fact]
     public void FindStep_NestedKey_ParentNotScoped_ReturnsNull()
     {
+        // Arrange
         var parent = new StepMetadata { Type = "Simple" };
         var collection = new StepCollection { ["parent"] = parent };
 
-        collection.FindStep("parent.child").Should().BeNull();
+        // Act
+        var result = collection.FindStep("parent.child");
+
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public void FindStep_DeeplyNestedKey_ReturnsCorrectStep()
     {
+        // Arrange
         var grandchild = new StepMetadata { Type = "GrandchildType" };
         var child = new LoopStepMetadata
         {
@@ -61,12 +81,17 @@ public class StepCollectionTests
         };
         var collection = new StepCollection { ["parent"] = parent };
 
-        collection.FindStep("parent.child.grandchild").Should().BeSameAs(grandchild);
+        // Act
+        var result = collection.FindStep("parent.child.grandchild");
+
+        // Assert
+        Assert.Same(grandchild, result);
     }
 
     [Fact]
     public void FindStep_RuntimeLoopKey_WithIndex_ReturnsChildStep()
     {
+        // Arrange
         var child = new StepMetadata { Type = "ChildType" };
         var parent = new LoopStepMetadata
         {
@@ -75,12 +100,17 @@ public class StepCollectionTests
         };
         var collection = new StepCollection { ["parent"] = parent };
 
-        collection.FindStep("parent.0.child").Should().BeSameAs(child);
+        // Act
+        var result = collection.FindStep("parent.0.child");
+
+        // Assert
+        Assert.Same(child, result);
     }
 
     [Fact]
     public void FindNextStep_WithRunAfter_ReturnsSuccessor()
     {
+        // Arrange
         var step1 = new StepMetadata { Type = "A" };
         var step2 = new StepMetadata
         {
@@ -93,21 +123,31 @@ public class StepCollectionTests
             ["step2"] = step2
         };
 
-        collection.FindNextStep("step1").Should().BeSameAs(step2);
+        // Act
+        var result = collection.FindNextStep("step1");
+
+        // Assert
+        Assert.Same(step2, result);
     }
 
     [Fact]
     public void FindNextStep_NoSuccessor_ReturnsNull()
     {
+        // Arrange
         var step1 = new StepMetadata { Type = "A" };
         var collection = new StepCollection { ["step1"] = step1 };
 
-        collection.FindNextStep("step1").Should().BeNull();
+        // Act
+        var result = collection.FindNextStep("step1");
+
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public void FindNextStep_EmptyRunAfter_ReturnsNull()
     {
+        // Arrange
         var step1 = new StepMetadata { Type = "A" };
         var step2 = new StepMetadata
         {
@@ -120,12 +160,17 @@ public class StepCollectionTests
             ["step2"] = step2
         };
 
-        collection.FindNextStep("step1").Should().BeNull();
+        // Act
+        var result = collection.FindNextStep("step1");
+
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public void FindParentStep_NestedKey_ReturnsParent()
     {
+        // Arrange
         var child = new StepMetadata { Type = "ChildType" };
         var parent = new LoopStepMetadata
         {
@@ -134,14 +179,23 @@ public class StepCollectionTests
         };
         var collection = new StepCollection { ["parent"] = parent };
 
-        collection.FindParentStep("parent.child").Should().BeSameAs(parent);
+        // Act
+        var result = collection.FindParentStep("parent.child");
+
+        // Assert
+        Assert.Same(parent, result);
     }
 
     [Fact]
     public void FindParentStep_TopLevelKey_ReturnsNull()
     {
+        // Arrange
         var collection = new StepCollection { ["step1"] = new StepMetadata { Type = "A" } };
 
-        collection.FindParentStep("step1").Should().BeNull();
+        // Act
+        var result = collection.FindParentStep("step1");
+
+        // Assert
+        Assert.Null(result);
     }
 }

--- a/tests/FlowOrchestrator.Core.Tests/Abstractions/StepMetadataTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Abstractions/StepMetadataTests.cs
@@ -1,5 +1,4 @@
 using FlowOrchestrator.Core.Abstractions;
-using FluentAssertions;
 
 namespace FlowOrchestrator.Core.Tests.Abstractions;
 
@@ -8,61 +7,90 @@ public class StepMetadataTests
     [Fact]
     public void ShouldExecute_EmptyRunAfter_ReturnsTrue()
     {
+        // Arrange
         var step = new StepMetadata { Type = "A", RunAfter = new RunAfterCollection() };
 
-        step.ShouldExecute("anyStep", StepStatus.Succeeded).Should().BeTrue();
+        // Act
+        var result = step.ShouldExecute("anyStep", StepStatus.Succeeded);
+
+        // Assert
+        Assert.True(result);
     }
 
     [Fact]
     public void ShouldExecute_MatchingStepAndStatus_ReturnsTrue()
     {
+        // Arrange
         var step = new StepMetadata
         {
             Type = "B",
             RunAfter = new RunAfterCollection { ["step1"] = new[] { StepStatus.Succeeded, StepStatus.Failed } }
         };
 
-        step.ShouldExecute("step1", StepStatus.Succeeded).Should().BeTrue();
-        step.ShouldExecute("step1", StepStatus.Failed).Should().BeTrue();
+        // Act
+        var succeeded = step.ShouldExecute("step1", StepStatus.Succeeded);
+        var failed = step.ShouldExecute("step1", StepStatus.Failed);
+
+        // Assert
+        Assert.True(succeeded);
+        Assert.True(failed);
     }
 
     [Fact]
     public void ShouldExecute_StatusNotInAllowedList_ReturnsFalse()
     {
+        // Arrange
         var step = new StepMetadata
         {
             Type = "B",
             RunAfter = new RunAfterCollection { ["step1"] = new[] { StepStatus.Succeeded } }
         };
 
-        step.ShouldExecute("step1", StepStatus.Failed).Should().BeFalse();
+        // Act
+        var result = step.ShouldExecute("step1", StepStatus.Failed);
+
+        // Assert
+        Assert.False(result);
     }
 
     [Fact]
     public void ShouldExecute_DifferentPrecedingStep_ReturnsFalse()
     {
+        // Arrange
         var step = new StepMetadata
         {
             Type = "B",
             RunAfter = new RunAfterCollection { ["step1"] = new[] { StepStatus.Succeeded } }
         };
 
-        step.ShouldExecute("step2", StepStatus.Succeeded).Should().BeFalse();
+        // Act
+        var result = step.ShouldExecute("step2", StepStatus.Succeeded);
+
+        // Assert
+        Assert.False(result);
     }
 
     [Fact]
     public void DefaultInputs_IsEmptyDictionary()
     {
+        // Arrange
+
+        // Act
         var step = new StepMetadata { Type = "A" };
 
-        step.Inputs.Should().BeEmpty();
+        // Assert
+        Assert.Empty(step.Inputs);
     }
 
     [Fact]
     public void DefaultRunAfter_IsEmptyCollection()
     {
+        // Arrange
+
+        // Act
         var step = new StepMetadata { Type = "A" };
 
-        step.RunAfter.Should().BeEmpty();
+        // Assert
+        Assert.Empty(step.RunAfter);
     }
 }

--- a/tests/FlowOrchestrator.Core.Tests/Abstractions/TriggerMetadataTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Abstractions/TriggerMetadataTests.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using FlowOrchestrator.Core.Abstractions;
-using FluentAssertions;
 
 namespace FlowOrchestrator.Core.Tests.Abstractions;
 
@@ -9,21 +8,25 @@ public class TriggerMetadataTests
     [Fact]
     public void TryGetCronExpression_WithValidCronString_ReturnsTrue()
     {
+        // Arrange
         var trigger = new TriggerMetadata
         {
             Type = TriggerType.Cron,
             Inputs = new Dictionary<string, object?> { ["cronExpression"] = "*/10 * * * *" }
         };
 
+        // Act
         var found = trigger.TryGetCronExpression(out var cronExpression);
 
-        found.Should().BeTrue();
-        cronExpression.Should().Be("*/10 * * * *");
+        // Assert
+        Assert.True(found);
+        Assert.Equal("*/10 * * * *", cronExpression);
     }
 
     [Fact]
     public void TryGetCronExpression_WithJsonElementString_ReturnsTrue()
     {
+        // Arrange
         var trigger = new TriggerMetadata
         {
             Type = TriggerType.Cron,
@@ -33,36 +36,44 @@ public class TriggerMetadataTests
             }
         };
 
+        // Act
         var found = trigger.TryGetCronExpression(out var cronExpression);
 
-        found.Should().BeTrue();
-        cronExpression.Should().Be("*/5 * * * *");
+        // Assert
+        Assert.True(found);
+        Assert.Equal("*/5 * * * *", cronExpression);
     }
 
     [Fact]
     public void TryGetCronExpression_WithMissingInput_ReturnsFalse()
     {
+        // Arrange
         var trigger = new TriggerMetadata
         {
             Type = TriggerType.Cron
         };
 
+        // Act
         var found = trigger.TryGetCronExpression(out _);
 
-        found.Should().BeFalse();
+        // Assert
+        Assert.False(found);
     }
 
     [Fact]
     public void TryGetCronExpression_ForNonCronTrigger_ReturnsFalse()
     {
+        // Arrange
         var trigger = new TriggerMetadata
         {
             Type = TriggerType.Manual,
             Inputs = new Dictionary<string, object?> { ["cronExpression"] = "*/10 * * * *" }
         };
 
+        // Act
         var found = trigger.TryGetCronExpression(out _);
 
-        found.Should().BeFalse();
+        // Assert
+        Assert.False(found);
     }
 }

--- a/tests/FlowOrchestrator.Core.Tests/Execution/ExecutionContextTypedExtensionsTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Execution/ExecutionContextTypedExtensionsTests.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using FlowOrchestrator.Core.Execution;
-using FluentAssertions;
 
 namespace FlowOrchestrator.Core.Tests.Execution;
 
@@ -9,36 +8,45 @@ public class ExecutionContextTypedExtensionsTests
     [Fact]
     public void GetTriggerDataAs_WithJsonElement_ReturnsTypedObject()
     {
+        // Arrange
         var data = JsonSerializer.Deserialize<JsonElement>("{\"jobId\":\"JOB-1\",\"attempt\":3}");
         var context = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid(), TriggerData = data };
 
+        // Act
         var value = context.GetTriggerDataAs<TriggerPayload>();
 
-        value.Should().NotBeNull();
-        value!.JobId.Should().Be("JOB-1");
-        value.Attempt.Should().Be(3);
+        // Assert
+        Assert.NotNull(value);
+        Assert.Equal("JOB-1", value!.JobId);
+        Assert.Equal(3, value.Attempt);
     }
 
     [Fact]
     public void GetTriggerDataAs_WithNullTriggerData_ReturnsDefault()
     {
+        // Arrange
         var context = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid(), TriggerData = null };
 
+        // Act
         var value = context.GetTriggerDataAs<TriggerPayload>();
 
-        value.Should().BeNull();
+        // Assert
+        Assert.Null(value);
     }
 
     [Fact]
     public void TryGetTriggerDataAs_WithInvalidShape_ReturnsFalse()
     {
+        // Arrange
         var data = JsonSerializer.Deserialize<JsonElement>("{\"attempt\":\"x\"}");
         var context = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid(), TriggerData = data };
 
+        // Act
         var success = context.TryGetTriggerDataAs<TriggerPayload>(out var value);
 
-        success.Should().BeFalse();
-        value.Should().BeNull();
+        // Assert
+        Assert.False(success);
+        Assert.Null(value);
     }
 
     private sealed class TriggerPayload

--- a/tests/FlowOrchestrator.Core.Tests/Execution/FlowExecutorTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Execution/FlowExecutorTests.cs
@@ -1,7 +1,6 @@
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Storage;
-using FluentAssertions;
 using NSubstitute;
 
 namespace FlowOrchestrator.Core.Tests.Execution;
@@ -38,6 +37,7 @@ public class FlowExecutorTests
     [Fact]
     public async Task TriggerFlow_FindsEntryStep_WithNoRunAfter()
     {
+        // Arrange
         var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             ["X-Correlation-Id"] = "corr-1"
@@ -54,15 +54,17 @@ public class FlowExecutorTests
         var flow = CreateFlow(steps);
         var ctx = CreateTriggerContext(flow, headers);
 
+        // Act
         var result = await _sut.TriggerFlow(ctx);
 
-        result.Key.Should().Be("step1");
-        result.Type.Should().Be("LogMessage");
-        result.RunId.Should().Be(ctx.RunId);
-        ctx.TriggerData.Should().BeSameAs(ctx.Trigger.Data);
-        ctx.TriggerHeaders.Should().BeSameAs(headers);
-        result.TriggerData.Should().BeSameAs(ctx.TriggerData);
-        result.TriggerHeaders.Should().BeSameAs(headers);
+        // Assert
+        Assert.Equal("step1", result.Key);
+        Assert.Equal("LogMessage", result.Type);
+        Assert.Equal(ctx.RunId, result.RunId);
+        Assert.Same(ctx.Trigger.Data, ctx.TriggerData);
+        Assert.Same(headers, ctx.TriggerHeaders);
+        Assert.Same(ctx.TriggerData, result.TriggerData);
+        Assert.Same(headers, result.TriggerHeaders);
         await _outputsRepo.Received(1).SaveTriggerDataAsync(ctx, flow, ctx.Trigger);
         await _outputsRepo.Received(1).SaveTriggerHeadersAsync(ctx, flow, ctx.Trigger);
     }
@@ -70,6 +72,7 @@ public class FlowExecutorTests
     [Fact]
     public async Task TriggerFlow_ThrowsWhenNoEntryStep()
     {
+        // Arrange
         var steps = new StepCollection
         {
             ["step1"] = new StepMetadata
@@ -81,15 +84,18 @@ public class FlowExecutorTests
         var flow = CreateFlow(steps);
         var ctx = CreateTriggerContext(flow);
 
+        // Act
         var act = () => _sut.TriggerFlow(ctx).AsTask();
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*entry step*");
+        // Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(act);
+        Assert.Contains("entry step", ex.Message);
     }
 
     [Fact]
     public async Task GetNextStep_ReturnsNextStepWhenRunAfterMatches()
     {
+        // Arrange
         var steps = new StepCollection
         {
             ["step1"] = new StepMetadata { Type = "A" },
@@ -110,19 +116,22 @@ public class FlowExecutorTests
         var currentStep = new StepInstance("step1", "A") { RunId = ctx.RunId };
         var result = new StepResult { Key = "step1", Status = StepStatus.Succeeded };
 
+        // Act
         var next = await _sut.GetNextStep(ctx, flow, currentStep, result);
 
-        next.Should().NotBeNull();
-        next!.Key.Should().Be("step2");
-        next.Type.Should().Be("B");
-        next.RunId.Should().Be(ctx.RunId);
-        next.TriggerData.Should().BeSameAs(triggerData);
-        next.TriggerHeaders.Should().BeSameAs(triggerHeaders);
+        // Assert
+        Assert.NotNull(next);
+        Assert.Equal("step2", next!.Key);
+        Assert.Equal("B", next.Type);
+        Assert.Equal(ctx.RunId, next.RunId);
+        Assert.Same(triggerData, next.TriggerData);
+        Assert.Same(triggerHeaders, next.TriggerHeaders);
     }
 
     [Fact]
     public async Task GetNextStep_ReturnsNullWhenNoSuccessor()
     {
+        // Arrange
         var steps = new StepCollection
         {
             ["step1"] = new StepMetadata { Type = "A" }
@@ -132,14 +141,17 @@ public class FlowExecutorTests
         var currentStep = new StepInstance("step1", "A") { RunId = ctx.RunId };
         var result = new StepResult { Key = "step1", Status = StepStatus.Succeeded };
 
+        // Act
         var next = await _sut.GetNextStep(ctx, flow, currentStep, result);
 
-        next.Should().BeNull();
+        // Assert
+        Assert.Null(next);
     }
 
     [Fact]
     public async Task GetNextStep_ReturnsNullWhenStatusNotAllowed()
     {
+        // Arrange
         var steps = new StepCollection
         {
             ["step1"] = new StepMetadata { Type = "A" },
@@ -154,14 +166,17 @@ public class FlowExecutorTests
         var currentStep = new StepInstance("step1", "A") { RunId = ctx.RunId };
         var result = new StepResult { Key = "step1", Status = StepStatus.Failed };
 
+        // Act
         var next = await _sut.GetNextStep(ctx, flow, currentStep, result);
 
-        next.Should().BeNull();
+        // Assert
+        Assert.Null(next);
     }
 
     [Fact]
     public async Task TriggerFlow_CopiesInputsToStepInstance()
     {
+        // Arrange
         var steps = new StepCollection
         {
             ["step1"] = new StepMetadata
@@ -173,8 +188,10 @@ public class FlowExecutorTests
         var flow = CreateFlow(steps);
         var ctx = CreateTriggerContext(flow);
 
+        // Act
         var instance = await _sut.TriggerFlow(ctx);
 
-        instance.Inputs.Should().ContainKey("sql");
+        // Assert
+        Assert.True(instance.Inputs.ContainsKey("sql"));
     }
 }

--- a/tests/FlowOrchestrator.Core.Tests/Execution/FlowGraphPlannerTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Execution/FlowGraphPlannerTests.cs
@@ -1,6 +1,5 @@
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
-using FluentAssertions;
 using NSubstitute;
 
 namespace FlowOrchestrator.Core.Tests.Execution;
@@ -12,6 +11,7 @@ public class FlowGraphPlannerTests
     [Fact]
     public void Evaluate_FanOut_ReturnsMultipleReadySteps()
     {
+        // Arrange
         var flow = CreateFlow(new StepCollection
         {
             ["a"] = new StepMetadata { Type = "A" },
@@ -19,14 +19,18 @@ public class FlowGraphPlannerTests
             ["c"] = new StepMetadata { Type = "C", RunAfter = new RunAfterCollection { ["a"] = [StepStatus.Succeeded] } }
         });
 
+        // Act
         var evaluation = _sut.Evaluate(flow, new Dictionary<string, StepStatus> { ["a"] = StepStatus.Succeeded });
 
-        evaluation.ReadyStepKeys.Should().Contain(["b", "c"]);
+        // Assert
+        Assert.Contains("b", evaluation.ReadyStepKeys);
+        Assert.Contains("c", evaluation.ReadyStepKeys);
     }
 
     [Fact]
     public void Evaluate_FanInBlocked_ReturnsBlockedStep()
     {
+        // Arrange
         var flow = CreateFlow(new StepCollection
         {
             ["a"] = new StepMetadata { Type = "A" },
@@ -43,6 +47,7 @@ public class FlowGraphPlannerTests
             }
         });
 
+        // Act
         var evaluation = _sut.Evaluate(flow, new Dictionary<string, StepStatus>
         {
             ["a"] = StepStatus.Succeeded,
@@ -50,12 +55,14 @@ public class FlowGraphPlannerTests
             ["c"] = StepStatus.Succeeded
         });
 
-        evaluation.BlockedStepKeys.Should().Contain("d");
+        // Assert
+        Assert.Contains("d", evaluation.BlockedStepKeys);
     }
 
     [Fact]
     public void Evaluate_RuntimeScopedDependency_ResolvesRelativeDependency()
     {
+        // Arrange
         var flow = CreateFlow(new StepCollection
         {
             ["loop"] = new LoopStepMetadata
@@ -76,27 +83,32 @@ public class FlowGraphPlannerTests
             }
         });
 
+        // Act
         var evaluation = _sut.Evaluate(flow, new Dictionary<string, StepStatus>
         {
             ["loop.0.child1"] = StepStatus.Succeeded
         });
 
-        evaluation.ReadyStepKeys.Should().Contain("loop.0.child2");
+        // Assert
+        Assert.Contains("loop.0.child2", evaluation.ReadyStepKeys);
     }
 
     [Fact]
     public void Validate_DetectsCycle()
     {
+        // Arrange
         var flow = CreateFlow(new StepCollection
         {
             ["a"] = new StepMetadata { Type = "A", RunAfter = new RunAfterCollection { ["b"] = [StepStatus.Succeeded] } },
             ["b"] = new StepMetadata { Type = "B", RunAfter = new RunAfterCollection { ["a"] = [StepStatus.Succeeded] } }
         });
 
+        // Act
         var result = _sut.Validate(flow);
 
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.Contains("cycle", StringComparison.OrdinalIgnoreCase));
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("cycle", StringComparison.OrdinalIgnoreCase));
     }
 
     private static IFlowDefinition CreateFlow(StepCollection steps)

--- a/tests/FlowOrchestrator.Core.Tests/Execution/FlowGraphPlannerValidationTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Execution/FlowGraphPlannerValidationTests.cs
@@ -1,6 +1,5 @@
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
-using FluentAssertions;
 using NSubstitute;
 
 namespace FlowOrchestrator.Core.Tests.Execution;
@@ -29,7 +28,7 @@ public sealed class FlowGraphPlannerValidationTests
     [Fact]
     public void Validate_TwoStepDirectCycle_ReportsError()
     {
-        // a depends on b; b depends on a — direct mutual dependency.
+        // Arrange
         var steps = new StepCollection
         {
             ["a"] = new StepMetadata
@@ -44,28 +43,28 @@ public sealed class FlowGraphPlannerValidationTests
             }
         };
 
+        // Act
         var result = _sut.Validate(FlowWith(steps));
 
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.Contains("cycle"),
-            "a mutual two-step dependency is a cycle and must be detected");
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("cycle"));
     }
 
     [Fact]
     public void Validate_DiamondWithBackEdge_ReportsError()
     {
-        // Valid diamond: a → b, a → c, b → d, c → d
-        // Back-edge added:   d → b, creating the cycle: b → d → b.
+        // Arrange
         var steps = new StepCollection
         {
-            ["a"] = new StepMetadata { Type = "T" },   // entry
+            ["a"] = new StepMetadata { Type = "T" },
             ["b"] = new StepMetadata
             {
                 Type = "T",
                 RunAfter = new RunAfterCollection
                 {
                     ["a"] = [StepStatus.Succeeded],
-                    ["d"] = [StepStatus.Succeeded]   // back-edge introduces cycle
+                    ["d"] = [StepStatus.Succeeded]
                 }
             },
             ["c"] = new StepMetadata
@@ -84,17 +83,18 @@ public sealed class FlowGraphPlannerValidationTests
             }
         };
 
+        // Act
         var result = _sut.Validate(FlowWith(steps));
 
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.Contains("cycle"),
-            "a back-edge in the diamond graph creates a cycle that must be detected");
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("cycle"));
     }
 
     [Fact]
     public void Validate_StepWithMissingDependency_ReportsError()
     {
-        // step2 declares a dependency on "nonexistent", which has no entry in the manifest.
+        // Arrange
         var steps = new StepCollection
         {
             ["step1"] = new StepMetadata { Type = "T" },
@@ -105,18 +105,18 @@ public sealed class FlowGraphPlannerValidationTests
             }
         };
 
+        // Act
         var result = _sut.Validate(FlowWith(steps));
 
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.Contains("nonexistent"),
-            "the name of the missing dependency must appear in the error message");
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("nonexistent"));
     }
 
     [Fact]
     public void Validate_NoEntryStep_ReportsError()
     {
-        // Every step has RunAfter — no step can be the starting point.
-        // Also implies a cycle (each step waits for the other).
+        // Arrange
         var steps = new StepCollection
         {
             ["a"] = new StepMetadata
@@ -131,18 +131,18 @@ public sealed class FlowGraphPlannerValidationTests
             }
         };
 
+        // Act
         var result = _sut.Validate(FlowWith(steps));
 
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().Contain(e => e.Contains("entry") || e.Contains("cycle"),
-            "a graph with no entry step must produce a validation error");
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("entry") || e.Contains("cycle"));
     }
 
     [Fact]
     public void Validate_ValidDiamond_IsValid()
     {
-        // Acyclic diamond: a (entry) → b, a → c, b → d, c → d.
-        // All dependencies exist, no cycles, there is exactly one entry step.
+        // Arrange
         var steps = new StepCollection
         {
             ["a"] = new StepMetadata { Type = "T" },
@@ -167,10 +167,11 @@ public sealed class FlowGraphPlannerValidationTests
             }
         };
 
+        // Act
         var result = _sut.Validate(FlowWith(steps));
 
-        result.IsValid.Should().BeTrue(
-            "a valid diamond-shaped DAG has an entry step, no cycles, and all dependencies exist");
-        result.Errors.Should().BeEmpty();
+        // Assert
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
     }
 }

--- a/tests/FlowOrchestrator.Core.Tests/Execution/FlowOrchestratorEngineInvariantTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Execution/FlowOrchestratorEngineInvariantTests.cs
@@ -3,7 +3,6 @@ using FlowOrchestrator.Core.Configuration;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Storage;
 using FlowOrchestrator.InMemory;
-using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using CoreExecutionContext = FlowOrchestrator.Core.Execution.ExecutionContext;
@@ -33,8 +32,6 @@ public sealed class FlowOrchestratorEngineInvariantTests
 
     public FlowOrchestratorEngineInvariantTests()
     {
-        // Allow dispatch to proceed in all tests by default.
-        // Individual tests override this to exercise the "already dispatched" guard.
         _runStore.TryRecordDispatchAsync(
                 Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .ReturnsForAnyArgs(Task.FromResult(true));
@@ -89,18 +86,17 @@ public sealed class FlowOrchestratorEngineInvariantTests
     [Fact]
     public async Task TriggerAsync_WhenTryRecordDispatchReturnsFalse_DispatcherIsNeverCalled()
     {
-        // Override default: the dispatch ledger reports every step as already dispatched.
+        // Arrange
         _runStore.TryRecordDispatchAsync(
                 Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .ReturnsForAnyArgs(Task.FromResult(false));
-
         var ctx = MakeTriggerCtx(MakeFlow("step1"));
 
+        // Act
         await CreateEngine().TriggerAsync(ctx);
 
-        _dispatcher.ReceivedCalls().Should().BeEmpty(
-            "TryRecordDispatch returned false — the step is already in the dispatch ledger, " +
-            "so the runtime must not receive a second enqueue");
+        // Assert
+        Assert.Empty(_dispatcher.ReceivedCalls());
     }
 
     // ── Invariant 2: Claim exclusion ──────────────────────────────────────────
@@ -108,19 +104,17 @@ public sealed class FlowOrchestratorEngineInvariantTests
     [Fact]
     public async Task TriggerAsync_WhenTryClaimStepReturnsFalse_DispatcherIsNeverCalled()
     {
-        // A runtime store that always refuses the claim — simulates another worker
-        // already owning this step during a parallel fan-out.
+        // Arrange
         var runtimeStore = Substitute.For<IFlowRunRuntimeStore>();
         runtimeStore.TryClaimStepAsync(Arg.Any<Guid>(), Arg.Any<string>())
             .ReturnsForAnyArgs(Task.FromResult(false));
-
         var ctx = MakeTriggerCtx(MakeFlow("step1"));
 
+        // Act
         await CreateEngine(runtimeStore: runtimeStore).TriggerAsync(ctx);
 
-        _dispatcher.ReceivedCalls().Should().BeEmpty(
-            "TryClaimStep returned false — another worker already owns this step, " +
-            "so the dispatcher must not be called");
+        // Assert
+        Assert.Empty(_dispatcher.ReceivedCalls());
     }
 
     // ── Invariant 3: Polling rescheduling order ───────────────────────────────
@@ -128,7 +122,7 @@ public sealed class FlowOrchestratorEngineInvariantTests
     [Fact]
     public async Task RunStepAsync_WhenPending_ReleasesDispatchBeforeSchedulingNextAttempt()
     {
-        // Verify ordering: ReleaseDispatchAsync must fire before ScheduleStepAsync.
+        // Arrange
         var releaseWasCalled = false;
         var scheduleObservedReleaseFirst = false;
 
@@ -164,9 +158,11 @@ public sealed class FlowOrchestratorEngineInvariantTests
         var runId = Guid.NewGuid();
         var flow = MakeFlow("step1");
 
+        // Act
         await CreateEngine().RunStepAsync(
             MakeCtx(runId), flow, new StepInstance("step1", "Work") { RunId = runId });
 
+        // Assert
         await _runStore.Received(1)
             .ReleaseDispatchAsync(runId, "step1", Arg.Any<CancellationToken>());
         await _dispatcher.Received(1).ScheduleStepAsync(
@@ -175,9 +171,7 @@ public sealed class FlowOrchestratorEngineInvariantTests
             Arg.Is<IStepInstance>(s => s.Key == "step1"),
             Arg.Is<TimeSpan>(d => d == TimeSpan.FromSeconds(5)),
             Arg.Any<CancellationToken>());
-        scheduleObservedReleaseFirst.Should().BeTrue(
-            "ReleaseDispatchAsync must be called before ScheduleStepAsync so the next poll " +
-            "attempt can be atomically re-recorded in the dispatch ledger");
+        Assert.True(scheduleObservedReleaseFirst);
     }
 
     // ── Invariant 6: DispatchHint targeting static DAG step throws ────────────
@@ -185,7 +179,7 @@ public sealed class FlowOrchestratorEngineInvariantTests
     [Fact]
     public async Task RunStepAsync_DispatchHintTargetingStaticStep_ThrowsInvalidOperationException()
     {
-        // The executor returns a hint spawning "step2", which already exists in the manifest.
+        // Arrange
         var flow = MakeFlow("step1", "step2");
         var runId = Guid.NewGuid();
 
@@ -204,8 +198,9 @@ public sealed class FlowOrchestratorEngineInvariantTests
             await CreateEngine().RunStepAsync(
                 MakeCtx(runId), flow, new StepInstance("step1", "Work") { RunId = runId });
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*static DAG*");
+        // Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(act);
+        Assert.Contains("static DAG", ex.Message);
     }
 
     // ── Invariant 4: Cascade skip → run completes Skipped ─────────────────────
@@ -213,9 +208,7 @@ public sealed class FlowOrchestratorEngineInvariantTests
     [Fact]
     public async Task RunStepAsync_WhenAllLeafStepsAreSkipped_CompletesRunWithSkippedStatus()
     {
-        // Flow: step1 (entry, Succeeded) + step2 (only runs if step1 Failed).
-        // When step1 Succeeds, step2 is blocked by the graph → engine records it as Skipped.
-        // Since step2 is the only leaf and it is Skipped, the run must complete as Skipped.
+        // Arrange
         var realStore = new InMemoryFlowRunStore();
         var flowId = Guid.NewGuid();
         var runId = Guid.NewGuid();
@@ -232,7 +225,7 @@ public sealed class FlowOrchestratorEngineInvariantTests
                     Type = "Fallback",
                     RunAfter = new RunAfterCollection
                     {
-                        ["step1"] = [StepStatus.Failed]   // only runs on failure
+                        ["step1"] = [StepStatus.Failed]
                     }
                 }
             }
@@ -250,12 +243,12 @@ public sealed class FlowOrchestratorEngineInvariantTests
 
         var engine = CreateEngine(runtimeStore: realStore, runStoreOverride: realStore);
 
+        // Act
         await engine.RunStepAsync(
             MakeCtx(runId), flow, new StepInstance("step1", "Work") { RunId = runId });
 
+        // Assert
         var status = await realStore.GetRunStatusAsync(runId);
-        status.Should().Be(StepStatus.Skipped.ToString(),
-            "all leaf steps were skipped because their runAfter conditions could not be satisfied — " +
-            "the run should complete as Skipped, not Succeeded");
+        Assert.Equal("Skipped", status);
     }
 }

--- a/tests/FlowOrchestrator.Core.Tests/Execution/ForEachStepHandlerTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Execution/ForEachStepHandlerTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
-using FluentAssertions;
 using NSubstitute;
 
 namespace FlowOrchestrator.Core.Tests.Execution;
@@ -44,15 +43,20 @@ public class ForEachStepHandlerTests
     [Fact]
     public async Task ExecuteAsync_NonLoopStep_ReturnsNull()
     {
+        // Arrange
         var flow = FlowWith("loop1", new StepMetadata { Type = "Other" });
+
+        // Act
         var result = await _sut.ExecuteAsync(MakeContext(), flow, MakeStep());
 
-        result.Should().BeNull();
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task ExecuteAsync_EmptyItems_ReturnsZeroIterations()
     {
+        // Arrange
         var loop = new LoopStepMetadata
         {
             Type = "ForEach",
@@ -61,18 +65,20 @@ public class ForEachStepHandlerTests
         };
         var flow = FlowWith("loop1", loop);
 
+        // Act
         var raw = await _sut.ExecuteAsync(MakeContext(), flow, MakeStep());
 
-        var sr = raw.Should().BeOfType<StepResult>().Subject;
-        sr.Status.Should().Be(StepStatus.Succeeded);
-        sr.DispatchHint.Should().BeNull();
-        JsonSerializer.SerializeToElement(sr.Result)
-            .GetProperty("iterations").GetInt32().Should().Be(0);
+        // Assert
+        var sr = Assert.IsType<StepResult>(raw);
+        Assert.Equal(StepStatus.Succeeded, sr.Status);
+        Assert.Null(sr.DispatchHint);
+        Assert.Equal(0, JsonSerializer.SerializeToElement(sr.Result).GetProperty("iterations").GetInt32());
     }
 
     [Fact]
     public async Task ExecuteAsync_StaticList_ReturnsDispatchHintWithChildren()
     {
+        // Arrange
         var loop = new LoopStepMetadata
         {
             Type = "ForEach",
@@ -84,23 +90,25 @@ public class ForEachStepHandlerTests
         };
         var flow = FlowWith("loop1", loop);
 
+        // Act
         var raw = await _sut.ExecuteAsync(MakeContext(), flow, MakeStep("loop1"));
 
-        var sr = raw.Should().BeOfType<StepResult>().Subject;
-        sr.Status.Should().Be(StepStatus.Succeeded);
-        sr.DispatchHint.Should().NotBeNull();
-
+        // Assert
+        var sr = Assert.IsType<StepResult>(raw);
+        Assert.Equal(StepStatus.Succeeded, sr.Status);
+        Assert.NotNull(sr.DispatchHint);
         var spawn = sr.DispatchHint!.Spawn;
-        spawn.Should().HaveCount(3);
-        spawn[0].StepKey.Should().Be("loop1.0.child");
-        spawn[1].StepKey.Should().Be("loop1.1.child");
-        spawn[2].StepKey.Should().Be("loop1.2.child");
-        spawn.Should().AllSatisfy(r => r.StepType.Should().Be("DoWork"));
+        Assert.Equal(3, spawn.Count);
+        Assert.Equal("loop1.0.child", spawn[0].StepKey);
+        Assert.Equal("loop1.1.child", spawn[1].StepKey);
+        Assert.Equal("loop1.2.child", spawn[2].StepKey);
+        Assert.All(spawn, r => Assert.Equal("DoWork", r.StepType));
     }
 
     [Fact]
     public async Task ExecuteAsync_ChildInputsContainLoopItemAndIndex()
     {
+        // Arrange
         var loop = new LoopStepMetadata
         {
             Type = "ForEach",
@@ -117,22 +125,25 @@ public class ForEachStepHandlerTests
         };
         var flow = FlowWith("loop1", loop);
 
+        // Act
         var raw = await _sut.ExecuteAsync(MakeContext(), flow, MakeStep("loop1"));
 
+        // Assert
         var spawn = ((StepResult)raw!).DispatchHint!.Spawn;
         var inputs = spawn[0].Inputs;
-        inputs["__loopItem"].Should().Be("x");
-        inputs["__loopIndex"].Should().Be(0);
-        inputs["staticKey"].Should().Be("staticVal");
+        Assert.Equal("x", inputs["__loopItem"]);
+        Assert.Equal(0, inputs["__loopIndex"]);
+        Assert.Equal("staticVal", inputs["staticKey"]);
     }
 
     [Fact]
     public async Task ExecuteAsync_ConcurrencyLimit_AddsDelayForLaterBuckets()
     {
+        // Arrange
         var loop = new LoopStepMetadata
         {
             Type = "ForEach",
-            ConcurrencyLimit = 2,          // bucket 0 = items 0-1, bucket 1 = items 2-3
+            ConcurrencyLimit = 2,
             ForEach = new List<object?> { "a", "b", "c", "d" },
             Steps = new StepCollection
             {
@@ -141,18 +152,21 @@ public class ForEachStepHandlerTests
         };
         var flow = FlowWith("loop1", loop);
 
+        // Act
         var raw = await _sut.ExecuteAsync(MakeContext(), flow, MakeStep("loop1"));
         var spawn = ((StepResult)raw!).DispatchHint!.Spawn;
 
-        spawn[0].Delay.Should().BeNull();          // bucket 0 item 0
-        spawn[1].Delay.Should().BeNull();          // bucket 0 item 1
-        spawn[2].Delay.Should().Be(TimeSpan.FromMilliseconds(100));  // bucket 1 item 0
-        spawn[3].Delay.Should().Be(TimeSpan.FromMilliseconds(100));  // bucket 1 item 1
+        // Assert
+        Assert.Null(spawn[0].Delay);
+        Assert.Null(spawn[1].Delay);
+        Assert.Equal(TimeSpan.FromMilliseconds(100), spawn[2].Delay);
+        Assert.Equal(TimeSpan.FromMilliseconds(100), spawn[3].Delay);
     }
 
     [Fact]
     public async Task ExecuteAsync_JsonArrayTriggerBody_ResolvesItems()
     {
+        // Arrange
         var loop = new LoopStepMetadata
         {
             Type = "ForEach",
@@ -163,11 +177,13 @@ public class ForEachStepHandlerTests
             }
         };
         var flow = FlowWith("loop1", loop);
-
         var triggerData = JsonSerializer.Deserialize<JsonElement>("{\"items\":[1,2,3]}");
+
+        // Act
         var raw = await _sut.ExecuteAsync(MakeContext(triggerData), flow, MakeStep("loop1"));
 
+        // Assert
         var sr = (StepResult)raw!;
-        sr.DispatchHint!.Spawn.Should().HaveCount(3);
+        Assert.Equal(3, sr.DispatchHint!.Spawn.Count);
     }
 }

--- a/tests/FlowOrchestrator.Core.Tests/Execution/PollableStepHandlerTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Execution/PollableStepHandlerTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
-using FluentAssertions;
 
 namespace FlowOrchestrator.Core.Tests.Execution;
 
@@ -10,22 +9,26 @@ public class PollableStepHandlerTests
     [Fact]
     public async Task ExecuteAsync_PollDisabled_ReturnsSucceeded()
     {
+        // Arrange
         var input = new TestPollableInput { PollEnabled = false };
         var step = new TestStepInstance("step1", "Pollable", input);
         var handler = new TestPollableHandler(() => (ParseJson("{\"status\":\"processing\"}"), true));
 
+        // Act
         var result = await handler.ExecuteAsync(CreateContext(), CreateFlow(), step);
-        var typedResult = result.Should().BeOfType<StepResult<JsonElement>>().Subject;
 
-        typedResult.Status.Should().Be(StepStatus.Succeeded);
-        typedResult.DelayNextStep.Should().BeNull();
-        input.PollAttempt.Should().BeNull();
-        input.PollStartedAtUtc.Should().BeNull();
+        // Assert
+        var typedResult = Assert.IsType<StepResult<JsonElement>>(result);
+        Assert.Equal(StepStatus.Succeeded, typedResult.Status);
+        Assert.Null(typedResult.DelayNextStep);
+        Assert.Null(input.PollAttempt);
+        Assert.Null(input.PollStartedAtUtc);
     }
 
     [Fact]
     public async Task ExecuteAsync_ConditionNotMatched_ReturnsPending()
     {
+        // Arrange
         var input = new TestPollableInput
         {
             PollEnabled = true,
@@ -37,18 +40,21 @@ public class PollableStepHandlerTests
         var step = new TestStepInstance("step1", "Pollable", input);
         var handler = new TestPollableHandler(() => (ParseJson("{\"status\":\"processing\"}"), true));
 
+        // Act
         var result = await handler.ExecuteAsync(CreateContext(), CreateFlow(), step);
-        var typedResult = result.Should().BeOfType<StepResult<JsonElement>>().Subject;
 
-        typedResult.Status.Should().Be(StepStatus.Pending);
-        typedResult.DelayNextStep.Should().Be(TimeSpan.FromSeconds(7));
-        input.PollAttempt.Should().Be(1);
-        input.PollStartedAtUtc.Should().NotBeNullOrWhiteSpace();
+        // Assert
+        var typedResult = Assert.IsType<StepResult<JsonElement>>(result);
+        Assert.Equal(StepStatus.Pending, typedResult.Status);
+        Assert.Equal(TimeSpan.FromSeconds(7), typedResult.DelayNextStep);
+        Assert.Equal(1, input.PollAttempt);
+        Assert.False(string.IsNullOrWhiteSpace(input.PollStartedAtUtc));
     }
 
     [Fact]
     public async Task ExecuteAsync_MatchAfterMinimumAttempts_ReturnsSucceededAndResetsState()
     {
+        // Arrange
         var input = new TestPollableInput
         {
             PollEnabled = true,
@@ -61,24 +67,26 @@ public class PollableStepHandlerTests
         var step = new TestStepInstance("step1", "Pollable", input);
         var handler = new TestPollableHandler(() => (ParseJson("{\"status\":\"completed\"}"), true));
 
+        // Act
         var first = await handler.ExecuteAsync(CreateContext(), CreateFlow(), step);
-        var firstResult = first.Should().BeOfType<StepResult<JsonElement>>().Subject;
-        firstResult.Status.Should().Be(StepStatus.Pending);
-        firstResult.DelayNextStep.Should().Be(TimeSpan.FromSeconds(3));
-        input.PollAttempt.Should().Be(1);
-        input.PollStartedAtUtc.Should().NotBeNullOrWhiteSpace();
-
         var second = await handler.ExecuteAsync(CreateContext(), CreateFlow(), step);
-        var secondResult = second.Should().BeOfType<StepResult<JsonElement>>().Subject;
-        secondResult.Status.Should().Be(StepStatus.Succeeded);
-        secondResult.DelayNextStep.Should().BeNull();
-        input.PollAttempt.Should().BeNull();
-        input.PollStartedAtUtc.Should().BeNull();
+
+        // Assert
+        var firstResult = Assert.IsType<StepResult<JsonElement>>(first);
+        Assert.Equal(StepStatus.Pending, firstResult.Status);
+        Assert.Equal(TimeSpan.FromSeconds(3), firstResult.DelayNextStep);
+
+        var secondResult = Assert.IsType<StepResult<JsonElement>>(second);
+        Assert.Equal(StepStatus.Succeeded, secondResult.Status);
+        Assert.Null(secondResult.DelayNextStep);
+        Assert.Null(input.PollAttempt);
+        Assert.Null(input.PollStartedAtUtc);
     }
 
     [Fact]
     public async Task ExecuteAsync_TimeoutExceeded_ReturnsFailedAndResetsState()
     {
+        // Arrange
         var input = new TestPollableInput
         {
             PollEnabled = true,
@@ -92,18 +100,21 @@ public class PollableStepHandlerTests
         var step = new TestStepInstance("step1", "Pollable", input);
         var handler = new TestPollableHandler(() => (ParseJson("{\"status\":\"processing\"}"), true));
 
+        // Act
         var result = await handler.ExecuteAsync(CreateContext(), CreateFlow(), step);
-        var typedResult = result.Should().BeOfType<StepResult<JsonElement>>().Subject;
 
-        typedResult.Status.Should().Be(StepStatus.Failed);
-        typedResult.FailedReason.Should().Contain("Polling timed out after 10 seconds.");
-        input.PollAttempt.Should().BeNull();
-        input.PollStartedAtUtc.Should().BeNull();
+        // Assert
+        var typedResult = Assert.IsType<StepResult<JsonElement>>(result);
+        Assert.Equal(StepStatus.Failed, typedResult.Status);
+        Assert.Contains("Polling timed out after 10 seconds.", typedResult.FailedReason ?? string.Empty);
+        Assert.Null(input.PollAttempt);
+        Assert.Null(input.PollStartedAtUtc);
     }
 
     [Fact]
     public async Task ExecuteAsync_NonJsonWithConditionPath_ReturnsFailedAndResetsState()
     {
+        // Arrange
         var input = new TestPollableInput
         {
             PollEnabled = true,
@@ -114,13 +125,15 @@ public class PollableStepHandlerTests
         var step = new TestStepInstance("step1", "Pollable", input);
         var handler = new TestPollableHandler(() => (JsonSerializer.SerializeToElement("plain-response"), false));
 
+        // Act
         var result = await handler.ExecuteAsync(CreateContext(), CreateFlow(), step);
-        var typedResult = result.Should().BeOfType<StepResult<JsonElement>>().Subject;
 
-        typedResult.Status.Should().Be(StepStatus.Failed);
-        typedResult.FailedReason.Should().Contain("requires a JSON response body");
-        input.PollAttempt.Should().BeNull();
-        input.PollStartedAtUtc.Should().BeNull();
+        // Assert
+        var typedResult = Assert.IsType<StepResult<JsonElement>>(result);
+        Assert.Equal(StepStatus.Failed, typedResult.Status);
+        Assert.Contains("requires a JSON response body", typedResult.FailedReason ?? string.Empty);
+        Assert.Null(input.PollAttempt);
+        Assert.Null(input.PollStartedAtUtc);
     }
 
     private static IExecutionContext CreateContext()

--- a/tests/FlowOrchestrator.Core.Tests/Execution/RunControlTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Execution/RunControlTests.cs
@@ -3,7 +3,6 @@ using FlowOrchestrator.Core.Configuration;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Storage;
 using FlowOrchestrator.InMemory;
-using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using CoreExecutionContext = FlowOrchestrator.Core.Execution.ExecutionContext;
@@ -13,8 +12,6 @@ namespace FlowOrchestrator.Core.Tests.Execution;
 /// <summary>
 /// Tests for run-level control features: idempotency key deduplication,
 /// cancellation enforcement, and timeout enforcement.
-/// Uses the real <see cref="InMemoryFlowRunStore"/> instead of mocks so the
-/// full control-record lifecycle is exercised without SQL infrastructure.
 /// </summary>
 public sealed class RunControlTests
 {
@@ -32,21 +29,18 @@ public sealed class RunControlTests
 
     // ── Factory helpers ───────────────────────────────────────────────────────
 
-    /// <summary>
-    /// Creates an engine backed by <paramref name="store"/> for all storage roles.
-    /// </summary>
     private FlowOrchestratorEngine CreateEngine(InMemoryFlowRunStore store) =>
         new FlowOrchestratorEngine(
             _dispatcher,
             _flowExecutor,
             _graphPlanner,
             _stepExecutor,
-            store,          // IFlowRunStore
+            store,
             _outputsRepo,
             _ctxAccessor,
             _flowRepo,
-            [store],        // IFlowRunRuntimeStore
-            [store],        // IFlowRunControlStore
+            [store],
+            [store],
             new FlowRunControlOptions(),
             new FlowObservabilityOptions { EnableEventPersistence = false, EnableOpenTelemetry = false },
             new FlowOrchestratorTelemetry(),
@@ -71,10 +65,9 @@ public sealed class RunControlTests
     [Fact]
     public async Task TriggerAsync_DuplicateIdempotencyKey_ReturnsSameRunIdWithoutStartingNewRun()
     {
-        // Arrange: two triggers share the same Idempotency-Key header.
+        // Arrange
         var store = new InMemoryFlowRunStore();
         var engine = CreateEngine(store);
-
         var flowId = Guid.NewGuid();
         var flow = MakeSingleStepFlow(flowId);
         var idempotencyKey = Guid.NewGuid().ToString();
@@ -85,39 +78,29 @@ public sealed class RunControlTests
             Flow = flow,
             Trigger = new Trigger(
                 "manual", "Manual", null,
-                headers: new Dictionary<string, string>
-                {
-                    ["Idempotency-Key"] = idempotencyKey
-                })
+                headers: new Dictionary<string, string> { ["Idempotency-Key"] = idempotencyKey })
         };
 
-        // Act: first trigger creates the run.
+        // Act
         await engine.TriggerAsync(firstCtx);
         var firstRunId = firstCtx.RunId;
-        firstRunId.Should().NotBe(Guid.Empty);
+        Assert.NotEqual(Guid.Empty, firstRunId);
 
-        // Act: second trigger with the same idempotency key.
         var secondCtx = new TriggerContext
         {
-            RunId = Guid.NewGuid(),   // different initial RunId — engine should override it
+            RunId = Guid.NewGuid(),
             Flow = flow,
             Trigger = new Trigger(
                 "manual", "Manual", null,
-                headers: new Dictionary<string, string>
-                {
-                    ["Idempotency-Key"] = idempotencyKey
-                })
+                headers: new Dictionary<string, string> { ["Idempotency-Key"] = idempotencyKey })
         };
 
         await engine.TriggerAsync(secondCtx);
 
-        // Assert: the engine must have detected the duplicate and reused the first RunId.
-        secondCtx.RunId.Should().Be(firstRunId,
-            "duplicate triggers with the same idempotency key must be collapsed into the original run");
-
-        // The store should still have exactly one run record for this flow.
+        // Assert
+        Assert.Equal(firstRunId, secondCtx.RunId);
         var runs = await store.GetRunsAsync(flowId: flowId);
-        runs.Should().HaveCount(1, "no second run must have been started for a duplicate trigger");
+        Assert.Single(runs);
     }
 
     [Fact]
@@ -126,13 +109,11 @@ public sealed class RunControlTests
         // Arrange
         var store = new InMemoryFlowRunStore();
         var engine = CreateEngine(store);
-
         var flowId = Guid.NewGuid();
         var runId = Guid.NewGuid();
         var flow = MakeSingleStepFlow(flowId);
 
         await store.StartRunAsync(flowId, "TestFlow", runId, "manual", null, null);
-        // Signal cancellation before RunStepAsync is called.
         await store.RequestCancelAsync(runId, "Test cancellation");
 
         // Act
@@ -141,14 +122,11 @@ public sealed class RunControlTests
             flow,
             new StepInstance("step1", "Work") { RunId = runId });
 
-        // Assert: the step executor must NOT have been invoked.
+        // Assert
         await _stepExecutor.DidNotReceiveWithAnyArgs()
             .ExecuteAsync(default!, default!, default!);
-
-        // The run must be marked Cancelled.
         var status = await store.GetRunStatusAsync(runId);
-        status.Should().Be("Cancelled",
-            "a run with CancelRequested = true must be completed as Cancelled before any step handler is called");
+        Assert.Equal("Cancelled", status);
     }
 
     [Fact]
@@ -157,13 +135,11 @@ public sealed class RunControlTests
         // Arrange
         var store = new InMemoryFlowRunStore();
         var engine = CreateEngine(store);
-
         var flowId = Guid.NewGuid();
         var runId = Guid.NewGuid();
         var flow = MakeSingleStepFlow(flowId);
 
         await store.StartRunAsync(flowId, "TestFlow", runId, "manual", null, null);
-        // Mark the run as timed out before RunStepAsync is called.
         await store.MarkTimedOutAsync(runId, "Deadline exceeded");
 
         // Act
@@ -172,13 +148,10 @@ public sealed class RunControlTests
             flow,
             new StepInstance("step1", "Work") { RunId = runId });
 
-        // Assert: executor must not have been called.
+        // Assert
         await _stepExecutor.DidNotReceiveWithAnyArgs()
             .ExecuteAsync(default!, default!, default!);
-
-        // The run must be marked TimedOut.
         var status = await store.GetRunStatusAsync(runId);
-        status.Should().Be("TimedOut",
-            "a run whose timeout deadline has passed must be completed as TimedOut without executing any steps");
+        Assert.Equal("TimedOut", status);
     }
 }

--- a/tests/FlowOrchestrator.Core.Tests/Execution/StepInstanceTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Execution/StepInstanceTests.cs
@@ -1,5 +1,4 @@
 using FlowOrchestrator.Core.Execution;
-using FluentAssertions;
 
 namespace FlowOrchestrator.Core.Tests.Execution;
 
@@ -8,24 +7,36 @@ public class StepInstanceTests
     [Fact]
     public void Constructor_SetsKeyAndType()
     {
+        // Arrange
+
+        // Act
         var instance = new StepInstance("step1", "LogMessage");
 
-        instance.Key.Should().Be("step1");
-        instance.Type.Should().Be("LogMessage");
+        // Assert
+        Assert.Equal("step1", instance.Key);
+        Assert.Equal("LogMessage", instance.Type);
     }
 
     [Fact]
     public void DefaultInputs_IsEmptyDictionary()
     {
+        // Arrange
+
+        // Act
         var instance = new StepInstance("step1", "A");
 
-        instance.Inputs.Should().NotBeNull().And.BeEmpty();
+        // Assert
+        Assert.NotNull(instance.Inputs);
+        Assert.Empty(instance.Inputs);
     }
 
     [Fact]
     public void Properties_CanBeSet()
     {
+        // Arrange
         var runId = Guid.NewGuid();
+
+        // Act
         var instance = new StepInstance("step1", "Query")
         {
             RunId = runId,
@@ -35,9 +46,10 @@ public class StepInstanceTests
             ScopeMoveNext = true
         };
 
-        instance.RunId.Should().Be(runId);
-        instance.PrincipalId.Should().Be("user-1");
-        instance.Index.Should().Be(5);
-        instance.ScopeMoveNext.Should().BeTrue();
+        // Assert
+        Assert.Equal(runId, instance.RunId);
+        Assert.Equal("user-1", instance.PrincipalId);
+        Assert.Equal(5, instance.Index);
+        Assert.True(instance.ScopeMoveNext);
     }
 }

--- a/tests/FlowOrchestrator.Core.Tests/Execution/StepResultTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Execution/StepResultTests.cs
@@ -1,6 +1,5 @@
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
-using FluentAssertions;
 using System.Text.Json;
 
 namespace FlowOrchestrator.Core.Tests.Execution;
@@ -10,31 +9,46 @@ public class StepResultTests
     [Fact]
     public void DefaultStatus_IsSucceeded()
     {
+        // Arrange
+
+        // Act
         var result = new StepResult();
 
-        result.Status.Should().Be(StepStatus.Succeeded);
+        // Assert
+        Assert.Equal(StepStatus.Succeeded, result.Status);
     }
 
     [Fact]
     public void DefaultReThrow_IsFalse()
     {
+        // Arrange
+
+        // Act
         var result = new StepResult();
 
-        result.ReThrow.Should().BeFalse();
+        // Assert
+        Assert.False(result.ReThrow);
     }
 
     [Fact]
     public void DefaultDelayNextStep_IsNull()
     {
+        // Arrange
+
+        // Act
         var result = new StepResult();
 
-        result.DelayNextStep.Should().BeNull();
+        // Assert
+        Assert.Null(result.DelayNextStep);
     }
 
     [Fact]
     public void Properties_CanBeSet()
     {
+        // Arrange
         var delay = TimeSpan.FromSeconds(10);
+
+        // Act
         var result = new StepResult
         {
             Key = "step1",
@@ -45,37 +59,45 @@ public class StepResultTests
             DelayNextStep = delay
         };
 
-        result.Key.Should().Be("step1");
-        result.Status.Should().Be(StepStatus.Failed);
-        result.Result.Should().NotBeNull();
-        result.FailedReason.Should().Be("Something went wrong");
-        result.ReThrow.Should().BeTrue();
-        result.DelayNextStep.Should().Be(delay);
+        // Assert
+        Assert.Equal("step1", result.Key);
+        Assert.Equal(StepStatus.Failed, result.Status);
+        Assert.NotNull(result.Result);
+        Assert.Equal("Something went wrong", result.FailedReason);
+        Assert.True(result.ReThrow);
+        Assert.Equal(delay, result.DelayNextStep);
     }
 
     [Fact]
     public void GenericStepResult_MapsValueToResult()
     {
+        // Arrange
+
+        // Act
         var result = new StepResult<TestPayload>
         {
             Key = "step2",
             Value = new TestPayload { Code = "A1" }
         };
 
-        result.Result.Should().BeOfType<TestPayload>();
-        result.Value!.Code.Should().Be("A1");
+        // Assert
+        Assert.IsType<TestPayload>(result.Result);
+        Assert.Equal("A1", result.Value!.Code);
     }
 
     [Fact]
     public void GenericStepResult_MapsResultToValue()
     {
+        // Arrange
         var result = new StepResult<TestPayload> { Key = "step3" };
         var payloadElement = JsonSerializer.Deserialize<JsonElement>("{\"code\":\"B2\"}");
 
+        // Act
         result.Result = payloadElement;
 
-        result.Value.Should().NotBeNull();
-        result.Value!.Code.Should().Be("B2");
+        // Assert
+        Assert.NotNull(result.Value);
+        Assert.Equal("B2", result.Value!.Code);
     }
 
     private sealed class TestPayload

--- a/tests/FlowOrchestrator.Core.Tests/FlowOrchestrator.Core.Tests.csproj
+++ b/tests/FlowOrchestrator.Core.Tests/FlowOrchestrator.Core.Tests.csproj
@@ -14,7 +14,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/FlowOrchestrator.Core.Tests/Hosting/FlowRunRecoveryHostedServiceTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Hosting/FlowRunRecoveryHostedServiceTests.cs
@@ -2,7 +2,6 @@ using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Hosting;
 using FlowOrchestrator.Core.Storage;
-using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 
@@ -39,8 +38,6 @@ public class FlowRunRecoveryHostedServiceTests
         return flow;
     }
 
-    // ── helpers ────────────────────────────────────────────────────────────────
-
     private static IReadOnlyList<FlowRunRecord> RunList(params FlowRunRecord[] runs) => runs;
     private static IReadOnlyDictionary<string, StepStatus> EmptyStatuses() =>
         new Dictionary<string, StepStatus>();
@@ -49,32 +46,37 @@ public class FlowRunRecoveryHostedServiceTests
     private static IReadOnlySet<string> DispatchedSet(params string[] keys) =>
         new HashSet<string>(keys, StringComparer.Ordinal);
 
-    // ── tests ─────────────────────────────────────────────────────────────────
-
     [Fact]
     public async Task StartAsync_NoActiveRuns_DoesNotDispatch()
     {
+        // Arrange
         _runStore.GetActiveRunsAsync()
             .Returns(Task.FromResult<IReadOnlyList<FlowRunRecord>>(Array.Empty<FlowRunRecord>()));
 
+        // Act
         await CreateSut().StartAsync(default);
 
-        _dispatcher.ReceivedCalls().Should().BeEmpty();
+        // Assert
+        Assert.Empty(_dispatcher.ReceivedCalls());
     }
 
     [Fact]
     public async Task StartAsync_NoRuntimeStore_SkipsRecovery()
     {
+        // Arrange
+
+        // Act
         await CreateSut(includeRuntimeStore: false).StartAsync(default);
 
-        // GetActiveRunsAsync must NOT have been called — we bail out early.
+        // Assert
         await _runStore.DidNotReceiveWithAnyArgs().GetActiveRunsAsync();
-        _dispatcher.ReceivedCalls().Should().BeEmpty();
+        Assert.Empty(_dispatcher.ReceivedCalls());
     }
 
     [Fact]
     public async Task StartAsync_ReadyStepNotDispatched_EnqueuesStep()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var runId = Guid.NewGuid();
         var flow = FlowWith(flowId, "step1");
@@ -83,20 +85,17 @@ public class FlowRunRecoveryHostedServiceTests
             .Returns(Task.FromResult(RunList(new FlowRunRecord { Id = runId, FlowId = flowId, Status = "Running" })));
         _flowRepo.GetAllFlowsAsync()
             .Returns(new ValueTask<IReadOnlyList<IFlowDefinition>>(new IFlowDefinition[] { flow }));
-
-        // step1 has no dependencies → graph evaluates it as Ready.
         _runtimeStore.GetStepStatusesAsync(runId)
             .Returns(Task.FromResult(EmptyStatuses()));
-
-        // No dispatch row yet — recovery should enqueue it.
         _runStore.GetDispatchedStepKeysAsync(runId)
             .Returns(Task.FromResult(EmptyDispatched()));
-
         _runStore.TryRecordDispatchAsync(runId, "step1", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(true));
 
+        // Act
         await CreateSut().StartAsync(default);
 
+        // Assert
         await _dispatcher.Received(1).EnqueueStepAsync(
             Arg.Is<IExecutionContext>(c => c.RunId == runId),
             flow,
@@ -107,6 +106,7 @@ public class FlowRunRecoveryHostedServiceTests
     [Fact]
     public async Task StartAsync_ReadyStepAlreadyDispatched_DoesNotReEnqueue()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var runId = Guid.NewGuid();
         var flow = FlowWith(flowId, "step1");
@@ -117,20 +117,20 @@ public class FlowRunRecoveryHostedServiceTests
             .Returns(new ValueTask<IReadOnlyList<IFlowDefinition>>(new IFlowDefinition[] { flow }));
         _runtimeStore.GetStepStatusesAsync(runId)
             .Returns(Task.FromResult(EmptyStatuses()));
-
-        // Dispatch row already exists → recovery must skip it.
         _runStore.GetDispatchedStepKeysAsync(runId)
             .Returns(Task.FromResult(DispatchedSet("step1")));
 
+        // Act
         await CreateSut().StartAsync(default);
 
-        _dispatcher.ReceivedCalls().Should().BeEmpty();
+        // Assert
+        Assert.Empty(_dispatcher.ReceivedCalls());
     }
 
     [Fact]
     public async Task StartAsync_TryRecordDispatchReturnsFalse_DoesNotCallDispatcher()
     {
-        // Two recovery replicas race — only one wins TryRecordDispatch.
+        // Arrange
         var flowId = Guid.NewGuid();
         var runId = Guid.NewGuid();
         var flow = FlowWith(flowId, "step1");
@@ -143,13 +143,13 @@ public class FlowRunRecoveryHostedServiceTests
             .Returns(Task.FromResult(EmptyStatuses()));
         _runStore.GetDispatchedStepKeysAsync(runId)
             .Returns(Task.FromResult(EmptyDispatched()));
-
-        // This instance lost the atomic race.
         _runStore.TryRecordDispatchAsync(runId, "step1", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(false));
 
+        // Act
         await CreateSut().StartAsync(default);
 
-        _dispatcher.ReceivedCalls().Should().BeEmpty();
+        // Assert
+        Assert.Empty(_dispatcher.ReceivedCalls());
     }
 }

--- a/tests/FlowOrchestrator.Core.Tests/Serialization/StepMetadataJsonConverterTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Serialization/StepMetadataJsonConverterTests.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using FlowOrchestrator.Core.Abstractions;
-using FluentAssertions;
 
 namespace FlowOrchestrator.Core.Tests.Serialization;
 
@@ -11,6 +10,7 @@ public class StepMetadataJsonConverterTests
     [Fact]
     public void Deserialize_PlainStep_ReturnsStepMetadata()
     {
+        // Arrange
         var json = """
         {
             "type": "LogMessage",
@@ -19,19 +19,23 @@ public class StepMetadataJsonConverterTests
         }
         """;
 
+        // Act
         var result = JsonSerializer.Deserialize<StepMetadata>(json, Options);
 
-        result.Should().NotBeNull();
-        result.Should().BeOfType<StepMetadata>().And.NotBeOfType<LoopStepMetadata>();
-        result!.Type.Should().Be("LogMessage");
-        result.RunAfter.Should().ContainKey("step0");
-        result.RunAfter["step0"].Should().Contain(StepStatus.Succeeded);
-        result.Inputs.Should().ContainKey("message");
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<StepMetadata>(result);
+        Assert.IsNotType<LoopStepMetadata>(result);
+        Assert.Equal("LogMessage", result!.Type);
+        Assert.True(result.RunAfter.ContainsKey("step0"));
+        Assert.Contains(StepStatus.Succeeded, result.RunAfter["step0"]);
+        Assert.True(result.Inputs.ContainsKey("message"));
     }
 
     [Fact]
     public void Deserialize_ForEachStep_ReturnsLoopStepMetadata()
     {
+        // Arrange
         var json = """
         {
             "type": "ForEach",
@@ -45,19 +49,21 @@ public class StepMetadataJsonConverterTests
         }
         """;
 
+        // Act
         var result = JsonSerializer.Deserialize<StepMetadata>(json, Options);
 
-        result.Should().BeOfType<LoopStepMetadata>();
-        var loop = (LoopStepMetadata)result!;
-        loop.Type.Should().Be("ForEach");
-        loop.ConcurrencyLimit.Should().Be(5);
-        loop.Steps.Should().ContainKey("child1");
-        loop.Steps["child1"].Type.Should().Be("Process");
+        // Assert
+        var loop = Assert.IsType<LoopStepMetadata>(result);
+        Assert.Equal("ForEach", loop.Type);
+        Assert.Equal(5, loop.ConcurrencyLimit);
+        Assert.True(loop.Steps.ContainsKey("child1"));
+        Assert.Equal("Process", loop.Steps["child1"].Type);
     }
 
     [Fact]
     public void Serialize_PlainStep_ProducesCorrectJson()
     {
+        // Arrange
         var step = new StepMetadata
         {
             Type = "LogMessage",
@@ -65,16 +71,19 @@ public class StepMetadataJsonConverterTests
             Inputs = new Dictionary<string, object?> { ["message"] = "hello" }
         };
 
+        // Act
         var json = JsonSerializer.Serialize(step, Options);
 
-        json.Should().Contain("\"type\":\"LogMessage\"");
-        json.Should().Contain("\"runAfter\"");
-        json.Should().Contain("\"inputs\"");
+        // Assert
+        Assert.Contains("\"type\":\"LogMessage\"", json);
+        Assert.Contains("\"runAfter\"", json);
+        Assert.Contains("\"inputs\"", json);
     }
 
     [Fact]
     public void RoundTrip_PlainStep_PreservesData()
     {
+        // Arrange
         var original = new StepMetadata
         {
             Type = "QueryDatabase",
@@ -82,18 +91,21 @@ public class StepMetadataJsonConverterTests
             Inputs = new Dictionary<string, object?> { ["sql"] = "SELECT 1", ["timeout"] = 30 }
         };
 
+        // Act
         var json = JsonSerializer.Serialize(original, Options);
         var deserialized = JsonSerializer.Deserialize<StepMetadata>(json, Options);
 
-        deserialized.Should().NotBeNull();
-        deserialized!.Type.Should().Be(original.Type);
-        deserialized.RunAfter.Should().ContainKey("prev");
-        deserialized.RunAfter["prev"].Should().BeEquivalentTo(new[] { StepStatus.Succeeded, StepStatus.Failed });
+        // Assert
+        Assert.NotNull(deserialized);
+        Assert.Equal(original.Type, deserialized!.Type);
+        Assert.True(deserialized.RunAfter.ContainsKey("prev"));
+        Assert.Equal(new[] { StepStatus.Succeeded, StepStatus.Failed }, deserialized.RunAfter["prev"]);
     }
 
     [Fact]
     public void RoundTrip_LoopStep_PreservesNestedSteps()
     {
+        // Arrange
         var original = new LoopStepMetadata
         {
             Type = "ForEach",
@@ -108,19 +120,21 @@ public class StepMetadataJsonConverterTests
             }
         };
 
+        // Act
         var json = JsonSerializer.Serialize<StepMetadata>(original, Options);
         var deserialized = JsonSerializer.Deserialize<StepMetadata>(json, Options);
 
-        deserialized.Should().BeOfType<LoopStepMetadata>();
-        var loop = (LoopStepMetadata)deserialized!;
-        loop.ConcurrencyLimit.Should().Be(3);
-        loop.Steps.Should().ContainKey("inner");
-        loop.Steps["inner"].Type.Should().Be("Process");
+        // Assert
+        var loop = Assert.IsType<LoopStepMetadata>(deserialized);
+        Assert.Equal(3, loop.ConcurrencyLimit);
+        Assert.True(loop.Steps.ContainsKey("inner"));
+        Assert.Equal("Process", loop.Steps["inner"].Type);
     }
 
     [Fact]
     public void Deserialize_StepCollection_PolymorphicSteps()
     {
+        // Arrange
         var json = """
         {
             "plain": { "type": "LogMessage", "runAfter": {}, "inputs": {} },
@@ -128,22 +142,27 @@ public class StepMetadataJsonConverterTests
         }
         """;
 
+        // Act
         var result = JsonSerializer.Deserialize<StepCollection>(json, Options);
 
-        result.Should().NotBeNull();
-        result!["plain"].Should().BeOfType<StepMetadata>();
-        result["loop"].Should().BeOfType<LoopStepMetadata>();
-        ((LoopStepMetadata)result["loop"]).ConcurrencyLimit.Should().Be(2);
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<StepMetadata>(result!["plain"]);
+        var loop = Assert.IsType<LoopStepMetadata>(result["loop"]);
+        Assert.Equal(2, loop.ConcurrencyLimit);
     }
 
     [Fact]
     public void Deserialize_MissingType_DefaultsToNull()
     {
+        // Arrange
         var json = """{ "runAfter": {}, "inputs": {} }""";
 
+        // Act
         var result = JsonSerializer.Deserialize<StepMetadata>(json, Options);
 
-        result.Should().NotBeNull();
-        result!.Type.Should().BeNull();
+        // Assert
+        Assert.NotNull(result);
+        Assert.Null(result!.Type);
     }
 }

--- a/tests/FlowOrchestrator.Core.Tests/Storage/FlowRunStoreDispatchContractTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Storage/FlowRunStoreDispatchContractTests.cs
@@ -1,5 +1,4 @@
 using FlowOrchestrator.InMemory;
-using FluentAssertions;
 
 namespace FlowOrchestrator.Core.Tests.Storage;
 
@@ -8,76 +7,72 @@ namespace FlowOrchestrator.Core.Tests.Storage;
 /// <see cref="FlowOrchestrator.Core.Storage.IFlowRunStore.TryRecordDispatchAsync"/>,
 /// <see cref="FlowOrchestrator.Core.Storage.IFlowRunStore.ReleaseDispatchAsync"/>, and
 /// <see cref="FlowOrchestrator.Core.Storage.IFlowRunStore.GetDispatchedStepKeysAsync"/>.
-/// These methods form the idempotent dispatch ledger — "Dispatch many, Execute once".
 /// </summary>
 public sealed class FlowRunStoreDispatchContractTests
 {
-    // ── Invariant: first record returns true ──────────────────────────────────
-
     [Fact]
     public async Task TryRecordDispatchAsync_FirstCallForStep_ReturnsTrue()
     {
+        // Arrange
         var store = new InMemoryFlowRunStore();
         var runId = Guid.NewGuid();
 
+        // Act
         var result = await store.TryRecordDispatchAsync(runId, "step1");
 
-        result.Should().BeTrue("the first dispatch for a (RunId, StepKey) pair must always succeed");
+        // Assert
+        Assert.True(result);
     }
-
-    // ── Invariant: second record for same step returns false ──────────────────
 
     [Fact]
     public async Task TryRecordDispatchAsync_SecondCallSameStep_ReturnsFalse()
     {
+        // Arrange
         var store = new InMemoryFlowRunStore();
         var runId = Guid.NewGuid();
-
         await store.TryRecordDispatchAsync(runId, "step1");
+
+        // Act
         var second = await store.TryRecordDispatchAsync(runId, "step1");
 
-        second.Should().BeFalse(
-            "the same (RunId, StepKey) must not be dispatched twice — " +
-            "the second call indicates the step is already in the runtime queue");
+        // Assert
+        Assert.False(second);
     }
-
-    // ── Invariant: release allows re-dispatch (polling pattern) ──────────────
 
     [Fact]
     public async Task ReleaseDispatchAsync_AfterRelease_AllowsReRecording()
     {
-        // The Pending (polling) path: engine calls Release before scheduling the next attempt.
+        // Arrange
         var store = new InMemoryFlowRunStore();
         var runId = Guid.NewGuid();
+        await store.TryRecordDispatchAsync(runId, "step1");
+        await store.ReleaseDispatchAsync(runId, "step1");
 
-        await store.TryRecordDispatchAsync(runId, "step1");          // initial dispatch
-        await store.ReleaseDispatchAsync(runId, "step1");             // engine releases for re-poll
-        var canDispatchAgain = await store.TryRecordDispatchAsync(runId, "step1");  // next attempt
+        // Act
+        var canDispatchAgain = await store.TryRecordDispatchAsync(runId, "step1");
 
-        canDispatchAgain.Should().BeTrue(
-            "ReleaseDispatchAsync must remove the ledger entry so the step can be re-dispatched " +
-            "for the next polling attempt without a false-duplicate guard");
+        // Assert
+        Assert.True(canDispatchAgain);
     }
-
-    // ── Invariant: GetDispatchedStepKeysAsync reflects current ledger state ───
 
     [Fact]
     public async Task GetDispatchedStepKeysAsync_ReflectsDispatchedAndReleasedSteps()
     {
-        // Record three dispatches; release one (simulating a Pending step mid-poll).
+        // Arrange
         var store = new InMemoryFlowRunStore();
         var runId = Guid.NewGuid();
-
         await store.TryRecordDispatchAsync(runId, "step1");
         await store.TryRecordDispatchAsync(runId, "step2");
         await store.TryRecordDispatchAsync(runId, "step3");
-        await store.ReleaseDispatchAsync(runId, "step2");  // step2 released for re-polling
+        await store.ReleaseDispatchAsync(runId, "step2");
 
+        // Act
         var keys = await store.GetDispatchedStepKeysAsync(runId);
 
-        keys.Should().BeEquivalentTo(["step1", "step3"],
-            "only non-released dispatches should appear; step2 was released and must be absent");
-        keys.Should().NotContain("step2",
-            "a released dispatch record is not considered 'in flight' and must not block recovery");
+        // Assert
+        Assert.Equal(2, keys.Count);
+        Assert.Contains("step1", keys);
+        Assert.Contains("step3", keys);
+        Assert.DoesNotContain("step2", keys);
     }
 }

--- a/tests/FlowOrchestrator.Core.Tests/Storage/InMemoryFlowRepositoryTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Storage/InMemoryFlowRepositoryTests.cs
@@ -1,6 +1,5 @@
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Storage;
-using FluentAssertions;
 using NSubstitute;
 
 namespace FlowOrchestrator.Core.Tests.Storage;
@@ -10,27 +9,32 @@ public class InMemoryFlowRepositoryTests
     [Fact]
     public async Task Add_AndGetAllFlows_ReturnsAddedFlows()
     {
+        // Arrange
         var repo = new InMemoryFlowRepository();
         var flow1 = Substitute.For<IFlowDefinition>();
         var flow2 = Substitute.For<IFlowDefinition>();
 
+        // Act
         repo.Add(flow1);
         repo.Add(flow2);
-
         var all = await repo.GetAllFlowsAsync();
 
-        all.Should().HaveCount(2);
-        all.Should().Contain(flow1);
-        all.Should().Contain(flow2);
+        // Assert
+        Assert.Equal(2, all.Count());
+        Assert.Contains(flow1, all);
+        Assert.Contains(flow2, all);
     }
 
     [Fact]
     public async Task GetAllFlows_Empty_ReturnsEmptyList()
     {
+        // Arrange
         var repo = new InMemoryFlowRepository();
 
+        // Act
         var all = await repo.GetAllFlowsAsync();
 
-        all.Should().BeEmpty();
+        // Assert
+        Assert.Empty(all);
     }
 }

--- a/tests/FlowOrchestrator.Dashboard.Tests/BasicAuthEndpointTests.cs
+++ b/tests/FlowOrchestrator.Dashboard.Tests/BasicAuthEndpointTests.cs
@@ -26,71 +26,95 @@ public sealed class BasicAuthEndpointTests : IDisposable
     [Fact]
     public async Task GET_flows_without_auth_header_returns_401()
     {
+        // Arrange
+
+        // Act
         var response = await _client.GetAsync("/flows/api/flows");
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
     [Fact]
     public async Task GET_flows_with_correct_credentials_returns_200()
     {
+        // Arrange
         _client.DefaultRequestHeaders.Authorization =
             new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes("admin:secret123")));
 
+        // Act
         var response = await _client.GetAsync("/flows/api/flows");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
     public async Task GET_flows_with_wrong_password_returns_401()
     {
+        // Arrange
         _client.DefaultRequestHeaders.Authorization =
             new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes("admin:wrongpassword")));
 
+        // Act
         var response = await _client.GetAsync("/flows/api/flows");
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
     [Fact]
     public async Task GET_flows_with_wrong_username_returns_401()
     {
+        // Arrange
         _client.DefaultRequestHeaders.Authorization =
             new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes("hacker:secret123")));
 
+        // Act
         var response = await _client.GetAsync("/flows/api/flows");
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
     [Fact]
     public async Task GET_flows_with_invalid_base64_returns_401()
     {
+        // Arrange
         _client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", "Basic not-valid-base64!!!");
 
+        // Act
         var response = await _client.GetAsync("/flows/api/flows");
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
     [Fact]
     public async Task Unauthorized_response_includes_WWWAuthenticate_header()
     {
+        // Arrange
+
+        // Act
         var response = await _client.GetAsync("/flows/api/flows");
 
-        response.Headers.WwwAuthenticate.Should().NotBeEmpty();
-        response.Headers.WwwAuthenticate.ToString().Should().Contain("Basic");
+        // Assert
+        Assert.NotEmpty(response.Headers.WwwAuthenticate);
+        Assert.Contains("Basic", response.Headers.WwwAuthenticate.ToString());
     }
 
     [Fact]
     public async Task No_auth_required_when_credentials_not_configured()
     {
+        // Arrange
         using var server = new DashboardTestServer();
         server.FlowStore.GetAllAsync().Returns(Array.Empty<FlowDefinitionRecord>());
         using var client = server.CreateClient();
 
+        // Act
         var response = await client.GetAsync("/flows/api/flows");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 }

--- a/tests/FlowOrchestrator.Dashboard.Tests/FlowCatalogEndpointTests.cs
+++ b/tests/FlowOrchestrator.Dashboard.Tests/FlowCatalogEndpointTests.cs
@@ -15,86 +15,107 @@ public sealed class FlowCatalogEndpointTests : IDisposable
     [Fact]
     public async Task GET_api_flows_returns_200_with_flow_list()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         _server.FlowStore.GetAllAsync().Returns([
             new FlowDefinitionRecord { Id = flowId, Name = "TestFlow", Version = "1.0", IsEnabled = true }
         ]);
 
+        // Act
         var response = await _client.GetAsync("/flows/api/flows");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("TestFlow");
+        Assert.Contains("TestFlow", body);
     }
 
     [Fact]
     public async Task GET_api_flows_by_id_returns_200_for_existing_flow()
     {
+        // Arrange
         var id = Guid.NewGuid();
         _server.FlowStore.GetByIdAsync(id).Returns(new FlowDefinitionRecord { Id = id, Name = "FoundFlow", Version = "1.0" });
 
+        // Act
         var response = await _client.GetAsync($"/flows/api/flows/{id}");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("FoundFlow");
+        Assert.Contains("FoundFlow", body);
     }
 
     [Fact]
     public async Task GET_api_flows_by_id_returns_404_for_missing_flow()
     {
+        // Arrange
         _server.FlowStore.GetByIdAsync(Arg.Any<Guid>()).Returns((FlowDefinitionRecord?)null);
 
+        // Act
         var response = await _client.GetAsync($"/flows/api/flows/{Guid.NewGuid()}");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]
     public async Task POST_enable_returns_200_and_calls_sync()
     {
+        // Arrange
         var id = Guid.NewGuid();
         var record = new FlowDefinitionRecord { Id = id, Name = "Flow", Version = "1.0", IsEnabled = true };
         _server.FlowStore.SetEnabledAsync(id, true).Returns(record);
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/flows/{id}/enable", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         _server.TriggerSync.Received(1).SyncTriggers(id, true);
     }
 
     [Fact]
     public async Task POST_enable_returns_404_when_flow_not_found()
     {
+        // Arrange
         var id = Guid.NewGuid();
         _server.FlowStore.SetEnabledAsync(id, true).Returns<FlowDefinitionRecord>(_ => throw new KeyNotFoundException());
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/flows/{id}/enable", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]
     public async Task POST_disable_returns_200_and_calls_sync()
     {
+        // Arrange
         var id = Guid.NewGuid();
         var record = new FlowDefinitionRecord { Id = id, Name = "Flow", Version = "1.0", IsEnabled = false };
         _server.FlowStore.SetEnabledAsync(id, false).Returns(record);
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/flows/{id}/disable", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         _server.TriggerSync.Received(1).SyncTriggers(id, false);
     }
 
     [Fact]
     public async Task POST_disable_returns_404_when_flow_not_found()
     {
+        // Arrange
         var id = Guid.NewGuid();
         _server.FlowStore.SetEnabledAsync(id, false).Returns<FlowDefinitionRecord>(_ => throw new KeyNotFoundException());
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/flows/{id}/disable", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 }

--- a/tests/FlowOrchestrator.Dashboard.Tests/FlowDashboardOptionsTests.cs
+++ b/tests/FlowOrchestrator.Dashboard.Tests/FlowDashboardOptionsTests.cs
@@ -5,29 +5,49 @@ public sealed class FlowDashboardOptionsTests
     [Fact]
     public void IsEnabled_false_when_neither_username_nor_password_set()
     {
+        // Arrange
+
+        // Act
         var opts = new FlowDashboardBasicAuthOptions();
-        opts.IsEnabled.Should().BeFalse();
+
+        // Assert
+        Assert.False(opts.IsEnabled);
     }
 
     [Fact]
     public void IsEnabled_false_when_only_username_set()
     {
+        // Arrange
+
+        // Act
         var opts = new FlowDashboardBasicAuthOptions { Username = "admin" };
-        opts.IsEnabled.Should().BeFalse();
+
+        // Assert
+        Assert.False(opts.IsEnabled);
     }
 
     [Fact]
     public void IsEnabled_false_when_only_password_set()
     {
+        // Arrange
+
+        // Act
         var opts = new FlowDashboardBasicAuthOptions { Password = "secret" };
-        opts.IsEnabled.Should().BeFalse();
+
+        // Assert
+        Assert.False(opts.IsEnabled);
     }
 
     [Fact]
     public void IsEnabled_true_when_both_username_and_password_set()
     {
+        // Arrange
+
+        // Act
         var opts = new FlowDashboardBasicAuthOptions { Username = "admin", Password = "secret" };
-        opts.IsEnabled.Should().BeTrue();
+
+        // Assert
+        Assert.True(opts.IsEnabled);
     }
 
     [Theory]
@@ -37,29 +57,50 @@ public sealed class FlowDashboardOptionsTests
     [InlineData("admin", "  ")]
     public void IsEnabled_false_when_credentials_are_whitespace(string username, string password)
     {
+        // Arrange
+
+        // Act
         var opts = new FlowDashboardBasicAuthOptions { Username = username, Password = password };
-        opts.IsEnabled.Should().BeFalse();
+
+        // Assert
+        Assert.False(opts.IsEnabled);
     }
 
     [Fact]
     public void Default_realm_is_FlowOrchestrator_Dashboard()
     {
+        // Arrange
+
+        // Act
         var opts = new FlowDashboardBasicAuthOptions();
-        opts.Realm.Should().Be("FlowOrchestrator Dashboard");
+
+        // Assert
+        Assert.Equal("FlowOrchestrator Dashboard", opts.Realm);
     }
 
     [Fact]
     public void Default_branding_title_is_set()
     {
+        // Arrange
+
+        // Act
         var opts = new FlowDashboardBrandingOptions();
-        opts.Title.Should().Be("FlowOrchestrator Dashboard");
-        opts.Subtitle.Should().Be("Dashboard");
-        opts.LogoUrl.Should().BeNull();
+
+        // Assert
+        Assert.Equal("FlowOrchestrator Dashboard", opts.Title);
+        Assert.Equal("Dashboard", opts.Subtitle);
+        Assert.Null(opts.LogoUrl);
     }
 
     [Fact]
     public void FlowDashboardOptions_default_section_name_is_FlowDashboard()
     {
-        FlowDashboardOptions.DefaultSectionName.Should().Be("FlowDashboard");
+        // Arrange
+
+        // Act
+        var defaultName = FlowDashboardOptions.DefaultSectionName;
+
+        // Assert
+        Assert.Equal("FlowDashboard", defaultName);
     }
 }

--- a/tests/FlowOrchestrator.Dashboard.Tests/FlowOrchestrator.Dashboard.Tests.csproj
+++ b/tests/FlowOrchestrator.Dashboard.Tests/FlowOrchestrator.Dashboard.Tests.csproj
@@ -21,7 +21,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/FlowOrchestrator.Dashboard.Tests/GlobalUsings.cs
+++ b/tests/FlowOrchestrator.Dashboard.Tests/GlobalUsings.cs
@@ -1,3 +1,2 @@
 global using Xunit;
-global using FluentAssertions;
 global using NSubstitute;

--- a/tests/FlowOrchestrator.Dashboard.Tests/RunEndpointTests.cs
+++ b/tests/FlowOrchestrator.Dashboard.Tests/RunEndpointTests.cs
@@ -17,92 +17,114 @@ public sealed class RunEndpointTests : IDisposable
     [Fact]
     public async Task GET_api_runs_returns_200()
     {
+        // Arrange
         _server.FlowRunStore.GetRunsAsync(null, 0, 50)
             .Returns(Array.Empty<FlowRunRecord>());
 
+        // Act
         var response = await _client.GetAsync("/flows/api/runs");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
     public async Task GET_api_runs_with_includeTotal_returns_paged_response()
     {
+        // Arrange
         var run = new FlowRunRecord { Id = Guid.NewGuid(), Status = "Succeeded", FlowName = "F" };
         _server.FlowRunStore.GetRunsPageAsync(null, null, 0, 10, null)
             .Returns(([run], 1));
 
+        // Act
         var response = await _client.GetAsync("/flows/api/runs?includeTotal=true&take=10");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("\"total\"");
-        body.Should().Contain("\"items\"");
+        Assert.Contains("\"total\"", body);
+        Assert.Contains("\"items\"", body);
     }
 
     [Fact]
     public async Task GET_api_runs_with_status_filter_uses_GetRunsPageAsync()
     {
+        // Arrange
         _server.FlowRunStore.GetRunsPageAsync(null, "Failed", 0, 50, null)
             .Returns((Array.Empty<FlowRunRecord>(), 0));
 
+        // Act
         var response = await _client.GetAsync("/flows/api/runs?status=Failed");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         await _server.FlowRunStore.Received(1).GetRunsPageAsync(null, "Failed", 0, 50, null);
     }
 
     [Fact]
     public async Task GET_api_runs_active_returns_200()
     {
+        // Arrange
         _server.FlowRunStore.GetActiveRunsAsync().Returns(Array.Empty<FlowRunRecord>());
 
+        // Act
         var response = await _client.GetAsync("/flows/api/runs/active");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
     public async Task GET_api_runs_stats_returns_200()
     {
+        // Arrange
         _server.FlowRunStore.GetStatisticsAsync()
             .Returns(new DashboardStatistics { TotalFlows = 3, ActiveRuns = 1 });
 
+        // Act
         var response = await _client.GetAsync("/flows/api/runs/stats");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("totalFlows");
+        Assert.Contains("totalFlows", body);
     }
 
     [Fact]
     public async Task GET_api_runs_by_id_returns_200_for_existing_run()
     {
+        // Arrange
         var id = Guid.NewGuid();
         var run = new FlowRunRecord { Id = id, Status = "Succeeded", FlowName = "MyFlow" };
         _server.FlowRunStore.GetRunDetailAsync(id).Returns(run);
         _server.OutputsRepository.GetTriggerHeadersAsync(id).Returns((IReadOnlyDictionary<string, string>?)null);
 
+        // Act
         var response = await _client.GetAsync($"/flows/api/runs/{id}");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("MyFlow");
+        Assert.Contains("MyFlow", body);
     }
 
     [Fact]
     public async Task GET_api_runs_by_id_returns_404_for_missing_run()
     {
+        // Arrange
         _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
 
+        // Act
         var response = await _client.GetAsync($"/flows/api/runs/{Guid.NewGuid()}");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]
     public async Task GET_api_runs_steps_returns_200_with_steps()
     {
+        // Arrange
         var id = Guid.NewGuid();
         var run = new FlowRunRecord
         {
@@ -112,76 +134,94 @@ public sealed class RunEndpointTests : IDisposable
         };
         _server.FlowRunStore.GetRunDetailAsync(id).Returns(run);
 
+        // Act
         var response = await _client.GetAsync($"/flows/api/runs/{id}/steps");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("step1");
+        Assert.Contains("step1", body);
     }
 
     [Fact]
     public async Task GET_api_runs_steps_returns_404_for_missing_run()
     {
+        // Arrange
         _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
 
+        // Act
         var response = await _client.GetAsync($"/flows/api/runs/{Guid.NewGuid()}/steps");
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]
     public async Task GET_api_runs_events_returns_200()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         _server.EventReader.GetRunEventsAsync(runId, 0, 200)
             .Returns([new FlowEventRecord { RunId = runId, Sequence = 1, Type = "step.started" }]);
 
+        // Act
         var response = await _client.GetAsync($"/flows/api/runs/{runId}/events");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("step.started");
+        Assert.Contains("step.started", body);
     }
 
     [Fact]
     public async Task GET_api_runs_control_returns_200()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         _server.RunControlStore.GetRunControlAsync(runId)
             .Returns(new FlowRunControlRecord { RunId = runId, TriggerKey = "manual" });
 
+        // Act
         var response = await _client.GetAsync($"/flows/api/runs/{runId}/control");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
     public async Task POST_runs_cancel_returns_200_and_requests_cancel()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         _server.FlowRunStore.GetRunDetailAsync(runId)
             .Returns(new FlowRunRecord { Id = runId, FlowId = Guid.NewGuid(), Status = "Running" });
         _server.RunControlStore.RequestCancelAsync(runId, Arg.Any<string?>()).Returns(true);
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/runs/{runId}/cancel", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         await _server.RunControlStore.Received(1).RequestCancelAsync(runId, Arg.Any<string?>());
     }
 
     [Fact]
     public async Task POST_retry_returns_404_when_run_not_found()
     {
+        // Arrange
         _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/runs/{Guid.NewGuid()}/steps/step1/retry", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]
     public async Task POST_retry_returns_400_when_step_not_failed()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         var run = new FlowRunRecord
         {
@@ -192,38 +232,47 @@ public sealed class RunEndpointTests : IDisposable
         };
         _server.FlowRunStore.GetRunDetailAsync(runId).Returns(run);
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/runs/{runId}/steps/step1/retry", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
     public async Task POST_rerun_returns_404_when_run_missing()
     {
+        // Arrange
         _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/runs/{Guid.NewGuid()}/rerun", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]
     public async Task POST_rerun_returns_404_when_flow_missing_from_repository()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         var flowId = Guid.NewGuid();
         _server.FlowRunStore.GetRunDetailAsync(runId)
             .Returns(new FlowRunRecord { Id = runId, FlowId = flowId, Status = "Failed", TriggerKey = "manual" });
         _server.FlowRepository.GetAllFlowsAsync().Returns(Array.Empty<IFlowDefinition>());
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/runs/{runId}/rerun", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]
     public async Task POST_rerun_returns_200_and_triggers_new_run()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         var flowId = Guid.NewGuid();
         var flow = Substitute.For<IFlowDefinition>();
@@ -238,12 +287,14 @@ public sealed class RunEndpointTests : IDisposable
             TriggerDataJson = "{\"orderId\":42}"
         });
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/runs/{runId}/rerun", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("runId");
-        body.Should().Contain("sourceRunId");
+        Assert.Contains("runId", body);
+        Assert.Contains("sourceRunId", body);
         await _server.FlowOrchestrator.Received(1).TriggerAsync(Arg.Is<ITriggerContext>(ctx =>
             ctx.Flow.Id == flowId && ctx.Trigger.Key == "webhook"), Arg.Any<CancellationToken>());
     }
@@ -251,6 +302,7 @@ public sealed class RunEndpointTests : IDisposable
     [Fact]
     public async Task POST_retry_returns_200_for_failed_step()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         var run = new FlowRunRecord
         {
@@ -261,10 +313,12 @@ public sealed class RunEndpointTests : IDisposable
         };
         _server.FlowRunStore.GetRunDetailAsync(runId).Returns(run);
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/runs/{runId}/steps/step1/retry", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("success");
+        Assert.Contains("success", body);
     }
 }

--- a/tests/FlowOrchestrator.Dashboard.Tests/ScheduleEndpointTests.cs
+++ b/tests/FlowOrchestrator.Dashboard.Tests/ScheduleEndpointTests.cs
@@ -9,14 +9,7 @@ using FlowOrchestrator.Core.Storage;
 namespace FlowOrchestrator.Dashboard.Tests;
 
 /// <summary>
-/// Integration tests for the schedule management endpoints
-/// (<c>GET /api/schedules</c>, <c>POST /api/schedules/{jobId}/trigger</c>,
-/// <c>POST /api/schedules/{jobId}/pause</c>, <c>POST /api/schedules/{jobId}/resume</c>,
-/// <c>PUT /api/schedules/{jobId}/cron</c>) and the manual flow trigger endpoint
-/// (<c>POST /api/flows/{id}/trigger</c>).
-///
-/// These endpoints use <see cref="IRecurringTriggerDispatcher"/>, <see cref="IRecurringTriggerInspector"/>,
-/// and <see cref="IFlowOrchestrator"/> — all injected as mocks through <see cref="DashboardTestServer"/>.
+/// Integration tests for the schedule management endpoints and the manual flow trigger endpoint.
 /// </summary>
 public sealed class ScheduleEndpointTests : IDisposable
 {
@@ -27,41 +20,34 @@ public sealed class ScheduleEndpointTests : IDisposable
 
     public void Dispose() => _server.Dispose();
 
-    // ── helpers ───────────────────────────────────────────────────────────────
-
     private static string JobId(Guid flowId, string triggerKey) =>
         $"flow-{flowId:D}-{triggerKey}";
 
     private static StringContent JsonBody(object obj) =>
         new(JsonSerializer.Serialize(obj), Encoding.UTF8, "application/json");
 
-    // ═══════════════════════════════════════════════════════════════════════
-    // GET /api/schedules
-    // ═══════════════════════════════════════════════════════════════════════
-
-    /// <summary>Returns 200 with an empty array when no recurring jobs are registered.</summary>
     [Fact]
     public async Task GET_api_schedules_returns_200_with_empty_array_when_no_jobs()
     {
+        // Arrange
         _server.TriggerInspector.GetJobsAsync()
             .Returns(Array.Empty<RecurringTriggerInfo>());
         _server.FlowStore.GetAllAsync()
             .Returns(Array.Empty<FlowDefinitionRecord>());
 
+        // Act
         var response = await _client.GetAsync("/flows/api/schedules");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().StartWith("[");
+        Assert.StartsWith("[", body);
     }
 
-    /// <summary>
-    /// Returns 200 and includes job metadata when recurring jobs exist.
-    /// The response must include <c>jobId</c>, <c>cron</c>, and <c>flowName</c> fields.
-    /// </summary>
     [Fact]
     public async Task GET_api_schedules_returns_jobs_with_metadata()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var jobId = JobId(flowId, "cron");
 
@@ -81,46 +67,38 @@ public sealed class ScheduleEndpointTests : IDisposable
             new FlowDefinitionRecord { Id = flowId, Name = "HourlyFlow", IsEnabled = true }
         });
 
+        // Act
         var response = await _client.GetAsync("/flows/api/schedules");
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("HourlyFlow");
-        body.Should().Contain("0 * * * *");
+        Assert.Contains("HourlyFlow", body);
+        Assert.Contains("0 * * * *", body);
     }
 
-    // ═══════════════════════════════════════════════════════════════════════
-    // POST /api/schedules/{jobId}/trigger
-    // ═══════════════════════════════════════════════════════════════════════
-
-    /// <summary>
-    /// Calls <see cref="IRecurringTriggerDispatcher.TriggerOnce"/> when the job is not paused,
-    /// and returns 200 with a success message.
-    /// </summary>
     [Fact]
     public async Task POST_schedules_trigger_calls_TriggerOnce_for_active_job()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var jobId = JobId(flowId, "cron");
-
-        // No paused state — job is active.
         _server.ScheduleStateStore.GetAsync(jobId).Returns((FlowScheduleState?)null);
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/schedules/{jobId}/trigger", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         _server.TriggerDispatcher.Received(1).TriggerOnce(jobId);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("success");
+        Assert.Contains("success", body);
     }
 
-    /// <summary>
-    /// Calls <see cref="IRecurringTriggerDispatcher.EnqueueTriggerAsync"/> when the job is paused,
-    /// rather than <c>TriggerOnce</c> (which would fail for a removed job).
-    /// </summary>
     [Fact]
     public async Task POST_schedules_trigger_calls_EnqueueTriggerAsync_for_paused_job()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var jobId = JobId(flowId, "cron");
 
@@ -134,25 +112,20 @@ public sealed class ScheduleEndpointTests : IDisposable
                 FlowName = "PausedFlow"
             });
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/schedules/{jobId}/trigger", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         await _server.TriggerDispatcher.Received(1)
             .EnqueueTriggerAsync(flowId, "cron", Arg.Any<CancellationToken>());
         _server.TriggerDispatcher.DidNotReceive().TriggerOnce(Arg.Any<string>());
     }
 
-    // ═══════════════════════════════════════════════════════════════════════
-    // POST /api/schedules/{jobId}/pause
-    // ═══════════════════════════════════════════════════════════════════════
-
-    /// <summary>
-    /// Pausing a valid job calls <see cref="IRecurringTriggerDispatcher.Remove"/>
-    /// and saves the paused state to the store.
-    /// </summary>
     [Fact]
     public async Task POST_schedules_pause_removes_recurring_job_and_saves_state()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var jobId = JobId(flowId, "cron");
 
@@ -160,37 +133,33 @@ public sealed class ScheduleEndpointTests : IDisposable
             .Returns(new FlowDefinitionRecord { Id = flowId, Name = "DailyFlow", IsEnabled = true });
         _server.ScheduleStateStore.GetAsync(jobId).Returns((FlowScheduleState?)null);
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/schedules/{jobId}/pause", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         _server.TriggerDispatcher.Received(1).Remove(jobId);
         await _server.ScheduleStateStore.Received(1)
             .SaveAsync(Arg.Is<FlowScheduleState>(s => s.JobId == jobId && s.IsPaused));
     }
 
-    /// <summary>
-    /// Returns 400 when the job ID does not follow the <c>flow-{guid}-{key}</c> format.
-    /// </summary>
     [Fact]
     public async Task POST_schedules_pause_returns_400_for_invalid_job_id()
     {
+        // Arrange
+
+        // Act
         var response = await _client.PostAsync("/flows/api/schedules/not-a-valid-job/pause", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         _server.TriggerDispatcher.DidNotReceive().Remove(Arg.Any<string>());
     }
 
-    // ═══════════════════════════════════════════════════════════════════════
-    // POST /api/schedules/{jobId}/resume
-    // ═══════════════════════════════════════════════════════════════════════
-
-    /// <summary>
-    /// Resuming a paused job calls <see cref="IRecurringTriggerDispatcher.RegisterOrUpdate"/>
-    /// with the stored cron override and returns 200.
-    /// </summary>
     [Fact]
     public async Task POST_schedules_resume_registers_recurring_job_with_cron_override()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var jobId = JobId(flowId, "cron");
         const string cron = "*/15 * * * *";
@@ -214,42 +183,36 @@ public sealed class ScheduleEndpointTests : IDisposable
                 CronOverride = cron
             });
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/schedules/{jobId}/resume", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         _server.TriggerDispatcher.Received(1).RegisterOrUpdate(jobId, flowId, "cron", cron);
     }
 
-    /// <summary>
-    /// Returns 404 when the flow referenced by the job ID is not in the store.
-    /// </summary>
     [Fact]
     public async Task POST_schedules_resume_returns_404_when_flow_not_found()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var jobId = JobId(flowId, "cron");
-
         _server.FlowStore.GetByIdAsync(flowId).Returns((FlowDefinitionRecord?)null);
         _server.ScheduleStateStore.GetAsync(jobId).Returns((FlowScheduleState?)null);
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/schedules/{jobId}/resume", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         _server.TriggerDispatcher.DidNotReceive()
             .RegisterOrUpdate(Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>());
     }
 
-    // ═══════════════════════════════════════════════════════════════════════
-    // PUT /api/schedules/{jobId}/cron
-    // ═══════════════════════════════════════════════════════════════════════
-
-    /// <summary>
-    /// Updating the cron expression for an active (non-paused) job calls
-    /// <see cref="IRecurringTriggerDispatcher.RegisterOrUpdate"/> with the new expression.
-    /// </summary>
     [Fact]
     public async Task PUT_schedules_cron_updates_expression_and_calls_RegisterOrUpdate_for_active_job()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var jobId = JobId(flowId, "cron");
         const string newCron = "0 0 * * *";
@@ -265,23 +228,22 @@ public sealed class ScheduleEndpointTests : IDisposable
             });
         _server.ScheduleStateStore.GetAsync(jobId).Returns((FlowScheduleState?)null);
 
+        // Act
         var response = await _client.PutAsync(
             $"/flows/api/schedules/{jobId}/cron",
             JsonBody(new { cronExpression = newCron }));
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         _server.TriggerDispatcher.Received(1).RegisterOrUpdate(jobId, flowId, "cron", newCron);
         await _server.ScheduleStateStore.Received(1)
             .SaveAsync(Arg.Is<FlowScheduleState>(s => s.CronOverride == newCron));
     }
 
-    /// <summary>
-    /// Updating the cron for a paused job saves the new expression but does NOT
-    /// call <see cref="IRecurringTriggerDispatcher.RegisterOrUpdate"/> (job remains removed).
-    /// </summary>
     [Fact]
     public async Task PUT_schedules_cron_saves_override_without_registering_when_paused()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var jobId = JobId(flowId, "cron");
         const string newCron = "0 12 * * 1";
@@ -298,128 +260,124 @@ public sealed class ScheduleEndpointTests : IDisposable
         _server.ScheduleStateStore.GetAsync(jobId)
             .Returns(new FlowScheduleState { JobId = jobId, FlowId = flowId, TriggerKey = "cron", IsPaused = true });
 
+        // Act
         var response = await _client.PutAsync(
             $"/flows/api/schedules/{jobId}/cron",
             JsonBody(new { cronExpression = newCron }));
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         _server.TriggerDispatcher.DidNotReceive()
             .RegisterOrUpdate(Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>());
         await _server.ScheduleStateStore.Received(1)
             .SaveAsync(Arg.Is<FlowScheduleState>(s => s.CronOverride == newCron));
     }
 
-    /// <summary>
-    /// Returns 400 when the request body is missing the <c>cronExpression</c> field.
-    /// </summary>
     [Fact]
     public async Task PUT_schedules_cron_returns_400_when_cronExpression_missing()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var jobId = JobId(flowId, "cron");
 
+        // Act
         var response = await _client.PutAsync(
             $"/flows/api/schedules/{jobId}/cron",
             JsonBody(new { other = "field" }));
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
-    /// <summary>
-    /// Returns 404 when the flow cannot be found in the store.
-    /// </summary>
     [Fact]
     public async Task PUT_schedules_cron_returns_404_when_flow_not_found()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var jobId = JobId(flowId, "cron");
-
         _server.FlowStore.GetByIdAsync(flowId).Returns((FlowDefinitionRecord?)null);
         _server.ScheduleStateStore.GetAsync(jobId).Returns((FlowScheduleState?)null);
 
+        // Act
         var response = await _client.PutAsync(
             $"/flows/api/schedules/{jobId}/cron",
             JsonBody(new { cronExpression = "0 * * * *" }));
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
-    // ═══════════════════════════════════════════════════════════════════════
-    // POST /api/flows/{id}/trigger  (manual trigger endpoint)
-    // ═══════════════════════════════════════════════════════════════════════
-
-    /// <summary>
-    /// Manually triggering a registered flow calls
-    /// <see cref="IFlowOrchestrator.TriggerAsync"/> and returns 200 with a <c>runId</c>.
-    /// </summary>
     [Fact]
     public async Task POST_api_flows_trigger_calls_engine_TriggerAsync_and_returns_200()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var flow = Substitute.For<IFlowDefinition>();
         flow.Id.Returns(flowId);
         flow.Manifest.Returns(new FlowManifest());
         _server.FlowRepository.GetAllFlowsAsync().Returns(new[] { flow });
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/flows/{flowId}/trigger", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         await _server.FlowOrchestrator.Received(1).TriggerAsync(
             Arg.Is<ITriggerContext>(ctx => ctx.Flow.Id == flowId && ctx.Trigger.Key == "manual"),
             Arg.Any<CancellationToken>());
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("runId");
+        Assert.Contains("runId", body);
     }
 
-    /// <summary>
-    /// Returns 404 when the requested flow is not registered in the repository.
-    /// </summary>
     [Fact]
     public async Task POST_api_flows_trigger_returns_404_when_flow_not_found()
     {
+        // Arrange
         _server.FlowRepository.GetAllFlowsAsync().Returns(Array.Empty<IFlowDefinition>());
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/flows/{Guid.NewGuid()}/trigger", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         await _server.FlowOrchestrator.DidNotReceive()
             .TriggerAsync(Arg.Any<ITriggerContext>(), Arg.Any<CancellationToken>());
     }
 
-    /// <summary>
-    /// Returns 400 when the request body contains invalid JSON.
-    /// </summary>
     [Fact]
     public async Task POST_api_flows_trigger_returns_400_for_invalid_json_body()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var flow = Substitute.For<IFlowDefinition>();
         flow.Id.Returns(flowId);
         flow.Manifest.Returns(new FlowManifest());
         _server.FlowRepository.GetAllFlowsAsync().Returns(new[] { flow });
-
         var content = new StringContent("not-json", Encoding.UTF8, "application/json");
+
+        // Act
         var response = await _client.PostAsync($"/flows/api/flows/{flowId}/trigger", content);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
-    /// <summary>
-    /// Passes the JSON body to the trigger context so step handlers can access trigger data.
-    /// </summary>
     [Fact]
     public async Task POST_api_flows_trigger_with_json_body_passes_trigger_data_to_engine()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var flow = Substitute.For<IFlowDefinition>();
         flow.Id.Returns(flowId);
         flow.Manifest.Returns(new FlowManifest());
         _server.FlowRepository.GetAllFlowsAsync().Returns(new[] { flow });
-
         var content = new StringContent("""{"orderId":42}""", Encoding.UTF8, "application/json");
+
+        // Act
         var response = await _client.PostAsync($"/flows/api/flows/{flowId}/trigger", content);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         await _server.FlowOrchestrator.Received(1).TriggerAsync(
             Arg.Is<ITriggerContext>(ctx => ctx.Trigger.Data != null),
             Arg.Any<CancellationToken>());

--- a/tests/FlowOrchestrator.Dashboard.Tests/WebhookEndpointTests.cs
+++ b/tests/FlowOrchestrator.Dashboard.Tests/WebhookEndpointTests.cs
@@ -40,56 +40,69 @@ public sealed class WebhookEndpointTests : IDisposable
     [Fact]
     public async Task POST_webhook_by_guid_returns_200()
     {
+        // Arrange
         var id = Guid.NewGuid();
         var flow = MakeWebhookFlow(id);
         _server.FlowRepository.GetAllFlowsAsync().Returns(new[] { flow });
         _server.FlowStore.GetByIdAsync(id).Returns(new FlowDefinitionRecord { Id = id, IsEnabled = true });
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/webhook/{id}", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         await _server.FlowOrchestrator.Received(1).TriggerAsync(Arg.Any<ITriggerContext>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task POST_webhook_by_slug_returns_200()
     {
+        // Arrange
         var id = Guid.NewGuid();
         var flow = MakeWebhookFlow(id, slug: "order-received");
         _server.FlowRepository.GetAllFlowsAsync().Returns(new[] { flow });
         _server.FlowStore.GetByIdAsync(id).Returns(new FlowDefinitionRecord { Id = id, IsEnabled = true });
 
+        // Act
         var response = await _client.PostAsync("/flows/api/webhook/order-received", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
     public async Task POST_webhook_returns_404_when_flow_not_found()
     {
+        // Arrange
         _server.FlowRepository.GetAllFlowsAsync().Returns(Array.Empty<IFlowDefinition>());
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/webhook/{Guid.NewGuid()}", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
     [Fact]
     public async Task POST_webhook_returns_403_when_flow_disabled()
     {
+        // Arrange
         var id = Guid.NewGuid();
         var flow = MakeWebhookFlow(id);
         _server.FlowRepository.GetAllFlowsAsync().Returns(new[] { flow });
         _server.FlowStore.GetByIdAsync(id).Returns(new FlowDefinitionRecord { Id = id, IsEnabled = false });
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/webhook/{id}", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
     [Fact]
     public async Task POST_webhook_with_correct_secret_header_returns_200()
     {
+        // Arrange
         var id = Guid.NewGuid();
         var flow = MakeWebhookFlow(id, secret: "supersecret");
         _server.FlowRepository.GetAllFlowsAsync().Returns(new[] { flow });
@@ -98,14 +111,17 @@ public sealed class WebhookEndpointTests : IDisposable
         var request = new HttpRequestMessage(HttpMethod.Post, $"/flows/api/webhook/{id}");
         request.Headers.Add("X-Webhook-Key", "supersecret");
 
+        // Act
         var response = await _client.SendAsync(request);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
     public async Task POST_webhook_with_bearer_token_secret_returns_200()
     {
+        // Arrange
         var id = Guid.NewGuid();
         var flow = MakeWebhookFlow(id, secret: "mytoken");
         _server.FlowRepository.GetAllFlowsAsync().Returns(new[] { flow });
@@ -114,14 +130,17 @@ public sealed class WebhookEndpointTests : IDisposable
         var request = new HttpRequestMessage(HttpMethod.Post, $"/flows/api/webhook/{id}");
         request.Headers.Add("Authorization", "Bearer mytoken");
 
+        // Act
         var response = await _client.SendAsync(request);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
     public async Task POST_webhook_with_wrong_secret_returns_401()
     {
+        // Arrange
         var id = Guid.NewGuid();
         var flow = MakeWebhookFlow(id, secret: "correctsecret");
         _server.FlowRepository.GetAllFlowsAsync().Returns(new[] { flow });
@@ -130,35 +149,44 @@ public sealed class WebhookEndpointTests : IDisposable
         var request = new HttpRequestMessage(HttpMethod.Post, $"/flows/api/webhook/{id}");
         request.Headers.Add("X-Webhook-Key", "wrongsecret");
 
+        // Act
         var response = await _client.SendAsync(request);
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
     [Fact]
     public async Task POST_webhook_missing_secret_header_returns_401()
     {
+        // Arrange
         var id = Guid.NewGuid();
         var flow = MakeWebhookFlow(id, secret: "required");
         _server.FlowRepository.GetAllFlowsAsync().Returns(new[] { flow });
         _server.FlowStore.GetByIdAsync(id).Returns(new FlowDefinitionRecord { Id = id, IsEnabled = true });
 
+        // Act
         var response = await _client.PostAsync($"/flows/api/webhook/{id}", null);
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
     [Fact]
     public async Task POST_webhook_with_invalid_json_returns_400()
     {
+        // Arrange
         var id = Guid.NewGuid();
         var flow = MakeWebhookFlow(id);
         _server.FlowRepository.GetAllFlowsAsync().Returns(new[] { flow });
         _server.FlowStore.GetByIdAsync(id).Returns(new FlowDefinitionRecord { Id = id, IsEnabled = true });
 
         var content = new StringContent("not-json", System.Text.Encoding.UTF8, "application/json");
+
+        // Act
         var response = await _client.PostAsync($"/flows/api/webhook/{id}", content);
 
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 }

--- a/tests/FlowOrchestrator.Hangfire.Tests/DefaultStepExecutorTests.cs
+++ b/tests/FlowOrchestrator.Hangfire.Tests/DefaultStepExecutorTests.cs
@@ -5,7 +5,7 @@ using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Configuration;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Storage;
-using FluentAssertions;
+using FlowOrchestrator.Hangfire;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 
@@ -32,20 +32,24 @@ public class DefaultStepExecutorTests
     [Fact]
     public async Task ExecuteAsync_StepMetadataNotFound_ReturnsSkipped()
     {
+        // Arrange
         var flow = CreateFlow(new StepCollection());
         var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
         var step = new StepInstance("missing_step", "SomeType") { RunId = ctx.RunId };
         var executor = CreateExecutor();
 
+        // Act
         var result = await executor.ExecuteAsync(ctx, flow, step);
 
-        result.Status.Should().Be(StepStatus.Skipped);
-        result.FailedReason.Should().Contain("not found");
+        // Assert
+        Assert.Equal(StepStatus.Skipped, result.Status);
+        Assert.Contains("not found", result.FailedReason ?? string.Empty);
     }
 
     [Fact]
     public async Task ExecuteAsync_NoHandlerRegistered_ReturnsSkipped()
     {
+        // Arrange
         var steps = new StepCollection
         {
             ["step1"] = new StepMetadata { Type = "UnknownType" }
@@ -55,15 +59,18 @@ public class DefaultStepExecutorTests
         var step = new StepInstance("step1", "UnknownType") { RunId = ctx.RunId };
         var executor = CreateExecutor();
 
+        // Act
         var result = await executor.ExecuteAsync(ctx, flow, step);
 
-        result.Status.Should().Be(StepStatus.Skipped);
-        result.FailedReason.Should().Contain("No handler");
+        // Assert
+        Assert.Equal(StepStatus.Skipped, result.Status);
+        Assert.Contains("No handler", result.FailedReason ?? string.Empty);
     }
 
     [Fact]
     public async Task ExecuteAsync_HandlerFound_DelegatesToHandler()
     {
+        // Arrange
         var steps = new StepCollection
         {
             ["step1"] = new StepMetadata { Type = "LogMessage" }
@@ -79,16 +86,19 @@ public class DefaultStepExecutorTests
 
         var executor = CreateExecutor(handlerMeta);
 
+        // Act
         var result = await executor.ExecuteAsync(ctx, flow, step);
 
-        result.Status.Should().Be(StepStatus.Succeeded);
-        result.Key.Should().Be("step1");
+        // Assert
+        Assert.Equal(StepStatus.Succeeded, result.Status);
+        Assert.Equal("step1", result.Key);
         await handlerMeta.Received(1).ExecuteAsync(_serviceProvider, ctx, flow, step);
     }
 
     [Fact]
     public async Task ExecuteAsync_SavesStepInput()
     {
+        // Arrange
         var steps = new StepCollection
         {
             ["step1"] = new StepMetadata { Type = "LogMessage" }
@@ -104,14 +114,17 @@ public class DefaultStepExecutorTests
 
         var executor = CreateExecutor(handlerMeta);
 
+        // Act
         await executor.ExecuteAsync(ctx, flow, step);
 
+        // Assert
         await _outputsRepo.Received(1).SaveStepInputAsync(ctx, flow, step);
     }
 
     [Fact]
     public async Task ExecuteAsync_HandlerTypeMatch_IsCaseInsensitive()
     {
+        // Arrange
         var steps = new StepCollection
         {
             ["step1"] = new StepMetadata { Type = "logmessage" }
@@ -127,14 +140,17 @@ public class DefaultStepExecutorTests
 
         var executor = CreateExecutor(handlerMeta);
 
+        // Act
         var result = await executor.ExecuteAsync(ctx, flow, step);
 
-        result.Status.Should().Be(StepStatus.Succeeded);
+        // Assert
+        Assert.Equal(StepStatus.Succeeded, result.Status);
     }
 
     [Fact]
     public async Task ExecuteAsync_ResolvesStandaloneTriggerBodyExpression()
     {
+        // Arrange
         var steps = new StepCollection
         {
             ["step1"] = new StepMetadata { Type = "LogMessage" }
@@ -155,18 +171,20 @@ public class DefaultStepExecutorTests
 
         var executor = CreateExecutor(handlerMeta);
 
+        // Act
         await executor.ExecuteAsync(ctx, flow, step);
 
-        step.Inputs.Should().ContainKey("payload");
-        step.Inputs["payload"].Should().BeOfType<JsonElement>();
-        var payload = (JsonElement)step.Inputs["payload"]!;
-        payload.ValueKind.Should().Be(JsonValueKind.Object);
-        payload.GetProperty("orderId").GetString().Should().Be("ORD-1");
+        // Assert
+        Assert.True(step.Inputs.ContainsKey("payload"));
+        var payload = Assert.IsType<JsonElement>(step.Inputs["payload"]);
+        Assert.Equal(JsonValueKind.Object, payload.ValueKind);
+        Assert.Equal("ORD-1", payload.GetProperty("orderId").GetString());
     }
 
     [Fact]
     public async Task ExecuteAsync_ResolvesStandaloneTriggerBodyExpression_FromJsonElementString()
     {
+        // Arrange
         var steps = new StepCollection
         {
             ["step1"] = new StepMetadata { Type = "LogMessage" }
@@ -190,16 +208,18 @@ public class DefaultStepExecutorTests
 
         var executor = CreateExecutor(handlerMeta);
 
+        // Act
         await executor.ExecuteAsync(ctx, flow, step);
 
-        step.Inputs["payload"].Should().BeOfType<JsonElement>();
-        var payload = (JsonElement)step.Inputs["payload"]!;
-        payload.GetProperty("orderId").GetString().Should().Be("ORD-2");
+        // Assert
+        var payload = Assert.IsType<JsonElement>(step.Inputs["payload"]);
+        Assert.Equal("ORD-2", payload.GetProperty("orderId").GetString());
     }
 
     [Fact]
     public async Task ExecuteAsync_ResolvesTriggerHeadersExpression_ForSpecificHeader()
     {
+        // Arrange
         var steps = new StepCollection
         {
             ["step1"] = new StepMetadata { Type = "LogMessage" }
@@ -226,14 +246,17 @@ public class DefaultStepExecutorTests
 
         var executor = CreateExecutor(handlerMeta);
 
+        // Act
         await executor.ExecuteAsync(ctx, flow, step);
 
-        step.Inputs["requestId"].Should().Be("req-42");
+        // Assert
+        Assert.Equal("req-42", step.Inputs["requestId"]);
     }
 
     [Fact]
     public async Task ExecuteAsync_ResolvesTriggerHeadersExpression_ForAllHeaders()
     {
+        // Arrange
         var steps = new StepCollection
         {
             ["step1"] = new StepMetadata { Type = "LogMessage" }
@@ -261,19 +284,21 @@ public class DefaultStepExecutorTests
 
         var executor = CreateExecutor(handlerMeta);
 
+        // Act
         await executor.ExecuteAsync(ctx, flow, step);
 
-        step.Inputs["headers"].Should().BeOfType<JsonElement>();
-        var headersElement = (JsonElement)step.Inputs["headers"]!;
+        // Assert
+        var headersElement = Assert.IsType<JsonElement>(step.Inputs["headers"]);
         var headerMap = headersElement.EnumerateObject()
             .ToDictionary(p => p.Name, p => p.Value.GetString(), StringComparer.OrdinalIgnoreCase);
-        headerMap["X-Correlation-Id"].Should().Be("corr-1");
-        headerMap["Content-Type"].Should().Be("application/json");
+        Assert.Equal("corr-1", headerMap["X-Correlation-Id"]);
+        Assert.Equal("application/json", headerMap["Content-Type"]);
     }
 
     [Fact]
     public async Task ExecuteAsync_InputContainsUndefinedJsonElement_ResolvesToNull()
     {
+        // Arrange
         var steps = new StepCollection
         {
             ["step1"] = new StepMetadata { Type = "LogMessage" }
@@ -296,15 +321,18 @@ public class DefaultStepExecutorTests
 
         var executor = CreateExecutor(handlerMeta);
 
+        // Act
         var result = await executor.ExecuteAsync(ctx, flow, step);
 
-        result.Status.Should().Be(StepStatus.Succeeded);
-        step.Inputs["payload"].Should().BeNull();
+        // Assert
+        Assert.Equal(StepStatus.Succeeded, result.Status);
+        Assert.Null(step.Inputs["payload"]);
     }
 
     [Fact]
     public async Task ExecuteAsync_GenericHandler_CoercesStringValuesToTypedProperties()
     {
+        // Arrange
         CoercionTypedHandler.Reset();
 
         var services = new ServiceCollection();
@@ -331,18 +359,21 @@ public class DefaultStepExecutorTests
         var metadata = serviceProvider.GetServices<IStepHandlerMetadata>();
         var executor = new DefaultStepExecutor(metadata, serviceProvider, _outputsRepo);
 
+        // Act
         var result = await executor.ExecuteAsync(ctx, flow, step);
 
-        result.Status.Should().Be(StepStatus.Succeeded);
-        CoercionTypedHandler.LastInput.Should().NotBeNull();
-        CoercionTypedHandler.LastInput!.PollEnabled.Should().BeTrue();
-        CoercionTypedHandler.LastInput.PollIntervalSeconds.Should().Be(5);
-        CoercionTypedHandler.LastInput.PollAttempt.Should().Be(2);
+        // Assert
+        Assert.Equal(StepStatus.Succeeded, result.Status);
+        Assert.NotNull(CoercionTypedHandler.LastInput);
+        Assert.True(CoercionTypedHandler.LastInput!.PollEnabled);
+        Assert.Equal(5, CoercionTypedHandler.LastInput.PollIntervalSeconds);
+        Assert.Equal(2, CoercionTypedHandler.LastInput.PollAttempt);
     }
 
     [Fact]
     public async Task ExecuteAsync_GenericHandler_SyncsMutatedInputsBackToStep()
     {
+        // Arrange
         var services = new ServiceCollection();
         services.AddStepHandler<PollStateMutatingHandler>("PollStateMutatingHandler");
         var serviceProvider = services.BuildServiceProvider();
@@ -368,18 +399,21 @@ public class DefaultStepExecutorTests
         var metadata = serviceProvider.GetServices<IStepHandlerMetadata>();
         var executor = new DefaultStepExecutor(metadata, serviceProvider, _outputsRepo);
 
+        // Act
         var result = await executor.ExecuteAsync(ctx, flow, step);
 
-        result.Status.Should().Be(StepStatus.Pending);
-        step.Inputs.Should().ContainKey("__pollAttempt");
-        step.Inputs.Should().ContainKey("__pollStartedAtUtc");
-        ReadInt(step.Inputs["__pollAttempt"]).Should().Be(5);
-        ReadString(step.Inputs["__pollStartedAtUtc"]).Should().Be(PollStateMutatingHandler.NextStartedAtUtc);
+        // Assert
+        Assert.Equal(StepStatus.Pending, result.Status);
+        Assert.True(step.Inputs.ContainsKey("__pollAttempt"));
+        Assert.True(step.Inputs.ContainsKey("__pollStartedAtUtc"));
+        Assert.Equal(5, ReadInt(step.Inputs["__pollAttempt"]));
+        Assert.Equal(PollStateMutatingHandler.NextStartedAtUtc, ReadString(step.Inputs["__pollStartedAtUtc"]));
     }
 
     [Fact]
     public async Task ExecuteAsync_GenericHandler_BindsStrongTypedInput()
     {
+        // Arrange
         GenericTypedHandler.Reset();
 
         var services = new ServiceCollection();
@@ -405,19 +439,22 @@ public class DefaultStepExecutorTests
         var metadata = serviceProvider.GetServices<IStepHandlerMetadata>();
         var executor = new DefaultStepExecutor(metadata, serviceProvider, _outputsRepo);
 
+        // Act
         var result = await executor.ExecuteAsync(ctx, flow, step);
 
-        result.Status.Should().Be(StepStatus.Succeeded);
-        result.Result.Should().Be("JOB-123:4");
-        GenericTypedHandler.ExecutionCount.Should().Be(1);
-        GenericTypedHandler.LastInput.Should().NotBeNull();
-        GenericTypedHandler.LastInput!.JobId.Should().Be("JOB-123");
-        GenericTypedHandler.LastInput.Attempt.Should().Be(4);
+        // Assert
+        Assert.Equal(StepStatus.Succeeded, result.Status);
+        Assert.Equal("JOB-123:4", result.Result);
+        Assert.Equal(1, GenericTypedHandler.ExecutionCount);
+        Assert.NotNull(GenericTypedHandler.LastInput);
+        Assert.Equal("JOB-123", GenericTypedHandler.LastInput!.JobId);
+        Assert.Equal(4, GenericTypedHandler.LastInput.Attempt);
     }
 
     [Fact]
     public async Task ExecuteAsync_GenericHandler_InputDeserializeFailure_ReturnsFailedResult()
     {
+        // Arrange
         GenericTypedHandler.Reset();
 
         var services = new ServiceCollection();
@@ -443,12 +480,14 @@ public class DefaultStepExecutorTests
         var metadata = serviceProvider.GetServices<IStepHandlerMetadata>();
         var executor = new DefaultStepExecutor(metadata, serviceProvider, _outputsRepo);
 
+        // Act
         var result = await executor.ExecuteAsync(ctx, flow, step);
 
-        result.Status.Should().Be(StepStatus.Failed);
-        result.FailedReason.Should().Contain("Failed to deserialize inputs");
-        result.FailedReason.Should().Contain("step1");
-        GenericTypedHandler.ExecutionCount.Should().Be(0);
+        // Assert
+        Assert.Equal(StepStatus.Failed, result.Status);
+        Assert.Contains("Failed to deserialize inputs", result.FailedReason ?? string.Empty);
+        Assert.Contains("step1", result.FailedReason ?? string.Empty);
+        Assert.Equal(0, GenericTypedHandler.ExecutionCount);
     }
 
     private sealed class GenericTypedHandler : IStepHandler<GenericTypedInput>

--- a/tests/FlowOrchestrator.Hangfire.Tests/FlowOrchestrator.Hangfire.Tests.csproj
+++ b/tests/FlowOrchestrator.Hangfire.Tests/FlowOrchestrator.Hangfire.Tests.csproj
@@ -14,7 +14,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageReference Include="coverlet.collector" Version="8.0.1">

--- a/tests/FlowOrchestrator.Hangfire.Tests/FlowOrchestratorBuilderTests.cs
+++ b/tests/FlowOrchestrator.Hangfire.Tests/FlowOrchestratorBuilderTests.cs
@@ -2,7 +2,6 @@ using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Configuration;
 using FlowOrchestrator.Core.Storage;
 using FlowOrchestrator.SqlServer;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FlowOrchestrator.Hangfire.Tests;
@@ -12,62 +11,80 @@ public class FlowOrchestratorBuilderTests
     [Fact]
     public void UseSqlServer_RegistersSqlFlowStore()
     {
+        // Arrange
         var services = new ServiceCollection();
         var builder = new FlowOrchestratorBuilder(services);
 
+        // Act
         builder.UseSqlServer("Server=.;Database=Test");
 
+        // Assert
         var descriptor = services.SingleOrDefault(sd => sd.ServiceType == typeof(IFlowStore));
-        descriptor.Should().NotBeNull();
-        descriptor!.ImplementationFactory.Should().NotBeNull();
-        descriptor.ImplementationFactory!(null!).GetType().Name.Should().Be("SqlFlowStore");
+        Assert.NotNull(descriptor);
+        Assert.NotNull(descriptor!.ImplementationFactory);
+        Assert.Equal("SqlFlowStore", descriptor.ImplementationFactory!(null!).GetType().Name);
     }
 
     [Fact]
     public void UseHangfire_SetsFlag()
     {
+        // Arrange
         var services = new ServiceCollection();
         var builder = new FlowOrchestratorBuilder(services);
 
+        // Act
         builder.UseHangfire();
 
-        builder.HangfireEnabled.Should().BeTrue();
+        // Assert
+        Assert.True(builder.HangfireEnabled);
     }
 
     [Fact]
     public void AddFlow_RegistersFlowDefinition()
     {
+        // Arrange
         var services = new ServiceCollection();
         var builder = new FlowOrchestratorBuilder(services);
 
+        // Act
         builder.AddFlow<TestFlow>();
 
+        // Assert
         var sp = services.BuildServiceProvider();
         var flows = sp.GetServices<IFlowDefinition>();
-        flows.Should().ContainSingle().Which.Should().BeOfType<TestFlow>();
+        var flow = Assert.Single(flows);
+        Assert.IsType<TestFlow>(flow);
     }
 
     [Fact]
     public void FluentChaining_Works()
     {
+        // Arrange
         var services = new ServiceCollection();
         var builder = new FlowOrchestratorBuilder(services);
 
+        // Act
         var result = builder
             .UseSqlServer("Server=.")
             .UseHangfire()
             .AddFlow<TestFlow>();
 
-        result.Should().BeSameAs(builder);
+        // Assert
+        Assert.Same(builder, result);
     }
 
     [Fact]
     public void Services_IsExposedCorrectly()
     {
+        // Arrange
         var services = new ServiceCollection();
         var builder = new FlowOrchestratorBuilder(services);
 
-        builder.Services.Should().BeSameAs(services);
+        // Act
+        var exposed = builder.Services;
+
+        // Assert
+        Assert.Same(services, exposed);
     }
 
     private class TestFlow : IFlowDefinition

--- a/tests/FlowOrchestrator.Hangfire.Tests/FlowOrchestratorServiceCollectionExtensionsTests.cs
+++ b/tests/FlowOrchestrator.Hangfire.Tests/FlowOrchestratorServiceCollectionExtensionsTests.cs
@@ -2,7 +2,6 @@ using FlowOrchestrator.Core.Storage;
 using FlowOrchestrator.Hangfire;
 using FlowOrchestrator.InMemory;
 using FlowOrchestrator.SqlServer;
-using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FlowOrchestrator.Hangfire.Tests;
@@ -14,12 +13,15 @@ public class FlowOrchestratorServiceCollectionExtensionsTests
     [Fact]
     public void AddFlowOrchestrator_WithNoBackend_ThrowsInvalidOperationException()
     {
+        // Arrange
         var services = new ServiceCollection();
 
+        // Act
         var act = () => services.AddFlowOrchestrator(_ => { });
 
-        act.Should().Throw<InvalidOperationException>()
-           .WithMessage("*No FlowOrchestrator storage backend registered*");
+        // Assert
+        var ex = Assert.Throws<InvalidOperationException>(act);
+        Assert.Contains("No FlowOrchestrator storage backend registered", ex.Message);
     }
 
     // ─── InMemory backend ─────────────────────────────────────────────────────
@@ -27,42 +29,61 @@ public class FlowOrchestratorServiceCollectionExtensionsTests
     [Fact]
     public void AddFlowOrchestrator_WithUseInMemory_RegistersInMemoryFlowStore()
     {
+        // Arrange
         var services = new ServiceCollection();
         services.AddFlowOrchestrator(b => b.UseInMemory());
 
+        // Act
         using var provider = services.BuildServiceProvider();
-        provider.GetRequiredService<IFlowStore>().Should().BeOfType<InMemoryFlowStore>();
+        var store = provider.GetRequiredService<IFlowStore>();
+
+        // Assert
+        Assert.IsType<InMemoryFlowStore>(store);
     }
 
     [Fact]
     public void AddFlowOrchestrator_WithUseInMemory_RegistersInMemoryFlowRunStore()
     {
+        // Arrange
         var services = new ServiceCollection();
         services.AddFlowOrchestrator(b => b.UseInMemory());
 
+        // Act
         using var provider = services.BuildServiceProvider();
-        provider.GetRequiredService<IFlowRunStore>().Should().BeOfType<InMemoryFlowRunStore>();
+        var runStore = provider.GetRequiredService<IFlowRunStore>();
+
+        // Assert
+        Assert.IsType<InMemoryFlowRunStore>(runStore);
     }
 
     [Fact]
     public void AddFlowOrchestrator_WithUseInMemory_RegistersInMemoryOutputsRepository()
     {
+        // Arrange
         var services = new ServiceCollection();
         services.AddFlowOrchestrator(b => b.UseInMemory());
 
+        // Act
         using var provider = services.BuildServiceProvider();
-        provider.GetRequiredService<IOutputsRepository>().Should().BeOfType<InMemoryOutputsRepository>();
+        var repo = provider.GetRequiredService<IOutputsRepository>();
+
+        // Assert
+        Assert.IsType<InMemoryOutputsRepository>(repo);
     }
 
     [Fact]
     public void AddFlowOrchestrator_WithUseInMemory_ExactlyOneOfEachServiceRegistered()
     {
+        // Arrange
         var services = new ServiceCollection();
+
+        // Act
         services.AddFlowOrchestrator(b => b.UseInMemory());
 
-        services.Where(sd => sd.ServiceType == typeof(IFlowStore)).Should().ContainSingle();
-        services.Where(sd => sd.ServiceType == typeof(IFlowRunStore)).Should().ContainSingle();
-        services.Where(sd => sd.ServiceType == typeof(IOutputsRepository)).Should().ContainSingle();
+        // Assert
+        Assert.Single(services.Where(sd => sd.ServiceType == typeof(IFlowStore)));
+        Assert.Single(services.Where(sd => sd.ServiceType == typeof(IFlowRunStore)));
+        Assert.Single(services.Where(sd => sd.ServiceType == typeof(IOutputsRepository)));
     }
 
     // ─── SQL Server backend ───────────────────────────────────────────────────
@@ -70,43 +91,64 @@ public class FlowOrchestratorServiceCollectionExtensionsTests
     [Fact]
     public void AddFlowOrchestrator_WithUseSqlServer_RegistersSqlFlowStore()
     {
+        // Arrange
         var services = new ServiceCollection();
         services.AddFlowOrchestrator(b => b.UseSqlServer("Server=.;Database=Test"));
 
+        // Act
         using var provider = services.BuildServiceProvider();
-        provider.GetRequiredService<IFlowStore>().GetType().Name.Should().Be("SqlFlowStore");
+        var store = provider.GetRequiredService<IFlowStore>();
+
+        // Assert
+        Assert.Equal("SqlFlowStore", store.GetType().Name);
     }
 
     [Fact]
     public void AddFlowOrchestrator_WithUseSqlServer_RegistersSqlFlowRunStore()
     {
+        // Arrange
         var services = new ServiceCollection();
         services.AddFlowOrchestrator(b => b.UseSqlServer("Server=.;Database=Test"));
 
+        // Act
         using var provider = services.BuildServiceProvider();
-        provider.GetRequiredService<IFlowRunStore>().GetType().Name.Should().Be("SqlFlowRunStore");
+        var runStore = provider.GetRequiredService<IFlowRunStore>();
+
+        // Assert
+        Assert.Equal("SqlFlowRunStore", runStore.GetType().Name);
     }
 
     [Fact]
     public void AddFlowOrchestrator_WithUseSqlServer_RegistersSqlOutputsRepository()
     {
+        // Arrange
         var services = new ServiceCollection();
         services.AddFlowOrchestrator(b => b.UseSqlServer("Server=.;Database=Test"));
 
+        // Act
         using var provider = services.BuildServiceProvider();
-        provider.GetRequiredService<IOutputsRepository>().GetType().Name.Should().Be("SqlOutputsRepository");
+        var repo = provider.GetRequiredService<IOutputsRepository>();
+
+        // Assert
+        Assert.Equal("SqlOutputsRepository", repo.GetType().Name);
     }
 
     [Fact]
     public void AddFlowOrchestrator_WithUseSqlServer_DoesNotRegisterInMemoryTypes()
     {
+        // Arrange
         var services = new ServiceCollection();
+
+        // Act
         services.AddFlowOrchestrator(b => b.UseSqlServer("Server=.;Database=Test"));
 
-        services.Where(sd => sd.ServiceType == typeof(IFlowStore)).Should().ContainSingle();
+        // Assert
+        Assert.Single(services.Where(sd => sd.ServiceType == typeof(IFlowStore)));
 
         var storeDescriptor = services.Single(sd => sd.ServiceType == typeof(IFlowStore));
         if (storeDescriptor.ImplementationType is not null)
-            storeDescriptor.ImplementationType.Should().NotBe(typeof(InMemoryFlowStore));
+        {
+            Assert.NotEqual(typeof(InMemoryFlowStore), storeDescriptor.ImplementationType);
+        }
     }
 }

--- a/tests/FlowOrchestrator.Hangfire.Tests/FlowSyncHostedServiceTests.cs
+++ b/tests/FlowOrchestrator.Hangfire.Tests/FlowSyncHostedServiceTests.cs
@@ -3,7 +3,6 @@ using FlowOrchestrator.Core.Configuration;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Storage;
 using FlowOrchestrator.Hangfire;
-using FluentAssertions;
 using Hangfire;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -26,6 +25,7 @@ public class FlowSyncHostedServiceTests
     [Fact]
     public async Task StartAsync_SyncsFlowsToStore()
     {
+        // Arrange
         var flow = Substitute.For<IFlowDefinition>();
         flow.Id.Returns(Guid.NewGuid());
         flow.Version.Returns("1.0");
@@ -46,8 +46,10 @@ public class FlowSyncHostedServiceTests
 
         var sut = CreateSut(repository, store);
 
+        // Act
         await sut.StartAsync(CancellationToken.None);
 
+        // Assert
         await store.Received(1).SaveAsync(Arg.Is<FlowDefinitionRecord>(r =>
             r.Id == flow.Id && r.Version == "1.0" && r.ManifestJson != null));
     }
@@ -55,6 +57,7 @@ public class FlowSyncHostedServiceTests
     [Fact]
     public async Task StartAsync_UpdatesExistingFlow()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var flow = Substitute.For<IFlowDefinition>();
         flow.Id.Returns(flowId);
@@ -83,8 +86,10 @@ public class FlowSyncHostedServiceTests
 
         var sut = CreateSut(repository, store);
 
+        // Act
         await sut.StartAsync(CancellationToken.None);
 
+        // Assert
         await store.Received(1).SaveAsync(Arg.Is<FlowDefinitionRecord>(r =>
             r.Id == flowId && r.Version == "2.0"));
     }
@@ -92,6 +97,7 @@ public class FlowSyncHostedServiceTests
     [Fact]
     public async Task StartAsync_FlowSyncFailure_Throws()
     {
+        // Arrange
         var flow = Substitute.For<IFlowDefinition>();
         flow.Id.Returns(Guid.NewGuid());
         flow.Manifest.Returns(new FlowManifest());
@@ -104,26 +110,33 @@ public class FlowSyncHostedServiceTests
 
         var sut = CreateSut(repository, store);
 
+        // Act
         var act = () => sut.StartAsync(CancellationToken.None);
 
-        await act.Should().ThrowAsync<Exception>();
+        // Assert
+        var ex = await Record.ExceptionAsync(act);
+        Assert.NotNull(ex);
     }
 
     [Fact]
     public async Task StopAsync_CompletesImmediately()
     {
+        // Arrange
         var repository = Substitute.For<IFlowRepository>();
         var store = Substitute.For<IFlowStore>();
         var sut = CreateSut(repository, store);
 
-        var act = () => sut.StopAsync(CancellationToken.None);
+        // Act
+        var ex = await Record.ExceptionAsync(() => sut.StopAsync(CancellationToken.None));
 
-        await act.Should().NotThrowAsync();
+        // Assert
+        Assert.Null(ex);
     }
 
     [Fact]
     public async Task StartAsync_RegistersRecurringJobForCronTrigger()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var flow = Substitute.For<IFlowDefinition>();
         flow.Id.Returns(flowId);
@@ -154,8 +167,10 @@ public class FlowSyncHostedServiceTests
 
         var sut = CreateSut(repository, store);
 
+        // Act
         await sut.StartAsync(CancellationToken.None);
 
+        // Assert
         _recurringJobManager.Received(1).AddOrUpdate(
             $"flow-{flowId}-scheduled",
             Arg.Any<global::Hangfire.Common.Job>(),
@@ -166,6 +181,7 @@ public class FlowSyncHostedServiceTests
     [Fact]
     public async Task StartAsync_RemovesRecurringJobForDisabledFlow()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var flow = Substitute.For<IFlowDefinition>();
         flow.Id.Returns(flowId);
@@ -196,14 +212,17 @@ public class FlowSyncHostedServiceTests
 
         var sut = CreateSut(repository, store);
 
+        // Act
         await sut.StartAsync(CancellationToken.None);
 
+        // Assert
         _recurringJobManager.Received(1).RemoveIfExists($"flow-{flowId}-scheduled");
     }
 
     [Fact]
     public async Task StartAsync_RespectsPausedScheduleState()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var flow = Substitute.For<IFlowDefinition>();
         flow.Id.Returns(flowId);
@@ -233,8 +252,10 @@ public class FlowSyncHostedServiceTests
 
         var sut = CreateSut(repository, store);
 
+        // Act
         await sut.StartAsync(CancellationToken.None);
 
+        // Assert
         _recurringJobManager.Received(1).RemoveIfExists($"flow-{flowId}-scheduled");
         _recurringJobManager.DidNotReceive().AddOrUpdate(
             Arg.Any<string>(),
@@ -246,6 +267,7 @@ public class FlowSyncHostedServiceTests
     [Fact]
     public async Task StartAsync_UsesCronOverride_WhenPresent()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var flow = Substitute.For<IFlowDefinition>();
         flow.Id.Returns(flowId);
@@ -280,8 +302,10 @@ public class FlowSyncHostedServiceTests
 
         var sut = CreateSut(repository, store);
 
+        // Act
         await sut.StartAsync(CancellationToken.None);
 
+        // Assert
         _recurringJobManager.Received(1).AddOrUpdate(
             $"flow-{flowId}-scheduled",
             Arg.Any<global::Hangfire.Common.Job>(),
@@ -292,6 +316,7 @@ public class FlowSyncHostedServiceTests
     [Fact]
     public async Task StartAsync_InvalidGraph_Throws()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var flow = Substitute.For<IFlowDefinition>();
         flow.Id.Returns(flowId);
@@ -312,8 +337,10 @@ public class FlowSyncHostedServiceTests
 
         var sut = CreateSut(repository, store);
 
+        // Act
         var act = () => sut.StartAsync(CancellationToken.None);
 
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        // Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
     }
 }

--- a/tests/FlowOrchestrator.Hangfire.Tests/HangfireAdapterTests.cs
+++ b/tests/FlowOrchestrator.Hangfire.Tests/HangfireAdapterTests.cs
@@ -1,7 +1,6 @@
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Hangfire;
-using FluentAssertions;
 using Hangfire;
 using Hangfire.Common;
 using Hangfire.States;
@@ -13,17 +12,11 @@ namespace FlowOrchestrator.Hangfire.Tests;
 /// Unit tests for the three Hangfire adapter classes introduced in the v2.0 refactor:
 /// <see cref="HangfireStepDispatcher"/>, <see cref="HangfireRecurringTriggerDispatcher"/>,
 /// and <see cref="HangfireRecurringTriggerInspector"/>.
-/// All classes are <c>internal sealed</c>; the <c>InternalsVisibleTo</c> attribute on
-/// <c>FlowOrchestrator.Hangfire.csproj</c> makes them accessible from this test project.
 /// </summary>
 public sealed class HangfireAdapterTests
 {
-    // ── shared mocks ──────────────────────────────────────────────────────────
-
     private readonly IBackgroundJobClient _jobClient = Substitute.For<IBackgroundJobClient>();
     private readonly IRecurringJobManager _recurringManager = Substitute.For<IRecurringJobManager>();
-
-    // ── helpers ──────────────────────────────────────────────────────────────
 
     private static Core.Execution.ExecutionContext MakeContext() =>
         new() { RunId = Guid.NewGuid() };
@@ -42,137 +35,117 @@ public sealed class HangfireAdapterTests
     private static StepInstance MakeStep(Core.Execution.ExecutionContext ctx) =>
         new("step1", "DoWork") { RunId = ctx.RunId };
 
-    // ═════════════════════════════════════════════════════════════════════════
-    // HangfireStepDispatcher
-    // ═════════════════════════════════════════════════════════════════════════
-
-    /// <summary>
-    /// <see cref="HangfireStepDispatcher.EnqueueStepAsync"/> must call <see cref="IBackgroundJobClient.Create"/>
-    /// with an <see cref="EnqueuedState"/> and return the job ID produced by Hangfire.
-    /// </summary>
     [Fact]
     public async Task EnqueueStepAsync_CallsBackgroundJobClientCreate_WithEnqueuedState()
     {
-        // IBackgroundJobClient.Enqueue<T>() is an extension that delegates to IBackgroundJobClient.Create().
+        // Arrange
         const string expectedJobId = "job-enqueue-42";
         _jobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns(expectedJobId);
-
         var sut = new HangfireStepDispatcher(_jobClient);
         var ctx = MakeContext();
         var flow = MakeFlow();
         var step = MakeStep(ctx);
 
+        // Act
         var result = await sut.EnqueueStepAsync(ctx, flow, step, CancellationToken.None);
 
-        result.Should().Be(expectedJobId);
+        // Assert
+        Assert.Equal(expectedJobId, result);
         _jobClient.Received(1).Create(
             Arg.Any<Job>(),
             Arg.Is<IState>(s => s is EnqueuedState));
     }
 
-    /// <summary>
-    /// <see cref="HangfireStepDispatcher.ScheduleStepAsync"/> must call <see cref="IBackgroundJobClient.Create"/>
-    /// with a <see cref="ScheduledState"/> whose delay matches the requested delay.
-    /// </summary>
     [Fact]
     public async Task ScheduleStepAsync_CallsBackgroundJobClientCreate_WithScheduledState()
     {
+        // Arrange
         const string expectedJobId = "job-scheduled-99";
         _jobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns(expectedJobId);
-
         var sut = new HangfireStepDispatcher(_jobClient);
         var ctx = MakeContext();
         var flow = MakeFlow();
         var step = MakeStep(ctx);
         var delay = TimeSpan.FromSeconds(30);
 
+        // Act
         var result = await sut.ScheduleStepAsync(ctx, flow, step, delay, CancellationToken.None);
 
-        result.Should().Be(expectedJobId);
+        // Assert
+        Assert.Equal(expectedJobId, result);
         _jobClient.Received(1).Create(
             Arg.Any<Job>(),
             Arg.Is<IState>(s => s is ScheduledState));
     }
 
-    /// <summary>
-    /// <see cref="HangfireStepDispatcher.EnqueueStepAsync"/> targets <see cref="IHangfireStepRunner"/>
-    /// as the job type, not any other interface.
-    /// </summary>
     [Fact]
     public async Task EnqueueStepAsync_JobTargetsIHangfireStepRunner()
     {
+        // Arrange
         _jobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("job-123");
-
         var sut = new HangfireStepDispatcher(_jobClient);
         var ctx = MakeContext();
         var flow = MakeFlow();
         var step = MakeStep(ctx);
 
+        // Act
         await sut.EnqueueStepAsync(ctx, flow, step, CancellationToken.None);
 
+        // Assert
         _jobClient.Received(1).Create(
             Arg.Is<Job>(j => j.Type == typeof(IHangfireStepRunner)),
             Arg.Any<IState>());
     }
 
-    /// <summary>
-    /// <see cref="HangfireStepDispatcher.ScheduleStepAsync"/> targets <see cref="IHangfireStepRunner"/>
-    /// as the job type, not any other interface.
-    /// </summary>
     [Fact]
     public async Task ScheduleStepAsync_JobTargetsIHangfireStepRunner()
     {
+        // Arrange
         _jobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("job-456");
-
         var sut = new HangfireStepDispatcher(_jobClient);
         var ctx = MakeContext();
         var flow = MakeFlow();
         var step = MakeStep(ctx);
 
+        // Act
         await sut.ScheduleStepAsync(ctx, flow, step, TimeSpan.FromSeconds(5), CancellationToken.None);
 
+        // Assert
         _jobClient.Received(1).Create(
             Arg.Is<Job>(j => j.Type == typeof(IHangfireStepRunner)),
             Arg.Any<IState>());
     }
 
-    /// <summary>
-    /// Returns the job ID string produced by <see cref="IBackgroundJobClient.Create"/> for scheduled steps.
-    /// A <see langword="null"/> return from the client propagates correctly.
-    /// </summary>
     [Fact]
     public async Task ScheduleStepAsync_ReturnsNullWhenClientReturnsNull()
     {
+        // Arrange
         _jobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns((string)null!);
-
         var sut = new HangfireStepDispatcher(_jobClient);
         var ctx = MakeContext();
         var flow = MakeFlow();
         var step = MakeStep(ctx);
 
+        // Act
         var result = await sut.ScheduleStepAsync(ctx, flow, step, TimeSpan.FromSeconds(1), CancellationToken.None);
 
-        result.Should().BeNull();
+        // Assert
+        Assert.Null(result);
     }
 
-    // ═════════════════════════════════════════════════════════════════════════
-    // HangfireRecurringTriggerDispatcher
-    // ═════════════════════════════════════════════════════════════════════════
-
-    /// <summary>
-    /// <see cref="HangfireRecurringTriggerDispatcher.RegisterOrUpdate"/> must delegate to
-    /// <see cref="IRecurringJobManager.AddOrUpdate"/> with the correct job ID and cron expression.
-    /// </summary>
     [Fact]
     public void RegisterOrUpdate_DelegatesToRecurringJobManager_AddOrUpdate()
     {
+        // Arrange
         var sut = new HangfireRecurringTriggerDispatcher(_recurringManager, _jobClient);
         var flowId = Guid.NewGuid();
         const string jobId = "flow-test-job-cron";
         const string cron = "0 * * * *";
 
+        // Act
         sut.RegisterOrUpdate(jobId, flowId, "cron", cron);
 
+        // Assert
         _recurringManager.Received(1).AddOrUpdate(
             jobId,
             Arg.Any<Job>(),
@@ -180,18 +153,17 @@ public sealed class HangfireAdapterTests
             Arg.Any<RecurringJobOptions>());
     }
 
-    /// <summary>
-    /// <see cref="HangfireRecurringTriggerDispatcher.RegisterOrUpdate"/> targets
-    /// <see cref="IHangfireFlowTrigger"/> so that the correct handler is invoked at schedule time.
-    /// </summary>
     [Fact]
     public void RegisterOrUpdate_JobTargetsIHangfireFlowTrigger()
     {
+        // Arrange
         var sut = new HangfireRecurringTriggerDispatcher(_recurringManager, _jobClient);
         var flowId = Guid.NewGuid();
 
+        // Act
         sut.RegisterOrUpdate("flow-abc-cron", flowId, "cron", "*/5 * * * *");
 
+        // Assert
         _recurringManager.Received(1).AddOrUpdate(
             Arg.Any<string>(),
             Arg.Is<Job>(j => j.Type == typeof(IHangfireFlowTrigger)),
@@ -199,69 +171,63 @@ public sealed class HangfireAdapterTests
             Arg.Any<RecurringJobOptions>());
     }
 
-    /// <summary>
-    /// <see cref="HangfireRecurringTriggerDispatcher.Remove"/> must delegate to
-    /// <see cref="IRecurringJobManager.RemoveIfExists"/> with the provided job ID.
-    /// </summary>
     [Fact]
     public void Remove_DelegatesToRecurringJobManager_RemoveIfExists()
     {
+        // Arrange
         var sut = new HangfireRecurringTriggerDispatcher(_recurringManager, _jobClient);
         const string jobId = "flow-to-remove";
 
+        // Act
         sut.Remove(jobId);
 
+        // Assert
         _recurringManager.Received(1).RemoveIfExists(jobId);
     }
 
-    /// <summary>
-    /// <see cref="HangfireRecurringTriggerDispatcher.TriggerOnce"/> must delegate to
-    /// <see cref="IRecurringJobManager.Trigger"/> with the provided job ID.
-    /// </summary>
     [Fact]
     public void TriggerOnce_DelegatesToRecurringJobManager_Trigger()
     {
+        // Arrange
         var sut = new HangfireRecurringTriggerDispatcher(_recurringManager, _jobClient);
         const string jobId = "flow-to-fire-once";
 
+        // Act
         sut.TriggerOnce(jobId);
 
+        // Assert
         _recurringManager.Received(1).Trigger(jobId);
     }
 
-    /// <summary>
-    /// <see cref="HangfireRecurringTriggerDispatcher.EnqueueTriggerAsync"/> must delegate to
-    /// <see cref="IBackgroundJobClient.Create"/> to enqueue an immediate one-off trigger job
-    /// targeting <see cref="IHangfireFlowTrigger"/>.
-    /// </summary>
     [Fact]
     public async Task EnqueueTriggerAsync_DelegatesToBackgroundJobClient_Enqueue()
     {
+        // Arrange
         _jobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("one-off-job-id");
-
         var sut = new HangfireRecurringTriggerDispatcher(_recurringManager, _jobClient);
         var flowId = Guid.NewGuid();
 
+        // Act
         await sut.EnqueueTriggerAsync(flowId, "cron");
 
+        // Assert
         _jobClient.Received(1).Create(
             Arg.Is<Job>(j => j.Type == typeof(IHangfireFlowTrigger)),
             Arg.Is<IState>(s => s is EnqueuedState));
     }
 
-    /// <summary>
-    /// <see cref="HangfireRecurringTriggerDispatcher.EnqueueTriggerAsync"/> returns a completed
-    /// <see cref="Task"/> regardless of whether Hangfire assigns a job ID.
-    /// </summary>
     [Fact]
     public async Task EnqueueTriggerAsync_CompletesSuccessfully()
     {
+        // Arrange
         _jobClient.Create(Arg.Any<Job>(), Arg.Any<IState>()).Returns("trigger-job-id");
-
         var sut = new HangfireRecurringTriggerDispatcher(_recurringManager, _jobClient);
-
         var act = () => sut.EnqueueTriggerAsync(Guid.NewGuid(), "cron");
 
-        await act.Should().NotThrowAsync();
+        // Act
+        var ex = await Record.ExceptionAsync(act);
+
+        // Assert
+        Assert.Null(ex);
     }
 }

--- a/tests/FlowOrchestrator.Hangfire.Tests/HangfireFlowOrchestratorTests.cs
+++ b/tests/FlowOrchestrator.Hangfire.Tests/HangfireFlowOrchestratorTests.cs
@@ -3,7 +3,7 @@ using FlowOrchestrator.Core.Configuration;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Storage;
 using FlowOrchestrator.Hangfire;
-using FluentAssertions;
+using Hangfire;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -67,6 +67,7 @@ public class HangfireFlowOrchestratorTests
     [Fact]
     public async Task TriggerAsync_AssignsRunId_WhenEmpty()
     {
+        // Arrange
         var sut = CreateSut();
         var flow = CreateFlow();
         _runStore.StartRunAsync(default, default!, default, default!, default, default)
@@ -79,14 +80,17 @@ public class HangfireFlowOrchestratorTests
             Trigger = new Trigger("manual", "Manual", null)
         };
 
+        // Act
         await sut.TriggerAsync(ctx);
 
-        ctx.RunId.Should().NotBe(Guid.Empty);
+        // Assert
+        Assert.NotEqual(Guid.Empty, ctx.RunId);
     }
 
     [Fact]
     public async Task TriggerAsync_StartsRunInStore_AndEnqueuesEntryStep()
     {
+        // Arrange
         var sut = CreateSut();
         var flow = CreateFlow();
         var runId = Guid.NewGuid();
@@ -101,8 +105,10 @@ public class HangfireFlowOrchestratorTests
             Trigger = new Trigger("manual", "Manual", null)
         };
 
+        // Act
         await sut.TriggerAsync(ctx);
 
+        // Assert
         await _runStore.Received(1).StartRunAsync(
             flow.Id,
             Arg.Any<string>(),
@@ -110,12 +116,13 @@ public class HangfireFlowOrchestratorTests
             "manual",
             Arg.Any<string?>(),
             Arg.Any<string?>());
-        _dispatcher.ReceivedCalls().Should().NotBeEmpty();
+        Assert.NotEmpty(_dispatcher.ReceivedCalls());
     }
 
     [Fact]
     public async Task TriggerAsync_ClearsContextAccessor()
     {
+        // Arrange
         var sut = CreateSut();
         var flow = CreateFlow();
         _runStore.StartRunAsync(default, default!, default, default!, default, default)
@@ -128,14 +135,17 @@ public class HangfireFlowOrchestratorTests
             Trigger = new Trigger("manual", "Manual", null)
         };
 
+        // Act
         await sut.TriggerAsync(ctx);
 
-        _ctxAccessor.CurrentContext.Should().BeNull();
+        // Assert
+        Assert.Null(_ctxAccessor.CurrentContext);
     }
 
     [Fact]
     public async Task RunStepAsync_ExecutesStepAndSavesOutput()
     {
+        // Arrange
         var sut = CreateSut();
         var flow = CreateFlow();
         var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
@@ -145,14 +155,17 @@ public class HangfireFlowOrchestratorTests
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
         _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns((IStepInstance?)null);
 
+        // Act
         await sut.RunStepAsync(ctx, flow, step);
 
+        // Assert
         await _outputsRepo.Received(1).SaveStepOutputAsync(ctx, flow, step, stepResult);
     }
 
     [Fact]
     public async Task RunStepAsync_PendingStatus_ReschedulesCurrentStep()
     {
+        // Arrange
         var sut = CreateSut();
         var flow = CreateFlow();
         var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
@@ -166,16 +179,19 @@ public class HangfireFlowOrchestratorTests
         };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
 
+        // Act
         await sut.RunStepAsync(ctx, flow, step);
 
+        // Assert
         await _runStore.Received(1).RecordStepCompleteAsync(
             ctx.RunId, "step1", "Pending", Arg.Any<string?>(), Arg.Any<string?>());
-        _dispatcher.ReceivedCalls().Should().NotBeEmpty();
+        Assert.NotEmpty(_dispatcher.ReceivedCalls());
     }
 
     [Fact]
     public async Task RunStepAsync_CompletesRunWhenNoNextStep_LegacyPath()
     {
+        // Arrange
         var sut = CreateSut();
         var flow = CreateFlow();
         var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
@@ -185,14 +201,17 @@ public class HangfireFlowOrchestratorTests
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
         _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns((IStepInstance?)null);
 
+        // Act
         await sut.RunStepAsync(ctx, flow, step);
 
+        // Assert
         await _runStore.Received(1).CompleteRunAsync(ctx.RunId, "Succeeded");
     }
 
     [Fact]
     public async Task RunStepAsync_ReThrowTrue_ThrowsException()
     {
+        // Arrange
         var sut = CreateSut();
         var flow = CreateFlow();
         var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
@@ -202,14 +221,18 @@ public class HangfireFlowOrchestratorTests
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
         _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns((IStepInstance?)null);
 
+        // Act
         var act = () => sut.RunStepAsync(ctx, flow, step).AsTask();
 
-        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("critical");
+        // Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(act);
+        Assert.Contains("critical", ex.Message);
     }
 
     [Fact]
     public async Task TriggerAsync_RunStoreFailure_DoesNotThrow()
     {
+        // Arrange
         var sut = CreateSut();
         var flow = CreateFlow();
 
@@ -223,14 +246,17 @@ public class HangfireFlowOrchestratorTests
             Trigger = new Trigger("manual", "Manual", null)
         };
 
-        var act = () => sut.TriggerAsync(ctx).AsTask();
+        // Act
+        var ex = await Record.ExceptionAsync(() => sut.TriggerAsync(ctx).AsTask());
 
-        await act.Should().NotThrowAsync();
+        // Assert
+        Assert.Null(ex);
     }
 
     [Fact]
     public async Task TriggerAsync_IdempotencyDuplicate_ReturnsExistingRun()
     {
+        // Arrange
         var controlStore = Substitute.For<IFlowRunControlStore>();
         var existingRunId = Guid.NewGuid();
         controlStore.FindRunIdByIdempotencyKeyAsync(Arg.Any<Guid>(), "manual", "dup-key")
@@ -249,16 +275,19 @@ public class HangfireFlowOrchestratorTests
             Trigger = new Trigger("manual", "Manual", null, headers)
         };
 
+        // Act
         var result = await sut.TriggerAsync(ctx);
 
-        ctx.RunId.Should().Be(existingRunId);
-        result.Should().NotBeNull();
-        _dispatcher.ReceivedCalls().Should().BeEmpty();
+        // Assert
+        Assert.Equal(existingRunId, ctx.RunId);
+        Assert.NotNull(result);
+        Assert.Empty(_dispatcher.ReceivedCalls());
     }
 
     [Fact]
     public async Task RunStepAsync_CancelRequested_SkipsStepAndCompletesRun()
     {
+        // Arrange
         var runtimeStore = Substitute.For<IFlowRunRuntimeStore>();
         runtimeStore.GetStepStatusesAsync(Arg.Any<Guid>())
             .Returns(new Dictionary<string, StepStatus>());
@@ -274,8 +303,10 @@ public class HangfireFlowOrchestratorTests
         var ctx = new Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
         var step = new StepInstance("step1", "LogMessage") { RunId = ctx.RunId };
 
+        // Act
         await sut.RunStepAsync(ctx, flow, step);
 
+        // Assert
         await _runStore.Received(1).CompleteRunAsync(ctx.RunId, "Cancelled");
     }
 
@@ -311,18 +342,13 @@ public class HangfireFlowOrchestratorTests
         var failedResult = new StepResult { Key = "step1", Status = StepStatus.Failed, FailedReason = "Input validation failed." };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(failedResult);
 
-        // Both calls to GetStepStatusesAsync return the post-execution state:
-        // step1 = Failed, step2 = Skipped (already recorded by a prior worker call).
         IReadOnlyDictionary<string, StepStatus> statuses = new Dictionary<string, StepStatus>
         {
             ["step1"] = StepStatus.Failed,
             ["step2"] = StepStatus.Skipped
         };
         runtimeStore.GetStepStatusesAsync(runId).Returns(statuses);
-        // No step is still in-flight and no step is claimed but unrecorded.
         runtimeStore.GetClaimedStepKeysAsync(runId).Returns((IReadOnlyCollection<string>)Array.Empty<string>());
-        // TryClaimStepAsync — step2 is already recorded Skipped so graph evaluation won't put it in BlockedStepKeys;
-        // but if the planner does try to claim it, return false (already done).
         runtimeStore.TryClaimStepAsync(runId, Arg.Any<string>()).Returns(false);
         runtimeStore.GetRunStatusAsync(runId).Returns((string?)null);
 
@@ -359,8 +385,6 @@ public class HangfireFlowOrchestratorTests
                     Type = "LogMessage",
                     RunAfter = new RunAfterCollection { ["step_b"] = [StepStatus.Succeeded] }
                 },
-                // step_d is the ONLY leaf — it only runs if step_c fails.
-                // Since step_c Succeeded, step_d is Skipped.
                 ["step_d"] = new StepMetadata
                 {
                     Type = "LogMessage",
@@ -371,14 +395,12 @@ public class HangfireFlowOrchestratorTests
 
         var runId = Guid.NewGuid();
         var ctx = new Core.Execution.ExecutionContext { RunId = runId };
-        // step_c is the step completing now (the last Succeeded step before the leaf check)
         var step = new StepInstance("step_c", "LogMessage") { RunId = runId };
 
         var succeededResult = new StepResult { Key = "step_c", Status = StepStatus.Succeeded };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(succeededResult);
         _flowExecutor.GetNextStep(ctx, flow, step, succeededResult).Returns((IStepInstance?)null);
 
-        // Post-execution statuses: A, B, C all Succeeded; D already Skipped (blocked).
         IReadOnlyDictionary<string, StepStatus> statuses = new Dictionary<string, StepStatus>
         {
             ["step_a"] = StepStatus.Succeeded,
@@ -414,13 +436,11 @@ public class HangfireFlowOrchestratorTests
             Steps = new StepCollection
             {
                 ["start"] = new StepMetadata { Type = "LogMessage" },
-                // leaf 1 — runs on success (Succeeded)
                 ["happy_path"] = new StepMetadata
                 {
                     Type = "LogMessage",
                     RunAfter = new RunAfterCollection { ["start"] = [StepStatus.Succeeded] }
                 },
-                // leaf 2 — only runs on failure (Skipped because start Succeeded)
                 ["error_handler"] = new StepMetadata
                 {
                     Type = "LogMessage",
@@ -440,8 +460,8 @@ public class HangfireFlowOrchestratorTests
         IReadOnlyDictionary<string, StepStatus> statuses = new Dictionary<string, StepStatus>
         {
             ["start"]         = StepStatus.Succeeded,
-            ["happy_path"]    = StepStatus.Succeeded,   // leaf — Succeeded
-            ["error_handler"] = StepStatus.Skipped      // leaf — Skipped
+            ["happy_path"]    = StepStatus.Succeeded,
+            ["error_handler"] = StepStatus.Skipped
         };
         runtimeStore.GetStepStatusesAsync(runId).Returns(statuses);
         runtimeStore.GetClaimedStepKeysAsync(runId).Returns((IReadOnlyCollection<string>)Array.Empty<string>());
@@ -478,9 +498,9 @@ public class HangfireFlowOrchestratorTests
 
         // Should dispatch one immediate + one delayed child
         var calls = _dispatcher.ReceivedCalls().ToList();
-        calls.Should().HaveCount(2);
-        calls.Any(c => c.GetMethodInfo().Name == nameof(IStepDispatcher.EnqueueStepAsync)).Should().BeTrue();
-        calls.Any(c => c.GetMethodInfo().Name == nameof(IStepDispatcher.ScheduleStepAsync)).Should().BeTrue();
+        Assert.Equal(2, calls.Count);
+        Assert.True(calls.Any(c => c.GetMethodInfo().Name == nameof(IStepDispatcher.EnqueueStepAsync)));
+        Assert.True(calls.Any(c => c.GetMethodInfo().Name == nameof(IStepDispatcher.ScheduleStepAsync)));
     }
 
     [Fact]
@@ -502,7 +522,9 @@ public class HangfireFlowOrchestratorTests
 
         var act = () => sut.RunStepAsync(ctx, flow, step).AsTask();
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*static DAG*step1*");
+        // Act + Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(act);
+        Assert.Contains("static DAG", ex.Message);
+        Assert.Contains("step1", ex.Message);
     }
 }

--- a/tests/FlowOrchestrator.InMemory.Tests/FlowOrchestrator.InMemory.Tests.csproj
+++ b/tests/FlowOrchestrator.InMemory.Tests/FlowOrchestrator.InMemory.Tests.csproj
@@ -14,7 +14,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/FlowOrchestrator.InMemory.Tests/InMemoryFlowRunStoreTests.cs
+++ b/tests/FlowOrchestrator.InMemory.Tests/InMemoryFlowRunStoreTests.cs
@@ -1,5 +1,4 @@
 using FlowOrchestrator.InMemory;
-using FluentAssertions;
 
 namespace FlowOrchestrator.InMemory.Tests;
 
@@ -10,125 +9,151 @@ public class InMemoryFlowRunStoreTests
     [Fact]
     public async Task StartRunAsync_CreatesRunningRecord()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var runId = Guid.NewGuid();
 
+        // Act
         var record = await _sut.StartRunAsync(flowId, "TestFlow", runId, "manual", null, null);
 
-        record.Id.Should().Be(runId);
-        record.FlowId.Should().Be(flowId);
-        record.Status.Should().Be("Running");
+        // Assert
+        Assert.Equal(runId, record.Id);
+        Assert.Equal(flowId, record.FlowId);
+        Assert.Equal("Running", record.Status);
     }
 
     [Fact]
     public async Task RecordStepStartAsync_CreatesStepRecord()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         await _sut.StartRunAsync(Guid.NewGuid(), "TestFlow", runId, "manual", null, null);
 
+        // Act
         await _sut.RecordStepStartAsync(runId, "step1", "LogMessage", "{}", "job1");
 
+        // Assert
         var detail = await _sut.GetRunDetailAsync(runId);
-        detail!.Steps.Should().HaveCount(1);
-        detail.Steps![0].StepKey.Should().Be("step1");
-        detail.Steps[0].Status.Should().Be("Running");
-        detail.Steps[0].AttemptCount.Should().Be(1);
-        detail.Steps[0].Attempts.Should().HaveCount(1);
-        detail.Steps[0].Attempts![0].Attempt.Should().Be(1);
+        Assert.NotNull(detail);
+        Assert.Single(detail!.Steps!);
+        Assert.Equal("step1", detail.Steps![0].StepKey);
+        Assert.Equal("Running", detail.Steps[0].Status);
+        Assert.Equal(1, detail.Steps[0].AttemptCount);
+        Assert.Single(detail.Steps[0].Attempts!);
+        Assert.Equal(1, detail.Steps[0].Attempts![0].Attempt);
     }
 
     [Fact]
     public async Task RecordStepCompleteAsync_UpdatesStepStatus()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         await _sut.StartRunAsync(Guid.NewGuid(), "TestFlow", runId, "manual", null, null);
         await _sut.RecordStepStartAsync(runId, "step1", "LogMessage", null, null);
 
+        // Act
         await _sut.RecordStepCompleteAsync(runId, "step1", "Succeeded", "{\"result\":1}", null);
 
+        // Assert
         var detail = await _sut.GetRunDetailAsync(runId);
-        detail!.Steps![0].Status.Should().Be("Succeeded");
-        detail.Steps[0].OutputJson.Should().Be("{\"result\":1}");
-        detail.Steps[0].CompletedAt.Should().NotBeNull();
-        detail.Steps[0].AttemptCount.Should().Be(1);
-        detail.Steps[0].Attempts.Should().HaveCount(1);
-        detail.Steps[0].Attempts![0].Status.Should().Be("Succeeded");
+        Assert.Equal("Succeeded", detail!.Steps![0].Status);
+        Assert.Equal("{\"result\":1}", detail.Steps[0].OutputJson);
+        Assert.NotNull(detail.Steps[0].CompletedAt);
+        Assert.Equal(1, detail.Steps[0].AttemptCount);
+        Assert.Single(detail.Steps[0].Attempts!);
+        Assert.Equal("Succeeded", detail.Steps[0].Attempts![0].Status);
     }
 
     [Fact]
     public async Task RecordStepStartAsync_MultipleStarts_CreatesAttemptHistory()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         await _sut.StartRunAsync(Guid.NewGuid(), "TestFlow", runId, "manual", null, null);
 
+        // Act
         await _sut.RecordStepStartAsync(runId, "step1", "CallExternalApi", "{\"attempt\":1}", "job-1");
         await _sut.RecordStepCompleteAsync(runId, "step1", "Pending", "{\"status\":\"processing\"}", null);
         await _sut.RecordStepStartAsync(runId, "step1", "CallExternalApi", "{\"attempt\":2}", "job-2");
         await _sut.RecordStepCompleteAsync(runId, "step1", "Succeeded", "{\"status\":\"done\"}", null);
 
+        // Assert
         var detail = await _sut.GetRunDetailAsync(runId);
-        detail!.Steps.Should().ContainSingle();
-        detail.Steps![0].Status.Should().Be("Succeeded");
-        detail.Steps[0].AttemptCount.Should().Be(2);
-        detail.Steps[0].Attempts.Should().HaveCount(2);
+        Assert.Single(detail!.Steps!);
+        Assert.Equal("Succeeded", detail.Steps![0].Status);
+        Assert.Equal(2, detail.Steps[0].AttemptCount);
+        Assert.Equal(2, detail.Steps[0].Attempts!.Count);
         var attempts = detail.Steps[0].Attempts!;
-        attempts[0].Attempt.Should().Be(1);
-        attempts[0].Status.Should().Be("Pending");
-        attempts[1].Attempt.Should().Be(2);
-        attempts[1].Status.Should().Be("Succeeded");
+        Assert.Equal(1, attempts[0].Attempt);
+        Assert.Equal("Pending", attempts[0].Status);
+        Assert.Equal(2, attempts[1].Attempt);
+        Assert.Equal("Succeeded", attempts[1].Status);
     }
 
     [Fact]
     public async Task CompleteRunAsync_UpdatesRunStatus()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         await _sut.StartRunAsync(Guid.NewGuid(), "TestFlow", runId, "manual", null, null);
 
+        // Act
         await _sut.CompleteRunAsync(runId, "Succeeded");
 
+        // Assert
         var detail = await _sut.GetRunDetailAsync(runId);
-        detail!.Status.Should().Be("Succeeded");
-        detail.CompletedAt.Should().NotBeNull();
+        Assert.Equal("Succeeded", detail!.Status);
+        Assert.NotNull(detail.CompletedAt);
     }
 
     [Fact]
     public async Task GetRunsAsync_ReturnsAllRuns()
     {
+        // Arrange
         await _sut.StartRunAsync(Guid.NewGuid(), "Flow1", Guid.NewGuid(), "manual", null, null);
         await _sut.StartRunAsync(Guid.NewGuid(), "Flow2", Guid.NewGuid(), "manual", null, null);
 
+        // Act
         var runs = await _sut.GetRunsAsync();
 
-        runs.Should().HaveCount(2);
+        // Assert
+        Assert.Equal(2, runs.Count);
     }
 
     [Fact]
     public async Task GetRunsAsync_FilterByFlowId()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         await _sut.StartRunAsync(flowId, "Flow1", Guid.NewGuid(), "manual", null, null);
         await _sut.StartRunAsync(Guid.NewGuid(), "Flow2", Guid.NewGuid(), "manual", null, null);
 
+        // Act
         var runs = await _sut.GetRunsAsync(flowId: flowId);
 
-        runs.Should().HaveCount(1);
-        runs[0].FlowId.Should().Be(flowId);
+        // Assert
+        Assert.Single(runs);
+        Assert.Equal(flowId, runs[0].FlowId);
     }
 
     [Fact]
     public async Task GetRunsAsync_SkipAndTake()
     {
+        // Arrange
         for (int i = 0; i < 5; i++)
             await _sut.StartRunAsync(Guid.NewGuid(), $"Flow{i}", Guid.NewGuid(), "manual", null, null);
 
+        // Act
         var runs = await _sut.GetRunsAsync(skip: 2, take: 2);
 
-        runs.Should().HaveCount(2);
+        // Assert
+        Assert.Equal(2, runs.Count);
     }
 
     [Fact]
     public async Task GetRunsPageAsync_FiltersByStatus_AndReturnsTotal()
     {
+        // Arrange
         var runId1 = Guid.NewGuid();
         var runId2 = Guid.NewGuid();
         var runId3 = Guid.NewGuid();
@@ -139,30 +164,36 @@ public class InMemoryFlowRunStoreTests
         await _sut.CompleteRunAsync(runId1, "Succeeded");
         await _sut.CompleteRunAsync(runId2, "Succeeded");
 
+        // Act
         var page = await _sut.GetRunsPageAsync(status: "Succeeded", skip: 0, take: 1);
 
-        page.TotalCount.Should().Be(2);
-        page.Runs.Should().HaveCount(1);
-        page.Runs[0].Status.Should().Be("Succeeded");
+        // Assert
+        Assert.Equal(2, page.TotalCount);
+        Assert.Single(page.Runs);
+        Assert.Equal("Succeeded", page.Runs[0].Status);
     }
 
     [Fact]
     public async Task GetRunsPageAsync_SearchesByRunFields()
     {
+        // Arrange
         var targetRunId = Guid.NewGuid();
         await _sut.StartRunAsync(Guid.NewGuid(), "OrderPipeline", targetRunId, "manual-order", null, "bg-job-1001");
         await _sut.StartRunAsync(Guid.NewGuid(), "EmailPipeline", Guid.NewGuid(), "manual-email", null, "bg-job-1002");
 
+        // Act
         var page = await _sut.GetRunsPageAsync(search: "job-1001");
 
-        page.TotalCount.Should().Be(1);
-        page.Runs.Should().ContainSingle();
-        page.Runs[0].Id.Should().Be(targetRunId);
+        // Assert
+        Assert.Equal(1, page.TotalCount);
+        Assert.Single(page.Runs);
+        Assert.Equal(targetRunId, page.Runs[0].Id);
     }
 
     [Fact]
     public async Task GetRunsPageAsync_SearchesByStepKey()
     {
+        // Arrange
         var runId1 = Guid.NewGuid();
         var runId2 = Guid.NewGuid();
         await _sut.StartRunAsync(Guid.NewGuid(), "Flow1", runId1, "manual", null, null);
@@ -170,16 +201,19 @@ public class InMemoryFlowRunStoreTests
         await _sut.RecordStepStartAsync(runId1, "validateOrder", "ValidateOrder", null, null);
         await _sut.RecordStepStartAsync(runId2, "sendEmail", "SendEmail", null, null);
 
+        // Act
         var page = await _sut.GetRunsPageAsync(search: "validate");
 
-        page.TotalCount.Should().Be(1);
-        page.Runs.Should().ContainSingle();
-        page.Runs[0].Id.Should().Be(runId1);
+        // Assert
+        Assert.Equal(1, page.TotalCount);
+        Assert.Single(page.Runs);
+        Assert.Equal(runId1, page.Runs[0].Id);
     }
 
     [Fact]
     public async Task GetRunsPageAsync_SearchesByStepErrorMessage()
     {
+        // Arrange
         var runId1 = Guid.NewGuid();
         var runId2 = Guid.NewGuid();
         await _sut.StartRunAsync(Guid.NewGuid(), "Flow1", runId1, "manual", null, null);
@@ -189,16 +223,19 @@ public class InMemoryFlowRunStoreTests
         await _sut.RecordStepCompleteAsync(runId1, "payment", "Failed", null, "Payment timeout on gateway");
         await _sut.RecordStepCompleteAsync(runId2, "notify", "Failed", null, "Template rendering failed");
 
+        // Act
         var page = await _sut.GetRunsPageAsync(search: "timeout");
 
-        page.TotalCount.Should().Be(1);
-        page.Runs.Should().ContainSingle();
-        page.Runs[0].Id.Should().Be(runId1);
+        // Assert
+        Assert.Equal(1, page.TotalCount);
+        Assert.Single(page.Runs);
+        Assert.Equal(runId1, page.Runs[0].Id);
     }
 
     [Fact]
     public async Task GetRunsPageAsync_SearchesByAttemptHistoryErrorMessage()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         await _sut.StartRunAsync(Guid.NewGuid(), "Flow1", runId, "manual", null, null);
         await _sut.RecordStepStartAsync(runId, "payment", "Payment", null, null);
@@ -206,16 +243,19 @@ public class InMemoryFlowRunStoreTests
         await _sut.RecordStepStartAsync(runId, "payment", "Payment", null, null);
         await _sut.RecordStepCompleteAsync(runId, "payment", "Succeeded", "{\"ok\":true}", null);
 
+        // Act
         var page = await _sut.GetRunsPageAsync(search: "timeout on first");
 
-        page.TotalCount.Should().Be(1);
-        page.Runs.Should().ContainSingle();
-        page.Runs[0].Id.Should().Be(runId);
+        // Assert
+        Assert.Equal(1, page.TotalCount);
+        Assert.Single(page.Runs);
+        Assert.Equal(runId, page.Runs[0].Id);
     }
 
     [Fact]
     public async Task GetRunsPageAsync_SearchesByStepOutputJson()
     {
+        // Arrange
         var runId1 = Guid.NewGuid();
         var runId2 = Guid.NewGuid();
         await _sut.StartRunAsync(Guid.NewGuid(), "Flow1", runId1, "manual", null, null);
@@ -225,16 +265,19 @@ public class InMemoryFlowRunStoreTests
         await _sut.RecordStepCompleteAsync(runId1, "payment", "Succeeded", "{\"transactionId\":\"tx-7788\"}", null);
         await _sut.RecordStepCompleteAsync(runId2, "notify", "Succeeded", "{\"message\":\"ok\"}", null);
 
+        // Act
         var page = await _sut.GetRunsPageAsync(search: "tx-7788");
 
-        page.TotalCount.Should().Be(1);
-        page.Runs.Should().ContainSingle();
-        page.Runs[0].Id.Should().Be(runId1);
+        // Assert
+        Assert.Equal(1, page.TotalCount);
+        Assert.Single(page.Runs);
+        Assert.Equal(runId1, page.Runs[0].Id);
     }
 
     [Fact]
     public async Task GetRunsPageAsync_CombinesFlowStatusSearchAndPagination()
     {
+        // Arrange
         var targetFlowId = Guid.NewGuid();
         var runId1 = Guid.NewGuid();
         var runId2 = Guid.NewGuid();
@@ -250,24 +293,31 @@ public class InMemoryFlowRunStoreTests
         await _sut.RecordStepCompleteAsync(runId2, "process", "Failed", null, "fatal error on flow A");
         await _sut.RecordStepCompleteAsync(runId3, "process", "Failed", null, "fatal error on flow B");
 
+        // Act
         var page = await _sut.GetRunsPageAsync(flowId: targetFlowId, status: "Failed", skip: 0, take: 1, search: "fatal");
 
-        page.TotalCount.Should().Be(1);
-        page.Runs.Should().ContainSingle();
-        page.Runs[0].Id.Should().Be(runId2);
+        // Assert
+        Assert.Equal(1, page.TotalCount);
+        Assert.Single(page.Runs);
+        Assert.Equal(runId2, page.Runs[0].Id);
     }
 
     [Fact]
     public async Task GetRunDetailAsync_NonExistentRun_ReturnsNull()
     {
+        // Arrange
+
+        // Act
         var result = await _sut.GetRunDetailAsync(Guid.NewGuid());
 
-        result.Should().BeNull();
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task GetStatisticsAsync_ReturnsCorrectCounts()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var runId1 = Guid.NewGuid();
         var runId2 = Guid.NewGuid();
@@ -275,24 +325,29 @@ public class InMemoryFlowRunStoreTests
         await _sut.StartRunAsync(flowId, "Flow", runId2, "manual", null, null);
         await _sut.CompleteRunAsync(runId1, "Succeeded");
 
+        // Act
         var stats = await _sut.GetStatisticsAsync();
 
-        stats.ActiveRuns.Should().Be(1);
-        stats.CompletedToday.Should().Be(1);
+        // Assert
+        Assert.Equal(1, stats.ActiveRuns);
+        Assert.Equal(1, stats.CompletedToday);
     }
 
     [Fact]
     public async Task GetActiveRunsAsync_ReturnsOnlyRunning()
     {
+        // Arrange
         var runId1 = Guid.NewGuid();
         var runId2 = Guid.NewGuid();
         await _sut.StartRunAsync(Guid.NewGuid(), "Flow", runId1, "manual", null, null);
         await _sut.StartRunAsync(Guid.NewGuid(), "Flow", runId2, "manual", null, null);
         await _sut.CompleteRunAsync(runId1, "Succeeded");
 
+        // Act
         var active = await _sut.GetActiveRunsAsync();
 
-        active.Should().HaveCount(1);
-        active[0].Id.Should().Be(runId2);
+        // Assert
+        Assert.Single(active);
+        Assert.Equal(runId2, active[0].Id);
     }
 }

--- a/tests/FlowOrchestrator.InMemory.Tests/InMemoryFlowStoreTests.cs
+++ b/tests/FlowOrchestrator.InMemory.Tests/InMemoryFlowStoreTests.cs
@@ -1,6 +1,5 @@
 using FlowOrchestrator.Core.Storage;
 using FlowOrchestrator.InMemory;
-using FluentAssertions;
 
 namespace FlowOrchestrator.InMemory.Tests;
 
@@ -20,40 +19,50 @@ public class InMemoryFlowStoreTests
     [Fact]
     public async Task SaveAsync_AndGetByIdAsync_ReturnsRecord()
     {
+        // Arrange
         var record = CreateRecord();
         await _sut.SaveAsync(record);
 
+        // Act
         var result = await _sut.GetByIdAsync(record.Id);
 
-        result.Should().NotBeNull();
-        result!.Name.Should().Be("TestFlow");
-        result.UpdatedAt.Should().NotBe(default);
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("TestFlow", result!.Name);
+        Assert.NotEqual(default, result.UpdatedAt);
     }
 
     [Fact]
     public async Task SaveAsync_SetsCreatedAtOnFirstSave()
     {
+        // Arrange
         var record = CreateRecord();
 
+        // Act
         await _sut.SaveAsync(record);
 
-        record.CreatedAt.Should().NotBe(default);
+        // Assert
+        Assert.NotEqual(default, record.CreatedAt);
     }
 
     [Fact]
     public async Task GetAllAsync_ReturnsAllRecords()
     {
+        // Arrange
         await _sut.SaveAsync(CreateRecord());
         await _sut.SaveAsync(CreateRecord());
 
+        // Act
         var all = await _sut.GetAllAsync();
 
-        all.Should().HaveCount(2);
+        // Assert
+        Assert.Equal(2, all.Count);
     }
 
     [Fact]
     public async Task GetAllAsync_ReturnsOrderedByName()
     {
+        // Arrange
         var r1 = CreateRecord();
         r1.Name = "Bravo";
         var r2 = CreateRecord();
@@ -62,56 +71,75 @@ public class InMemoryFlowStoreTests
         await _sut.SaveAsync(r1);
         await _sut.SaveAsync(r2);
 
+        // Act
         var all = await _sut.GetAllAsync();
-        all[0].Name.Should().Be("Alpha");
-        all[1].Name.Should().Be("Bravo");
+
+        // Assert
+        Assert.Equal("Alpha", all[0].Name);
+        Assert.Equal("Bravo", all[1].Name);
     }
 
     [Fact]
     public async Task DeleteAsync_RemovesRecord()
     {
+        // Arrange
         var record = CreateRecord();
         await _sut.SaveAsync(record);
 
+        // Act
         await _sut.DeleteAsync(record.Id);
 
+        // Assert
         var result = await _sut.GetByIdAsync(record.Id);
-        result.Should().BeNull();
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task DeleteAsync_NonExistentId_DoesNotThrow()
     {
-        var act = () => _sut.DeleteAsync(Guid.NewGuid());
+        // Arrange
 
-        await act.Should().NotThrowAsync();
+        // Act
+        var ex = await Record.ExceptionAsync(() => _sut.DeleteAsync(Guid.NewGuid()));
+
+        // Assert
+        Assert.Null(ex);
     }
 
     [Fact]
     public async Task SetEnabledAsync_UpdatesIsEnabled()
     {
+        // Arrange
         var record = CreateRecord();
         record.IsEnabled = true;
         await _sut.SaveAsync(record);
 
+        // Act
         var result = await _sut.SetEnabledAsync(record.Id, false);
 
-        result.IsEnabled.Should().BeFalse();
+        // Assert
+        Assert.False(result.IsEnabled);
     }
 
     [Fact]
     public async Task SetEnabledAsync_NonExistentId_ThrowsKeyNotFound()
     {
+        // Arrange
         var act = () => _sut.SetEnabledAsync(Guid.NewGuid(), true);
 
-        await act.Should().ThrowAsync<KeyNotFoundException>();
+        // Act + Assert
+        await Assert.ThrowsAsync<KeyNotFoundException>(act);
     }
 
     [Fact]
     public async Task GetByIdAsync_NonExistentId_ReturnsNull()
     {
+        // Arrange
+
+        // Act
         var result = await _sut.GetByIdAsync(Guid.NewGuid());
 
-        result.Should().BeNull();
+        // Assert
+        Assert.Null(result);
     }
 }

--- a/tests/FlowOrchestrator.InMemory.Tests/InMemoryOutputsRepositoryTests.cs
+++ b/tests/FlowOrchestrator.InMemory.Tests/InMemoryOutputsRepositoryTests.cs
@@ -2,7 +2,6 @@ using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Storage;
 using FlowOrchestrator.InMemory;
-using FluentAssertions;
 using NSubstitute;
 
 namespace FlowOrchestrator.InMemory.Tests;
@@ -22,27 +21,35 @@ public class InMemoryOutputsRepositoryTests
     [Fact]
     public async Task SaveAndGetTriggerData_RoundTrip()
     {
+        // Arrange
         var flow = CreateFlow();
         var trigger = new Trigger("manual", "Manual", new { foo = "bar" });
         var ctx = new TriggerContext { RunId = Guid.NewGuid(), Flow = flow, Trigger = trigger };
 
+        // Act
         await _sut.SaveTriggerDataAsync(ctx, flow, trigger);
         var result = await _sut.GetTriggerDataAsync(ctx.RunId);
 
-        result.Should().NotBeNull();
+        // Assert
+        Assert.NotNull(result);
     }
 
     [Fact]
     public async Task GetTriggerDataAsync_NonExistentRunId_ReturnsNull()
     {
+        // Arrange
+
+        // Act
         var result = await _sut.GetTriggerDataAsync(Guid.NewGuid());
 
-        result.Should().BeNull();
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task SaveAndGetTriggerHeaders_RoundTrip()
     {
+        // Arrange
         var flow = CreateFlow();
         var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -52,39 +59,49 @@ public class InMemoryOutputsRepositoryTests
         var trigger = new Trigger("manual", "Manual", new { foo = "bar" }, headers);
         var ctx = new TriggerContext { RunId = Guid.NewGuid(), Flow = flow, Trigger = trigger };
 
+        // Act
         await _sut.SaveTriggerHeadersAsync(ctx, flow, trigger);
         var result = await _sut.GetTriggerHeadersAsync(ctx.RunId);
 
-        result.Should().NotBeNull();
-        result!["X-Correlation-Id"].Should().Be("corr-123");
-        result["content-type"].Should().Be("application/json");
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("corr-123", result!["X-Correlation-Id"]);
+        Assert.Equal("application/json", result["content-type"]);
     }
 
     [Fact]
     public async Task SaveAndGetStepOutput_RoundTrip()
     {
+        // Arrange
         var flow = CreateFlow();
         var ctx = new FlowOrchestrator.Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
         var step = new StepInstance("step1", "LogMessage") { RunId = ctx.RunId };
         var stepResult = new StepResult { Key = "step1", Result = new { count = 42 } };
 
+        // Act
         await _sut.SaveStepOutputAsync(ctx, flow, step, stepResult);
         var output = await _sut.GetStepOutputAsync(ctx.RunId, "step1");
 
-        output.Should().NotBeNull();
+        // Assert
+        Assert.NotNull(output);
     }
 
     [Fact]
     public async Task GetStepOutputAsync_NonExistentKey_ReturnsNull()
     {
+        // Arrange
+
+        // Act
         var result = await _sut.GetStepOutputAsync(Guid.NewGuid(), "missing");
 
-        result.Should().BeNull();
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task SaveStepInputAsync_StoresInput()
     {
+        // Arrange
         var flow = CreateFlow();
         var ctx = new FlowOrchestrator.Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
         var step = new StepInstance("step1", "Query")
@@ -93,48 +110,59 @@ public class InMemoryOutputsRepositoryTests
             Inputs = new Dictionary<string, object?> { ["sql"] = "SELECT 1" }
         };
 
+        // Act
         await _sut.SaveStepInputAsync(ctx, flow, step);
 
+        // Assert
         var result = await _sut.GetStepOutputAsync(ctx.RunId, "step1:input");
-        result.Should().NotBeNull();
+        Assert.NotNull(result);
     }
 
     [Fact]
     public async Task EndScopeAsync_DoesNotThrow()
     {
+        // Arrange
         var flow = CreateFlow();
         var ctx = new FlowOrchestrator.Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
         var step = new StepInstance("step1", "A") { RunId = ctx.RunId };
 
-        var act = () => _sut.EndScopeAsync(ctx, flow, step).AsTask();
+        // Act
+        var ex = await Record.ExceptionAsync(async () => await _sut.EndScopeAsync(ctx, flow, step));
 
-        await act.Should().NotThrowAsync();
+        // Assert
+        Assert.Null(ex);
     }
 
     [Fact]
     public async Task RecordEventAsync_DoesNotThrow()
     {
+        // Arrange
         var flow = CreateFlow();
         var ctx = new FlowOrchestrator.Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
         var step = new StepInstance("step1", "A") { RunId = ctx.RunId };
         var evt = new FlowEvent { Type = "Info", Message = "Test event" };
 
-        var act = () => _sut.RecordEventAsync(ctx, flow, step, evt).AsTask();
+        // Act
+        var ex = await Record.ExceptionAsync(async () => await _sut.RecordEventAsync(ctx, flow, step, evt));
 
-        await act.Should().NotThrowAsync();
+        // Assert
+        Assert.Null(ex);
     }
 
     [Fact]
     public async Task SaveStepOutput_WithNullResult_StoresSuccessfully()
     {
+        // Arrange
         var flow = CreateFlow();
         var ctx = new FlowOrchestrator.Core.Execution.ExecutionContext { RunId = Guid.NewGuid() };
         var step = new StepInstance("step1", "A") { RunId = ctx.RunId };
         var stepResult = new StepResult { Key = "step1", Result = null };
 
+        // Act
         await _sut.SaveStepOutputAsync(ctx, flow, step, stepResult);
         var output = await _sut.GetStepOutputAsync(ctx.RunId, "step1");
 
-        output.Should().NotBeNull();
+        // Assert
+        Assert.NotNull(output);
     }
 }

--- a/tests/FlowOrchestrator.InMemory.Tests/InMemoryRuntimeTests.cs
+++ b/tests/FlowOrchestrator.InMemory.Tests/InMemoryRuntimeTests.cs
@@ -7,7 +7,6 @@ using FlowOrchestrator.InMemory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NSubstitute;
-using FluentAssertions;
 
 namespace FlowOrchestrator.InMemory.Tests;
 
@@ -17,8 +16,6 @@ namespace FlowOrchestrator.InMemory.Tests;
 /// </summary>
 public sealed class InMemoryRuntimeTests
 {
-    // ── Helpers ──────────────────────────────────────────────────────────
-
     private static IExecutionContext MakeContext(Guid runId) =>
         new Core.Execution.ExecutionContext { RunId = runId };
 
@@ -33,77 +30,84 @@ public sealed class InMemoryRuntimeTests
     private static IStepInstance MakeStep(string key = "step1") =>
         new StepInstance(key, "TestStep");
 
-    // ── Dispatcher tests ─────────────────────────────────────────────────
-
     [Fact]
     public async Task EnqueueStepAsync_WritesEnvelopeToChannel()
     {
+        // Arrange
         var channel = Channel.CreateUnbounded<InMemoryStepEnvelope>();
         var dispatcher = new InMemoryStepDispatcher(channel.Writer);
         var ctx = MakeContext(Guid.NewGuid());
         var flow = MakeFlow();
         var step = MakeStep();
 
+        // Act
         var jobId = await dispatcher.EnqueueStepAsync(ctx, flow, step);
 
-        channel.Reader.TryRead(out var envelope).Should().BeTrue("one item should be in the channel");
-        envelope.Should().NotBeNull();
-        envelope!.Context.RunId.Should().Be(ctx.RunId);
-        envelope.Step.Key.Should().Be(step.Key);
-        jobId.Should().NotBeNullOrEmpty("dispatcher returns a non-null opaque id");
+        // Assert
+        Assert.True(channel.Reader.TryRead(out var envelope));
+        Assert.NotNull(envelope);
+        Assert.Equal(ctx.RunId, envelope!.Context.RunId);
+        Assert.Equal(step.Key, envelope.Step.Key);
+        Assert.False(string.IsNullOrEmpty(jobId));
     }
 
     [Fact]
     public async Task EnqueueStepAsync_CalledTwice_WritesTwoEnvelopes()
     {
+        // Arrange
         var channel = Channel.CreateUnbounded<InMemoryStepEnvelope>();
         var dispatcher = new InMemoryStepDispatcher(channel.Writer);
         var ctx = MakeContext(Guid.NewGuid());
         var flow = MakeFlow();
 
+        // Act
         await dispatcher.EnqueueStepAsync(ctx, flow, MakeStep("a"));
         await dispatcher.EnqueueStepAsync(ctx, flow, MakeStep("b"));
 
-        channel.Reader.Count.Should().Be(2);
+        // Assert
+        Assert.Equal(2, channel.Reader.Count);
     }
 
     [Fact]
     public async Task ScheduleStepAsync_WithZeroDelay_WritesEnvelopePromptly()
     {
+        // Arrange
         var channel = Channel.CreateUnbounded<InMemoryStepEnvelope>();
         var dispatcher = new InMemoryStepDispatcher(channel.Writer);
         var ctx = MakeContext(Guid.NewGuid());
         var flow = MakeFlow();
         var step = MakeStep();
 
+        // Act
         var jobId = await dispatcher.ScheduleStepAsync(ctx, flow, step, TimeSpan.Zero);
-
-        // Allow the fire-and-forget task a moment to complete.
         await Task.Delay(100);
 
-        channel.Reader.TryRead(out var envelope).Should().BeTrue();
-        envelope!.EnvelopeId.Should().Be(jobId);
+        // Assert
+        Assert.True(channel.Reader.TryRead(out var envelope));
+        Assert.Equal(jobId, envelope!.EnvelopeId);
     }
 
     [Fact]
     public async Task ScheduleStepAsync_ReturnsDistinctIdFromEnqueue()
     {
+        // Arrange
         var channel = Channel.CreateUnbounded<InMemoryStepEnvelope>();
         var dispatcher = new InMemoryStepDispatcher(channel.Writer);
         var ctx = MakeContext(Guid.NewGuid());
         var flow = MakeFlow();
 
+        // Act
         var enqueueId = await dispatcher.EnqueueStepAsync(ctx, flow, MakeStep("a"));
         var scheduleId = await dispatcher.ScheduleStepAsync(ctx, flow, MakeStep("b"), TimeSpan.Zero);
 
-        enqueueId.Should().NotBe(scheduleId, "each dispatch produces a unique id");
+        // Assert
+        Assert.NotEqual(scheduleId, enqueueId);
     }
-
-    // ── Runner tests ─────────────────────────────────────────────────────
 
     [Fact]
     public async Task Runner_WhenEnvelopeWritten_CallsEngineRunStepAsync()
     {
+        // Arrange
         var channel = Channel.CreateUnbounded<InMemoryStepEnvelope>();
         var engine = Substitute.For<IFlowOrchestrator>();
         engine.RunStepAsync(Arg.Any<IExecutionContext>(), Arg.Any<IFlowDefinition>(),
@@ -119,17 +123,17 @@ public sealed class InMemoryRuntimeTests
 
         var cts = new CancellationTokenSource();
         var runner = sp.GetServices<IHostedService>().OfType<InMemoryStepRunnerHostedService>().Single();
-        var runTask = runner.StartAsync(cts.Token);
-
         var ctx = MakeContext(Guid.NewGuid());
         var flow = MakeFlow();
         var step = MakeStep();
-        await channel.Writer.WriteAsync(new InMemoryStepEnvelope(ctx, flow, step, "e1"));
 
-        // Give the runner a moment to process.
+        // Act
+        var runTask = runner.StartAsync(cts.Token);
+        await channel.Writer.WriteAsync(new InMemoryStepEnvelope(ctx, flow, step, "e1"));
         await Task.Delay(200);
         cts.Cancel();
 
+        // Assert
         await engine.Received(1).RunStepAsync(
             Arg.Is<IExecutionContext>(c => c.RunId == ctx.RunId),
             Arg.Any<IFlowDefinition>(),
@@ -140,6 +144,7 @@ public sealed class InMemoryRuntimeTests
     [Fact]
     public async Task Runner_EngineThrows_ContinuesProcessingNextEnvelope()
     {
+        // Arrange
         var channel = Channel.CreateUnbounded<InMemoryStepEnvelope>();
         var engine = Substitute.For<IFlowOrchestrator>();
         var callCount = 0;
@@ -162,96 +167,114 @@ public sealed class InMemoryRuntimeTests
 
         var cts = new CancellationTokenSource();
         var runner = sp.GetServices<IHostedService>().OfType<InMemoryStepRunnerHostedService>().Single();
-        await runner.StartAsync(cts.Token);
-
         var ctx = MakeContext(Guid.NewGuid());
         var flow = MakeFlow();
+
+        // Act
+        await runner.StartAsync(cts.Token);
         await channel.Writer.WriteAsync(new InMemoryStepEnvelope(ctx, flow, MakeStep("failing"), "e1"));
         await channel.Writer.WriteAsync(new InMemoryStepEnvelope(ctx, flow, MakeStep("ok"), "e2"));
-
         await Task.Delay(300);
         cts.Cancel();
 
-        // Both envelopes were attempted — runner survived the first failure.
+        // Assert
         await engine.Received(2).RunStepAsync(
             Arg.Any<IExecutionContext>(), Arg.Any<IFlowDefinition>(),
             Arg.Any<IStepInstance>(), Arg.Any<CancellationToken>());
     }
 
-    // ── UseInMemoryRuntime() DI integration ──────────────────────────────
-
     [Fact]
     public void UseInMemoryRuntime_RegistersStepDispatcher()
     {
+        // Arrange
         var services = new ServiceCollection();
         services.AddLogging();
-        // Minimal stub so AddFlowOrchestrator's IFlowStore validation passes.
         services.AddSingleton(Substitute.For<IFlowStore>());
-
         services.AddFlowOrchestrator(opts =>
         {
             opts.UseInMemory();
             opts.UseInMemoryRuntime();
         });
 
+        // Act
         using var sp = services.BuildServiceProvider();
         var dispatcher = sp.GetRequiredService<IStepDispatcher>();
-        dispatcher.Should().BeOfType<InMemoryStepDispatcher>();
+
+        // Assert
+        Assert.IsType<InMemoryStepDispatcher>(dispatcher);
     }
 
     [Fact]
     public void UseInMemoryRuntime_RegistersNullRecurringDispatcher()
     {
+        // Arrange
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddSingleton(Substitute.For<IFlowStore>());
-
         services.AddFlowOrchestrator(opts =>
         {
             opts.UseInMemory();
             opts.UseInMemoryRuntime();
         });
 
+        // Act
         using var sp = services.BuildServiceProvider();
         var dispatcher = sp.GetRequiredService<IRecurringTriggerDispatcher>();
-        dispatcher.Should().BeOfType<NullRecurringTriggerDispatcher>();
+
+        // Assert
+        Assert.IsType<NullRecurringTriggerDispatcher>(dispatcher);
     }
 
     [Fact]
     public void UseInMemoryRuntime_RegistersNullRecurringInspector()
     {
+        // Arrange
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddSingleton(Substitute.For<IFlowStore>());
-
         services.AddFlowOrchestrator(opts =>
         {
             opts.UseInMemory();
             opts.UseInMemoryRuntime();
         });
 
+        // Act
         using var sp = services.BuildServiceProvider();
         var inspector = sp.GetRequiredService<IRecurringTriggerInspector>();
-        inspector.Should().BeOfType<NullRecurringTriggerInspector>();
+
+        // Assert
+        Assert.IsType<NullRecurringTriggerInspector>(inspector);
     }
 
     [Fact]
     public async Task NullRecurringDispatcher_AllOperationsAreNoOps()
     {
+        // Arrange
         var dispatcher = new NullRecurringTriggerDispatcher();
 
-        // None of these should throw.
-        dispatcher.RegisterOrUpdate("job1", Guid.NewGuid(), "schedule", "0 * * * *");
-        dispatcher.Remove("job1");
-        dispatcher.TriggerOnce("job1");
-        await dispatcher.EnqueueTriggerAsync(Guid.NewGuid(), "schedule");
+        // Act
+        var ex = await Record.ExceptionAsync(async () =>
+        {
+            dispatcher.RegisterOrUpdate("job1", Guid.NewGuid(), "schedule", "0 * * * *");
+            dispatcher.Remove("job1");
+            dispatcher.TriggerOnce("job1");
+            await dispatcher.EnqueueTriggerAsync(Guid.NewGuid(), "schedule");
+        });
+
+        // Assert
+        Assert.Null(ex);
     }
 
     [Fact]
     public async Task NullRecurringInspector_ReturnsEmptyList()
     {
+        // Arrange
         var inspector = new NullRecurringTriggerInspector();
+
+        // Act
         var jobs = await inspector.GetJobsAsync();
-        jobs.Should().BeEmpty();
+
+        // Assert
+        Assert.Empty(jobs);
     }
 }

--- a/tests/FlowOrchestrator.InMemory.Tests/OutputsRepositoryTypedExtensionsTests.cs
+++ b/tests/FlowOrchestrator.InMemory.Tests/OutputsRepositoryTypedExtensionsTests.cs
@@ -2,7 +2,6 @@ using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Storage;
 using FlowOrchestrator.InMemory;
-using FluentAssertions;
 using NSubstitute;
 
 namespace FlowOrchestrator.InMemory.Tests;
@@ -14,21 +13,25 @@ public class OutputsRepositoryTypedExtensionsTests
     [Fact]
     public async Task GetTriggerDataAsync_WithTypedResult_ReturnsDeserializedPayload()
     {
+        // Arrange
         var flow = CreateFlow();
         var trigger = new Trigger("manual", "Manual", new TriggerPayload { JobId = "JOB-9", Attempt = 2 });
         var ctx = new TriggerContext { RunId = Guid.NewGuid(), Flow = flow, Trigger = trigger };
         await _sut.SaveTriggerDataAsync(ctx, flow, trigger);
 
+        // Act
         var payload = await _sut.GetTriggerDataAsync<TriggerPayload>(ctx.RunId);
 
-        payload.Should().NotBeNull();
-        payload!.JobId.Should().Be("JOB-9");
-        payload.Attempt.Should().Be(2);
+        // Assert
+        Assert.NotNull(payload);
+        Assert.Equal("JOB-9", payload!.JobId);
+        Assert.Equal(2, payload.Attempt);
     }
 
     [Fact]
     public async Task GetStepOutputAsync_WithTypedResult_ReturnsDeserializedPayload()
     {
+        // Arrange
         var flow = CreateFlow();
         var runId = Guid.NewGuid();
         var ctx = new FlowOrchestrator.Core.Execution.ExecutionContext { RunId = runId };
@@ -40,16 +43,19 @@ public class OutputsRepositoryTypedExtensionsTests
         };
         await _sut.SaveStepOutputAsync(ctx, flow, step, result);
 
+        // Act
         var payload = await _sut.GetStepOutputAsync<TriggerPayload>(runId, step.Key);
 
-        payload.Should().NotBeNull();
-        payload!.JobId.Should().Be("JOB-22");
-        payload.Attempt.Should().Be(7);
+        // Assert
+        Assert.NotNull(payload);
+        Assert.Equal("JOB-22", payload!.JobId);
+        Assert.Equal(7, payload.Attempt);
     }
 
     [Fact]
     public async Task GetStepOutputAsync_WithInvalidShape_ThrowsJsonException()
     {
+        // Arrange
         var flow = CreateFlow();
         var runId = Guid.NewGuid();
         var ctx = new FlowOrchestrator.Core.Execution.ExecutionContext { RunId = runId };
@@ -57,9 +63,11 @@ public class OutputsRepositoryTypedExtensionsTests
         var result = new StepResult { Key = step.Key, Result = new { attempt = "bad" } };
         await _sut.SaveStepOutputAsync(ctx, flow, step, result);
 
+        // Act
         var act = async () => await _sut.GetStepOutputAsync<TriggerPayload>(runId, step.Key);
 
-        await act.Should().ThrowAsync<System.Text.Json.JsonException>();
+        // Assert
+        await Assert.ThrowsAsync<System.Text.Json.JsonException>(act);
     }
 
     private static IFlowDefinition CreateFlow()

--- a/tests/FlowOrchestrator.PostgreSQL.Tests/FlowOrchestrator.PostgreSQL.Tests.csproj
+++ b/tests/FlowOrchestrator.PostgreSQL.Tests/FlowOrchestrator.PostgreSQL.Tests.csproj
@@ -14,7 +14,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.4.0" />
     <PackageReference Include="coverlet.collector" Version="8.0.1">

--- a/tests/FlowOrchestrator.PostgreSQL.Tests/PostgreSqlFlowRunStoreTests.cs
+++ b/tests/FlowOrchestrator.PostgreSQL.Tests/PostgreSqlFlowRunStoreTests.cs
@@ -1,5 +1,4 @@
 using FlowOrchestrator.Core.Storage;
-using FluentAssertions;
 
 namespace FlowOrchestrator.PostgreSQL.Tests;
 
@@ -15,111 +14,134 @@ public sealed class PostgreSqlFlowRunStoreTests : IClassFixture<PostgreSqlFixtur
     [Fact]
     public async Task StartRunAsync_creates_run_with_Running_status()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var runId = Guid.NewGuid();
 
+        // Act
         var run = await _store.StartRunAsync(flowId, "MyFlow", runId, "manual", null, "job-1");
 
-        run.Id.Should().Be(runId);
-        run.FlowId.Should().Be(flowId);
-        run.FlowName.Should().Be("MyFlow");
-        run.Status.Should().Be("Running");
-        run.TriggerKey.Should().Be("manual");
-        run.BackgroundJobId.Should().Be("job-1");
-        run.StartedAt.Should().NotBe(default);
-        run.CompletedAt.Should().BeNull();
+        // Assert
+        Assert.Equal(runId, run.Id);
+        Assert.Equal(flowId, run.FlowId);
+        Assert.Equal("MyFlow", run.FlowName);
+        Assert.Equal("Running", run.Status);
+        Assert.Equal("manual", run.TriggerKey);
+        Assert.Equal("job-1", run.BackgroundJobId);
+        Assert.NotEqual(default, run.StartedAt);
+        Assert.Null(run.CompletedAt);
     }
 
     [Fact]
     public async Task Full_run_state_machine()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var runId = Guid.NewGuid();
         await _store.StartRunAsync(flowId, "SM_Flow", runId, "webhook", """{"x":1}""", null);
 
+        // Act
         await _store.RecordStepStartAsync(runId, "step1", "LogMessage", """{"msg":"hi"}""", "j1");
         await _store.RecordStepCompleteAsync(runId, "step1", "Succeeded", """{"ok":true}""", null);
-
         await _store.CompleteRunAsync(runId, "Succeeded");
 
+        // Assert
         var detail = await _store.GetRunDetailAsync(runId);
-        detail.Should().NotBeNull();
-        detail!.Status.Should().Be("Succeeded");
-        detail.CompletedAt.Should().NotBeNull();
-        detail.Steps.Should().HaveCount(1);
-        detail.Steps![0].StepKey.Should().Be("step1");
-        detail.Steps![0].Status.Should().Be("Succeeded");
-        detail.Steps![0].Attempts.Should().HaveCount(1);
+        Assert.NotNull(detail);
+        Assert.Equal("Succeeded", detail!.Status);
+        Assert.NotNull(detail.CompletedAt);
+        Assert.Single(detail.Steps!);
+        Assert.Equal("step1", detail.Steps![0].StepKey);
+        Assert.Equal("Succeeded", detail.Steps![0].Status);
+        Assert.Single(detail.Steps![0].Attempts!);
     }
 
     [Fact]
     public async Task RecordStepStartAsync_increments_attempt_counter()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         await _store.StartRunAsync(Guid.NewGuid(), "AttemptFlow", runId, "manual", null, null);
 
+        // Act
         await _store.RecordStepStartAsync(runId, "s1", "T", null, null);
         await _store.RecordStepCompleteAsync(runId, "s1", "Failed", null, "err");
         await _store.RecordStepStartAsync(runId, "s1", "T", null, null);
         await _store.RecordStepCompleteAsync(runId, "s1", "Succeeded", null, null);
 
+        // Assert
         var detail = await _store.GetRunDetailAsync(runId);
-        detail!.Steps![0].Attempts.Should().HaveCount(2);
-        detail!.Steps![0].Attempts![0].Attempt.Should().Be(1);
-        detail!.Steps![0].Attempts![1].Attempt.Should().Be(2);
+        Assert.Equal(2, detail!.Steps![0].Attempts!.Count);
+        Assert.Equal(1, detail!.Steps![0].Attempts![0].Attempt);
+        Assert.Equal(2, detail!.Steps![0].Attempts![1].Attempt);
     }
 
     [Fact]
     public async Task GetRunDetailAsync_returns_null_for_unknown_run()
     {
+        // Arrange
+
+        // Act
         var result = await _store.GetRunDetailAsync(Guid.NewGuid());
-        result.Should().BeNull();
+
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task GetRunsPageAsync_respects_skip_and_take()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         for (var i = 0; i < 5; i++)
             await _store.StartRunAsync(flowId, "PageFlow", Guid.NewGuid(), "manual", null, null);
 
+        // Act
         var (page1, total) = await _store.GetRunsPageAsync(flowId, null, 0, 2, null);
         var (page2, _) = await _store.GetRunsPageAsync(flowId, null, 2, 2, null);
 
-        total.Should().BeGreaterThanOrEqualTo(5);
-        page1.Should().HaveCount(2);
-        page2.Should().HaveCount(2);
+        // Assert
+        Assert.True(total >= 5);
+        Assert.Equal(2, page1.Count);
+        Assert.Equal(2, page2.Count);
     }
 
     [Fact]
     public async Task GetRunsPageAsync_filters_by_status()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var runId = Guid.NewGuid();
         await _store.StartRunAsync(flowId, "StatusFilter", runId, "manual", null, null);
         await _store.CompleteRunAsync(runId, "Succeeded");
 
+        // Act
         var (runs, total) = await _store.GetRunsPageAsync(flowId, "Succeeded", 0, 10, null);
 
-        total.Should().BeGreaterThanOrEqualTo(1);
-        runs.All(r => r.Status == "Succeeded").Should().BeTrue();
+        // Assert
+        Assert.True(total >= 1);
+        Assert.True(runs.All(r => r.Status == "Succeeded"));
     }
 
     [Fact]
     public async Task GetStatisticsAsync_returns_counts()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         await _store.StartRunAsync(Guid.NewGuid(), "StatFlow", runId, "manual", null, null);
 
+        // Act
         var stats = await _store.GetStatisticsAsync();
 
-        stats.TotalFlows.Should().BeGreaterThanOrEqualTo(1);
-        stats.ActiveRuns.Should().BeGreaterThanOrEqualTo(1);
+        // Assert
+        Assert.True(stats.TotalFlows >= 1);
+        Assert.True(stats.ActiveRuns >= 1);
     }
 
     [Fact]
     public async Task RetryStepAsync_resets_step_and_run_to_Running()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var runId = Guid.NewGuid();
         await _store.StartRunAsync(flowId, "RetryFlow", runId, "manual", null, null);
@@ -127,34 +149,42 @@ public sealed class PostgreSqlFlowRunStoreTests : IClassFixture<PostgreSqlFixtur
         await _store.RecordStepCompleteAsync(runId, "step1", "Failed", null, "oops");
         await _store.CompleteRunAsync(runId, "Failed");
 
+        // Act
         await _store.RetryStepAsync(runId, "step1");
 
+        // Assert
         var detail = await _store.GetRunDetailAsync(runId);
-        detail!.Status.Should().Be("Running");
-        detail.Steps![0].Status.Should().Be("Running");
+        Assert.Equal("Running", detail!.Status);
+        Assert.Equal("Running", detail.Steps![0].Status);
     }
 
     [Fact]
     public async Task GetActiveRunsAsync_returns_running_runs()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         await _store.StartRunAsync(Guid.NewGuid(), "ActiveFlow", runId, "manual", null, null);
 
+        // Act
         var active = await _store.GetActiveRunsAsync();
 
-        active.Should().Contain(r => r.Id == runId);
+        // Assert
+        Assert.Contains(active, r => r.Id == runId);
     }
 
     [Fact]
     public async Task GetRunsPageAsync_search_matches_flow_name()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var uniqueName = $"SearchableFlow_{Guid.NewGuid():N}";
         await _store.StartRunAsync(flowId, uniqueName, Guid.NewGuid(), "manual", null, null);
 
+        // Act
         var (runs, total) = await _store.GetRunsPageAsync(null, null, 0, 10, uniqueName);
 
-        total.Should().BeGreaterThanOrEqualTo(1);
-        runs.All(r => r.FlowName == uniqueName).Should().BeTrue();
+        // Assert
+        Assert.True(total >= 1);
+        Assert.True(runs.All(r => r.FlowName == uniqueName));
     }
 }

--- a/tests/FlowOrchestrator.PostgreSQL.Tests/PostgreSqlFlowStoreTests.cs
+++ b/tests/FlowOrchestrator.PostgreSQL.Tests/PostgreSqlFlowStoreTests.cs
@@ -1,5 +1,4 @@
 using FlowOrchestrator.Core.Storage;
-using FluentAssertions;
 
 namespace FlowOrchestrator.PostgreSQL.Tests;
 
@@ -15,6 +14,7 @@ public sealed class PostgreSqlFlowStoreTests : IClassFixture<PostgreSqlFixture>
     [Fact]
     public async Task SaveAsync_then_GetByIdAsync_round_trip()
     {
+        // Arrange
         var record = new FlowDefinitionRecord
         {
             Id = Guid.NewGuid(),
@@ -24,81 +24,103 @@ public sealed class PostgreSqlFlowStoreTests : IClassFixture<PostgreSqlFixture>
             IsEnabled = true
         };
 
+        // Act
         var saved = await _store.SaveAsync(record);
 
-        saved.Id.Should().Be(record.Id);
-        saved.Name.Should().Be("TestFlow");
-        saved.ManifestJson.Should().Be("""{"steps":[]}""");
-        saved.IsEnabled.Should().BeTrue();
-        saved.CreatedAt.Should().NotBe(default);
-        saved.UpdatedAt.Should().NotBe(default);
+        // Assert
+        Assert.Equal(record.Id, saved.Id);
+        Assert.Equal("TestFlow", saved.Name);
+        Assert.Equal("""{"steps":[]}""", saved.ManifestJson);
+        Assert.True(saved.IsEnabled);
+        Assert.NotEqual(default, saved.CreatedAt);
+        Assert.NotEqual(default, saved.UpdatedAt);
     }
 
     [Fact]
     public async Task GetByIdAsync_returns_null_for_unknown_id()
     {
+        // Arrange
+
+        // Act
         var result = await _store.GetByIdAsync(Guid.NewGuid());
-        result.Should().BeNull();
+
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task SaveAsync_updates_existing_record()
     {
+        // Arrange
         var id = Guid.NewGuid();
         await _store.SaveAsync(new FlowDefinitionRecord { Id = id, Name = "Original", Version = "1.0" });
 
+        // Act
         var updated = await _store.SaveAsync(new FlowDefinitionRecord { Id = id, Name = "Updated", Version = "2.0" });
 
-        updated.Name.Should().Be("Updated");
-        updated.Version.Should().Be("2.0");
+        // Assert
+        Assert.Equal("Updated", updated.Name);
+        Assert.Equal("2.0", updated.Version);
     }
 
     [Fact]
     public async Task SetEnabledAsync_toggles_IsEnabled()
     {
+        // Arrange
         var id = Guid.NewGuid();
         await _store.SaveAsync(new FlowDefinitionRecord { Id = id, Name = "FlowEnable", Version = "1.0", IsEnabled = true });
 
+        // Act
         var disabled = await _store.SetEnabledAsync(id, false);
-        disabled.IsEnabled.Should().BeFalse();
-
         var enabled = await _store.SetEnabledAsync(id, true);
-        enabled.IsEnabled.Should().BeTrue();
+
+        // Assert
+        Assert.False(disabled.IsEnabled);
+        Assert.True(enabled.IsEnabled);
     }
 
     [Fact]
     public async Task SetEnabledAsync_throws_for_unknown_id()
     {
+        // Arrange
         var act = async () => await _store.SetEnabledAsync(Guid.NewGuid(), false);
-        await act.Should().ThrowAsync<KeyNotFoundException>();
+
+        // Act + Assert
+        await Assert.ThrowsAsync<KeyNotFoundException>(act);
     }
 
     [Fact]
     public async Task DeleteAsync_removes_record()
     {
+        // Arrange
         var id = Guid.NewGuid();
         await _store.SaveAsync(new FlowDefinitionRecord { Id = id, Name = "ToDelete", Version = "1.0" });
 
+        // Act
         await _store.DeleteAsync(id);
 
+        // Assert
         var result = await _store.GetByIdAsync(id);
-        result.Should().BeNull();
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task GetAllAsync_returns_records_ordered_by_name()
     {
+        // Arrange
         var prefix = Guid.NewGuid().ToString("N")[..8];
         await _store.SaveAsync(new FlowDefinitionRecord { Id = Guid.NewGuid(), Name = $"{prefix}_Zebra", Version = "1.0" });
         await _store.SaveAsync(new FlowDefinitionRecord { Id = Guid.NewGuid(), Name = $"{prefix}_Alpha", Version = "1.0" });
         await _store.SaveAsync(new FlowDefinitionRecord { Id = Guid.NewGuid(), Name = $"{prefix}_Mango", Version = "1.0" });
 
+        // Act
         var all = await _store.GetAllAsync();
         var prefixed = all.Where(r => r.Name.StartsWith(prefix, StringComparison.Ordinal)).ToList();
 
-        prefixed.Should().HaveCount(3);
-        prefixed[0].Name.Should().Contain("Alpha");
-        prefixed[1].Name.Should().Contain("Mango");
-        prefixed[2].Name.Should().Contain("Zebra");
+        // Assert
+        Assert.Equal(3, prefixed.Count);
+        Assert.Contains("Alpha", prefixed[0].Name);
+        Assert.Contains("Mango", prefixed[1].Name);
+        Assert.Contains("Zebra", prefixed[2].Name);
     }
 }

--- a/tests/FlowOrchestrator.PostgreSQL.Tests/PostgreSqlOutputsRepositoryTests.cs
+++ b/tests/FlowOrchestrator.PostgreSQL.Tests/PostgreSqlOutputsRepositoryTests.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Storage;
-using FluentAssertions;
 using NSubstitute;
 
 namespace FlowOrchestrator.PostgreSQL.Tests;
@@ -19,6 +18,7 @@ public sealed class PostgreSqlOutputsRepositoryTests : IClassFixture<PostgreSqlF
     [Fact]
     public async Task SaveTriggerDataAsync_then_GetTriggerDataAsync_round_trip()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         var ctx = MakeTriggerContext(runId);
         var flow = Substitute.For<IFlowDefinition>();
@@ -26,25 +26,33 @@ public sealed class PostgreSqlOutputsRepositoryTests : IClassFixture<PostgreSqlF
         trigger.Data.Returns(new { OrderId = 42, Customer = "Test" });
         trigger.Headers.Returns((IReadOnlyDictionary<string, string>?)null);
 
+        // Act
         await _repo.SaveTriggerDataAsync(ctx, flow, trigger);
         var result = await _repo.GetTriggerDataAsync(runId);
 
-        result.Should().NotBeNull();
-        result.Should().BeOfType<JsonElement>();
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsType<JsonElement>(result);
         var je = (JsonElement)result!;
-        je.GetProperty("orderId").GetInt32().Should().Be(42);
+        Assert.Equal(42, je.GetProperty("orderId").GetInt32());
     }
 
     [Fact]
     public async Task GetTriggerDataAsync_returns_null_for_unknown_run()
     {
+        // Arrange
+
+        // Act
         var result = await _repo.GetTriggerDataAsync(Guid.NewGuid());
-        result.Should().BeNull();
+
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task SaveTriggerHeadersAsync_then_GetTriggerHeadersAsync_round_trip()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         var ctx = MakeTriggerContext(runId);
         var flow = Substitute.For<IFlowDefinition>();
@@ -53,23 +61,31 @@ public sealed class PostgreSqlOutputsRepositoryTests : IClassFixture<PostgreSqlF
         var headers = new Dictionary<string, string> { ["X-Request-Id"] = "abc123" };
         trigger.Headers.Returns((IReadOnlyDictionary<string, string>)headers);
 
+        // Act
         await _repo.SaveTriggerHeadersAsync(ctx, flow, trigger);
         var result = await _repo.GetTriggerHeadersAsync(runId);
 
-        result.Should().NotBeNull();
-        result!["X-Request-Id"].Should().Be("abc123");
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("abc123", result!["X-Request-Id"]);
     }
 
     [Fact]
     public async Task GetTriggerHeadersAsync_returns_null_when_no_headers_saved()
     {
+        // Arrange
+
+        // Act
         var result = await _repo.GetTriggerHeadersAsync(Guid.NewGuid());
-        result.Should().BeNull();
+
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task SaveStepOutputAsync_then_GetStepOutputAsync_round_trip()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         var ctx = MakeExecutionContext(runId);
         var flow = Substitute.For<IFlowDefinition>();
@@ -78,24 +94,32 @@ public sealed class PostgreSqlOutputsRepositoryTests : IClassFixture<PostgreSqlF
         var result = Substitute.For<IStepResult>();
         result.Result.Returns((object?)new { Value = 99 });
 
+        // Act
         await _repo.SaveStepOutputAsync(ctx, flow, step, result);
         var output = await _repo.GetStepOutputAsync(runId, "step1");
 
-        output.Should().NotBeNull();
+        // Assert
+        Assert.NotNull(output);
         var je = (JsonElement)output!;
-        je.GetProperty("value").GetInt32().Should().Be(99);
+        Assert.Equal(99, je.GetProperty("value").GetInt32());
     }
 
     [Fact]
     public async Task GetStepOutputAsync_returns_null_for_unknown_key()
     {
+        // Arrange
+
+        // Act
         var result = await _repo.GetStepOutputAsync(Guid.NewGuid(), "nonexistent");
-        result.Should().BeNull();
+
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task SaveStepOutputAsync_overwrites_on_second_save()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         var ctx = MakeExecutionContext(runId);
         var flow = Substitute.For<IFlowDefinition>();
@@ -108,29 +132,44 @@ public sealed class PostgreSqlOutputsRepositoryTests : IClassFixture<PostgreSqlF
 
         var result2 = Substitute.For<IStepResult>();
         result2.Result.Returns((object?)new { Value = 2 });
-        await _repo.SaveStepOutputAsync(ctx, flow, step, result2);
 
+        // Act
+        await _repo.SaveStepOutputAsync(ctx, flow, step, result2);
         var output = await _repo.GetStepOutputAsync(runId, "overwrite-step");
+
+        // Assert
         var je = (JsonElement)output!;
-        je.GetProperty("value").GetInt32().Should().Be(2);
+        Assert.Equal(2, je.GetProperty("value").GetInt32());
     }
 
     [Fact]
     public async Task EndScopeAsync_completes_without_error()
     {
+        // Arrange
         var ctx = MakeExecutionContext(Guid.NewGuid());
         var flow = Substitute.For<IFlowDefinition>();
         var step = Substitute.For<IStepInstance>();
-        await _repo.EndScopeAsync(ctx, flow, step);
+
+        // Act
+        var ex = await Record.ExceptionAsync(() => _repo.EndScopeAsync(ctx, flow, step).AsTask());
+
+        // Assert
+        Assert.Null(ex);
     }
 
     [Fact]
     public async Task RecordEventAsync_completes_without_error()
     {
+        // Arrange
         var ctx = MakeExecutionContext(Guid.NewGuid());
         var flow = Substitute.For<IFlowDefinition>();
         var step = Substitute.For<IStepInstance>();
-        await _repo.RecordEventAsync(ctx, flow, step, new FlowEvent { Type = "test" });
+
+        // Act
+        var ex = await Record.ExceptionAsync(() => _repo.RecordEventAsync(ctx, flow, step, new FlowEvent { Type = "test" }).AsTask());
+
+        // Assert
+        Assert.Null(ex);
     }
 
     private static ITriggerContext MakeTriggerContext(Guid runId)

--- a/tests/FlowOrchestrator.SqlServer.Tests/FlowOrchestrator.SqlServer.Tests.csproj
+++ b/tests/FlowOrchestrator.SqlServer.Tests/FlowOrchestrator.SqlServer.Tests.csproj
@@ -14,7 +14,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.4.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />

--- a/tests/FlowOrchestrator.SqlServer.Tests/GlobalUsings.cs
+++ b/tests/FlowOrchestrator.SqlServer.Tests/GlobalUsings.cs
@@ -1,2 +1,1 @@
 global using Xunit;
-global using FluentAssertions;

--- a/tests/FlowOrchestrator.SqlServer.Tests/SqlFlowRunStoreTests.cs
+++ b/tests/FlowOrchestrator.SqlServer.Tests/SqlFlowRunStoreTests.cs
@@ -14,109 +14,134 @@ public sealed class SqlFlowRunStoreTests : IClassFixture<SqlServerFixture>
     [Fact]
     public async Task StartRunAsync_creates_run_with_Running_status()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var runId = Guid.NewGuid();
 
+        // Act
         var run = await _store.StartRunAsync(flowId, "MyFlow", runId, "manual", null, "job-1");
 
-        run.Id.Should().Be(runId);
-        run.FlowId.Should().Be(flowId);
-        run.FlowName.Should().Be("MyFlow");
-        run.Status.Should().Be("Running");
-        run.TriggerKey.Should().Be("manual");
-        run.BackgroundJobId.Should().Be("job-1");
-        run.StartedAt.Should().NotBe(default);
-        run.CompletedAt.Should().BeNull();
+        // Assert
+        Assert.Equal(runId, run.Id);
+        Assert.Equal(flowId, run.FlowId);
+        Assert.Equal("MyFlow", run.FlowName);
+        Assert.Equal("Running", run.Status);
+        Assert.Equal("manual", run.TriggerKey);
+        Assert.Equal("job-1", run.BackgroundJobId);
+        Assert.NotEqual(default, run.StartedAt);
+        Assert.Null(run.CompletedAt);
     }
 
     [Fact]
     public async Task Full_run_state_machine()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var runId = Guid.NewGuid();
         await _store.StartRunAsync(flowId, "SM_Flow", runId, "webhook", """{"x":1}""", null);
 
+        // Act
         await _store.RecordStepStartAsync(runId, "step1", "LogMessage", """{"msg":"hi"}""", "j1");
         await _store.RecordStepCompleteAsync(runId, "step1", "Succeeded", """{"ok":true}""", null);
         await _store.CompleteRunAsync(runId, "Succeeded");
 
+        // Assert
         var detail = await _store.GetRunDetailAsync(runId);
-        detail.Should().NotBeNull();
-        detail!.Status.Should().Be("Succeeded");
-        detail.CompletedAt.Should().NotBeNull();
-        detail.Steps.Should().HaveCount(1);
-        detail.Steps![0].StepKey.Should().Be("step1");
-        detail.Steps![0].Status.Should().Be("Succeeded");
-        detail.Steps![0].Attempts.Should().HaveCount(1);
+        Assert.NotNull(detail);
+        Assert.Equal("Succeeded", detail!.Status);
+        Assert.NotNull(detail.CompletedAt);
+        Assert.Single(detail.Steps!);
+        Assert.Equal("step1", detail.Steps![0].StepKey);
+        Assert.Equal("Succeeded", detail.Steps![0].Status);
+        Assert.Single(detail.Steps![0].Attempts!);
     }
 
     [Fact]
     public async Task RecordStepStartAsync_increments_attempt_counter()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         await _store.StartRunAsync(Guid.NewGuid(), "AttemptFlow", runId, "manual", null, null);
 
+        // Act
         await _store.RecordStepStartAsync(runId, "s1", "T", null, null);
         await _store.RecordStepCompleteAsync(runId, "s1", "Failed", null, "err");
         await _store.RecordStepStartAsync(runId, "s1", "T", null, null);
         await _store.RecordStepCompleteAsync(runId, "s1", "Succeeded", null, null);
 
+        // Assert
         var detail = await _store.GetRunDetailAsync(runId);
-        detail!.Steps![0].Attempts.Should().HaveCount(2);
-        detail!.Steps![0].Attempts![0].Attempt.Should().Be(1);
-        detail!.Steps![0].Attempts![1].Attempt.Should().Be(2);
+        Assert.Equal(2, detail!.Steps![0].Attempts!.Count);
+        Assert.Equal(1, detail!.Steps![0].Attempts![0].Attempt);
+        Assert.Equal(2, detail!.Steps![0].Attempts![1].Attempt);
     }
 
     [Fact]
     public async Task GetRunDetailAsync_returns_null_for_unknown_run()
     {
+        // Arrange
+
+        // Act
         var result = await _store.GetRunDetailAsync(Guid.NewGuid());
-        result.Should().BeNull();
+
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task GetRunsPageAsync_respects_skip_and_take()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         for (var i = 0; i < 5; i++)
             await _store.StartRunAsync(flowId, "PageFlow", Guid.NewGuid(), "manual", null, null);
 
+        // Act
         var (page1, total) = await _store.GetRunsPageAsync(flowId, null, 0, 2, null);
         var (page2, _) = await _store.GetRunsPageAsync(flowId, null, 2, 2, null);
 
-        total.Should().BeGreaterThanOrEqualTo(5);
-        page1.Should().HaveCount(2);
-        page2.Should().HaveCount(2);
+        // Assert
+        Assert.True(total >= 5);
+        Assert.Equal(2, page1.Count);
+        Assert.Equal(2, page2.Count);
     }
 
     [Fact]
     public async Task GetRunsPageAsync_filters_by_status()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var runId = Guid.NewGuid();
         await _store.StartRunAsync(flowId, "StatusFilter", runId, "manual", null, null);
         await _store.CompleteRunAsync(runId, "Succeeded");
 
-        var (runs, _) = await _store.GetRunsPageAsync(flowId, "Succeeded", 0, 10, null);
+        // Act
+        var (runs, total) = await _store.GetRunsPageAsync(flowId, "Succeeded", 0, 10, null);
 
-        runs.All(r => r.Status == "Succeeded").Should().BeTrue();
+        // Assert
+        Assert.True(total >= 1);
+        Assert.True(runs.All(r => r.Status == "Succeeded"));
     }
 
     [Fact]
     public async Task GetStatisticsAsync_returns_counts()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         await _store.StartRunAsync(Guid.NewGuid(), "StatFlow", runId, "manual", null, null);
 
+        // Act
         var stats = await _store.GetStatisticsAsync();
 
-        stats.TotalFlows.Should().BeGreaterThanOrEqualTo(1);
-        stats.ActiveRuns.Should().BeGreaterThanOrEqualTo(1);
+        // Assert
+        Assert.True(stats.TotalFlows >= 1);
+        Assert.True(stats.ActiveRuns >= 1);
     }
 
     [Fact]
     public async Task RetryStepAsync_resets_step_and_run_to_Running()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var runId = Guid.NewGuid();
         await _store.StartRunAsync(flowId, "RetryFlow", runId, "manual", null, null);
@@ -124,34 +149,42 @@ public sealed class SqlFlowRunStoreTests : IClassFixture<SqlServerFixture>
         await _store.RecordStepCompleteAsync(runId, "step1", "Failed", null, "oops");
         await _store.CompleteRunAsync(runId, "Failed");
 
+        // Act
         await _store.RetryStepAsync(runId, "step1");
 
+        // Assert
         var detail = await _store.GetRunDetailAsync(runId);
-        detail!.Status.Should().Be("Running");
-        detail.Steps![0].Status.Should().Be("Running");
+        Assert.Equal("Running", detail!.Status);
+        Assert.Equal("Running", detail.Steps![0].Status);
     }
 
     [Fact]
     public async Task GetActiveRunsAsync_returns_running_runs()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         await _store.StartRunAsync(Guid.NewGuid(), "ActiveFlow", runId, "manual", null, null);
 
+        // Act
         var active = await _store.GetActiveRunsAsync();
 
-        active.Should().Contain(r => r.Id == runId);
+        // Assert
+        Assert.Contains(active, r => r.Id == runId);
     }
 
     [Fact]
     public async Task GetRunsPageAsync_search_matches_flow_name()
     {
+        // Arrange
         var flowId = Guid.NewGuid();
         var uniqueName = $"SearchableFlow_{Guid.NewGuid():N}";
         await _store.StartRunAsync(flowId, uniqueName, Guid.NewGuid(), "manual", null, null);
 
+        // Act
         var (runs, total) = await _store.GetRunsPageAsync(null, null, 0, 10, uniqueName);
 
-        total.Should().BeGreaterThanOrEqualTo(1);
-        runs.All(r => r.FlowName == uniqueName).Should().BeTrue();
+        // Assert
+        Assert.True(total >= 1);
+        Assert.True(runs.All(r => r.FlowName == uniqueName));
     }
 }

--- a/tests/FlowOrchestrator.SqlServer.Tests/SqlFlowStoreTests.cs
+++ b/tests/FlowOrchestrator.SqlServer.Tests/SqlFlowStoreTests.cs
@@ -14,6 +14,7 @@ public sealed class SqlFlowStoreTests : IClassFixture<SqlServerFixture>
     [Fact]
     public async Task SaveAsync_then_GetByIdAsync_round_trip()
     {
+        // Arrange
         var record = new FlowDefinitionRecord
         {
             Id = Guid.NewGuid(),
@@ -23,81 +24,103 @@ public sealed class SqlFlowStoreTests : IClassFixture<SqlServerFixture>
             IsEnabled = true
         };
 
+        // Act
         var saved = await _store.SaveAsync(record);
 
-        saved.Id.Should().Be(record.Id);
-        saved.Name.Should().Be("TestFlow");
-        saved.ManifestJson.Should().Be("""{"steps":[]}""");
-        saved.IsEnabled.Should().BeTrue();
-        saved.CreatedAt.Should().NotBe(default);
-        saved.UpdatedAt.Should().NotBe(default);
+        // Assert
+        Assert.Equal(record.Id, saved.Id);
+        Assert.Equal("TestFlow", saved.Name);
+        Assert.Equal("""{"steps":[]}""", saved.ManifestJson);
+        Assert.True(saved.IsEnabled);
+        Assert.NotEqual(default, saved.CreatedAt);
+        Assert.NotEqual(default, saved.UpdatedAt);
     }
 
     [Fact]
     public async Task GetByIdAsync_returns_null_for_unknown_id()
     {
+        // Arrange
+
+        // Act
         var result = await _store.GetByIdAsync(Guid.NewGuid());
-        result.Should().BeNull();
+
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task SaveAsync_updates_existing_record()
     {
+        // Arrange
         var id = Guid.NewGuid();
         await _store.SaveAsync(new FlowDefinitionRecord { Id = id, Name = "Original", Version = "1.0" });
 
+        // Act
         var updated = await _store.SaveAsync(new FlowDefinitionRecord { Id = id, Name = "Updated", Version = "2.0" });
 
-        updated.Name.Should().Be("Updated");
-        updated.Version.Should().Be("2.0");
+        // Assert
+        Assert.Equal("Updated", updated.Name);
+        Assert.Equal("2.0", updated.Version);
     }
 
     [Fact]
     public async Task SetEnabledAsync_toggles_IsEnabled()
     {
+        // Arrange
         var id = Guid.NewGuid();
         await _store.SaveAsync(new FlowDefinitionRecord { Id = id, Name = "FlowEnable", Version = "1.0", IsEnabled = true });
 
+        // Act
         var disabled = await _store.SetEnabledAsync(id, false);
-        disabled.IsEnabled.Should().BeFalse();
-
         var enabled = await _store.SetEnabledAsync(id, true);
-        enabled.IsEnabled.Should().BeTrue();
+
+        // Assert
+        Assert.False(disabled.IsEnabled);
+        Assert.True(enabled.IsEnabled);
     }
 
     [Fact]
     public async Task SetEnabledAsync_throws_for_unknown_id()
     {
+        // Arrange
         var act = async () => await _store.SetEnabledAsync(Guid.NewGuid(), false);
-        await act.Should().ThrowAsync<KeyNotFoundException>();
+
+        // Act + Assert
+        await Assert.ThrowsAsync<KeyNotFoundException>(act);
     }
 
     [Fact]
     public async Task DeleteAsync_removes_record()
     {
+        // Arrange
         var id = Guid.NewGuid();
         await _store.SaveAsync(new FlowDefinitionRecord { Id = id, Name = "ToDelete", Version = "1.0" });
 
+        // Act
         await _store.DeleteAsync(id);
 
+        // Assert
         var result = await _store.GetByIdAsync(id);
-        result.Should().BeNull();
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task GetAllAsync_returns_records_ordered_by_name()
     {
+        // Arrange
         var prefix = Guid.NewGuid().ToString("N")[..8];
         await _store.SaveAsync(new FlowDefinitionRecord { Id = Guid.NewGuid(), Name = $"{prefix}_Zebra", Version = "1.0" });
         await _store.SaveAsync(new FlowDefinitionRecord { Id = Guid.NewGuid(), Name = $"{prefix}_Alpha", Version = "1.0" });
         await _store.SaveAsync(new FlowDefinitionRecord { Id = Guid.NewGuid(), Name = $"{prefix}_Mango", Version = "1.0" });
 
+        // Act
         var all = await _store.GetAllAsync();
         var prefixed = all.Where(r => r.Name.StartsWith(prefix, StringComparison.Ordinal)).ToList();
 
-        prefixed.Should().HaveCount(3);
-        prefixed[0].Name.Should().Contain("Alpha");
-        prefixed[1].Name.Should().Contain("Mango");
-        prefixed[2].Name.Should().Contain("Zebra");
+        // Assert
+        Assert.Equal(3, prefixed.Count);
+        Assert.Contains("Alpha", prefixed[0].Name);
+        Assert.Contains("Mango", prefixed[1].Name);
+        Assert.Contains("Zebra", prefixed[2].Name);
     }
 }

--- a/tests/FlowOrchestrator.SqlServer.Tests/SqlOutputsRepositoryTests.cs
+++ b/tests/FlowOrchestrator.SqlServer.Tests/SqlOutputsRepositoryTests.cs
@@ -18,6 +18,7 @@ public sealed class SqlOutputsRepositoryTests : IClassFixture<SqlServerFixture>
     [Fact]
     public async Task SaveTriggerDataAsync_then_GetTriggerDataAsync_round_trip()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         var ctx = MakeTriggerContext(runId);
         var flow = Substitute.For<IFlowDefinition>();
@@ -25,24 +26,32 @@ public sealed class SqlOutputsRepositoryTests : IClassFixture<SqlServerFixture>
         trigger.Data.Returns(new { OrderId = 42, Customer = "Test" });
         trigger.Headers.Returns((IReadOnlyDictionary<string, string>?)null);
 
+        // Act
         await _repo.SaveTriggerDataAsync(ctx, flow, trigger);
         var result = await _repo.GetTriggerDataAsync(runId);
 
-        result.Should().NotBeNull();
+        // Assert
+        Assert.NotNull(result);
         var je = (JsonElement)result!;
-        je.GetProperty("orderId").GetInt32().Should().Be(42);
+        Assert.Equal(42, je.GetProperty("orderId").GetInt32());
     }
 
     [Fact]
     public async Task GetTriggerDataAsync_returns_null_for_unknown_run()
     {
+        // Arrange
+
+        // Act
         var result = await _repo.GetTriggerDataAsync(Guid.NewGuid());
-        result.Should().BeNull();
+
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task SaveTriggerHeadersAsync_then_GetTriggerHeadersAsync_round_trip()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         var ctx = MakeTriggerContext(runId);
         var flow = Substitute.For<IFlowDefinition>();
@@ -51,23 +60,31 @@ public sealed class SqlOutputsRepositoryTests : IClassFixture<SqlServerFixture>
         var headers = new Dictionary<string, string> { ["X-Request-Id"] = "abc123" };
         trigger.Headers.Returns((IReadOnlyDictionary<string, string>)headers);
 
+        // Act
         await _repo.SaveTriggerHeadersAsync(ctx, flow, trigger);
         var result = await _repo.GetTriggerHeadersAsync(runId);
 
-        result.Should().NotBeNull();
-        result!["X-Request-Id"].Should().Be("abc123");
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("abc123", result!["X-Request-Id"]);
     }
 
     [Fact]
     public async Task GetTriggerHeadersAsync_returns_null_when_no_headers_saved()
     {
+        // Arrange
+
+        // Act
         var result = await _repo.GetTriggerHeadersAsync(Guid.NewGuid());
-        result.Should().BeNull();
+
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task SaveStepOutputAsync_then_GetStepOutputAsync_round_trip()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         var ctx = MakeExecutionContext(runId);
         var flow = Substitute.For<IFlowDefinition>();
@@ -76,24 +93,32 @@ public sealed class SqlOutputsRepositoryTests : IClassFixture<SqlServerFixture>
         var result = Substitute.For<IStepResult>();
         result.Result.Returns((object?)new { Value = 99 });
 
+        // Act
         await _repo.SaveStepOutputAsync(ctx, flow, step, result);
         var output = await _repo.GetStepOutputAsync(runId, "step1");
 
-        output.Should().NotBeNull();
+        // Assert
+        Assert.NotNull(output);
         var je = (JsonElement)output!;
-        je.GetProperty("value").GetInt32().Should().Be(99);
+        Assert.Equal(99, je.GetProperty("value").GetInt32());
     }
 
     [Fact]
     public async Task GetStepOutputAsync_returns_null_for_unknown_key()
     {
+        // Arrange
+
+        // Act
         var result = await _repo.GetStepOutputAsync(Guid.NewGuid(), "nonexistent");
-        result.Should().BeNull();
+
+        // Assert
+        Assert.Null(result);
     }
 
     [Fact]
     public async Task SaveStepOutputAsync_overwrites_on_second_save()
     {
+        // Arrange
         var runId = Guid.NewGuid();
         var ctx = MakeExecutionContext(runId);
         var flow = Substitute.For<IFlowDefinition>();
@@ -106,11 +131,14 @@ public sealed class SqlOutputsRepositoryTests : IClassFixture<SqlServerFixture>
 
         var result2 = Substitute.For<IStepResult>();
         result2.Result.Returns((object?)new { Value = 2 });
-        await _repo.SaveStepOutputAsync(ctx, flow, step, result2);
 
+        // Act
+        await _repo.SaveStepOutputAsync(ctx, flow, step, result2);
         var output = await _repo.GetStepOutputAsync(runId, "overwrite-step");
+
+        // Assert
         var je = (JsonElement)output!;
-        je.GetProperty("value").GetInt32().Should().Be(2);
+        Assert.Equal(2, je.GetProperty("value").GetInt32());
     }
 
     private static ITriggerContext MakeTriggerContext(Guid runId)

--- a/tests/FlowOrchestrator.SqlServer.Tests/SqlServerServiceCollectionExtensionsTests.cs
+++ b/tests/FlowOrchestrator.SqlServer.Tests/SqlServerServiceCollectionExtensionsTests.cs
@@ -9,49 +9,61 @@ public sealed class SqlServerServiceCollectionExtensionsTests
     [Fact]
     public void AddFlowOrchestratorSqlServer_registers_IFlowStore_as_SqlFlowStore()
     {
+        // Arrange
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddFlowOrchestratorSqlServer("Server=.;Database=test;");
 
+        // Act
         var sp = services.BuildServiceProvider();
 
-        sp.GetRequiredService<IFlowStore>().Should().BeOfType<SqlFlowStore>();
+        // Assert
+        Assert.IsType<SqlFlowStore>(sp.GetRequiredService<IFlowStore>());
     }
 
     [Fact]
     public void AddFlowOrchestratorSqlServer_registers_IFlowRunStore_as_SqlFlowRunStore()
     {
+        // Arrange
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddFlowOrchestratorSqlServer("Server=.;Database=test;");
 
+        // Act
         var sp = services.BuildServiceProvider();
 
-        sp.GetRequiredService<IFlowRunStore>().Should().BeOfType<SqlFlowRunStore>();
+        // Assert
+        Assert.IsType<SqlFlowRunStore>(sp.GetRequiredService<IFlowRunStore>());
     }
 
     [Fact]
     public void AddFlowOrchestratorSqlServer_registers_IOutputsRepository_as_SqlOutputsRepository()
     {
+        // Arrange
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddFlowOrchestratorSqlServer("Server=.;Database=test;");
 
+        // Act
         var sp = services.BuildServiceProvider();
 
-        sp.GetRequiredService<IOutputsRepository>().Should().BeOfType<SqlOutputsRepository>();
+        // Assert
+        Assert.IsType<SqlOutputsRepository>(sp.GetRequiredService<IOutputsRepository>());
     }
 
     [Fact]
     public void AddFlowOrchestratorSqlServer_registers_migrator_as_IHostedService()
     {
+        // Arrange
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddFlowOrchestratorSqlServer("Server=.;Database=test;");
 
+        // Act
         var sp = services.BuildServiceProvider();
 
+        // Assert
         var hostedServices = sp.GetServices<Microsoft.Extensions.Hosting.IHostedService>();
-        hostedServices.Should().Contain(s => s is FlowOrchestratorSqlMigrator);
+        Assert.Contains(hostedServices, s => s is FlowOrchestratorSqlMigrator);
     }
 }


### PR DESCRIPTION
…AA pattern

FluentAssertions v8 moved to a commercial licence for OSS projects. Replace all 489 call-sites across 34 test files in 6 projects with plain xUnit Assert.* and enforce the Arrange/Act/Assert comment pattern on every [Fact]/[Theory] body.

Changes:
- Remove <PackageReference Include="FluentAssertions"> from all 6 test .csproj files
- Drop `global using FluentAssertions` from Dashboard.Tests and SqlServer.Tests GlobalUsings.cs
- Migrate every assertion to xUnit equivalents (Assert.Equal, Assert.True/False, Assert.Null/NotNull, Assert.Contains, Assert.IsType<T>, Assert.ThrowsAsync, etc.)
- Use Record.ExceptionAsync + Assert.Null for "must not throw" cases
- Add // Arrange / // Act / // Assert blocks to every test body
- Fix FlowSyncHostedServiceTests: Assert.ThrowsAsync<Exception> (exact-type) replaced with Record.ExceptionAsync + Assert.NotNull to correctly handle InvalidOperationException subtype (mirrors original FA behaviour)
- Update CLAUDE.md, add-storage/SKILL.md, new-flow/SKILL.md, regression-test/SKILL.md to document the new assertion standard

All unit test projects pass: Core (65), Hangfire (50), InMemory (39), Dashboard (52) per target framework (net8/net9/net10). Integration test projects (PostgreSQL, SqlServer) require a live database and are excluded from local runs.