### PR TITLE
feat: Mermaid diagram export for flow manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to FlowOrchestrator are documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- **Mermaid diagram export** (`FlowOrchestrator.Core.Diagnostics.FlowMermaidExporter`).
+  Convert any `IFlowDefinition` or `FlowManifest` into a Mermaid `flowchart`
+  string with `flow.ToMermaid()`. Output renders directly in GitHub READMEs,
+  Notion, Confluence, and any modern Markdown surface.
+  - New `MermaidExportOptions` for direction, trigger inclusion, type display, and styling.
+  - Sample app now accepts `--export-mermaid <flowId|flowName>` to print the
+    diagram and exit — useful for CI workflows that comment the new shape on PRs.
+  - Dashboard exposes a "Mermaid" tab with a Copy button on every flow detail
+    page, served by `GET /flows/api/flows/{id}/mermaid` (`text/plain`).
+  - Documentation: [Mermaid Diagram Export](docs/articles/mermaid-export.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-04-30
+
 ### Added
 
 - **Mermaid diagram export** (`FlowOrchestrator.Core.Diagnostics.FlowMermaidExporter`).

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <RepositoryUrl>https://github.com/hoangsnowy/FlowOrchestrator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/hoangsnowy/FlowOrchestrator</PackageProjectUrl>
-    <VersionPrefix>1.14.0</VersionPrefix>
+    <VersionPrefix>1.15.0</VersionPrefix>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -221,6 +221,38 @@ For InMemory (no Hangfire, no database) and PostgreSQL variants, see **[📖 Get
 | Configuration reference | [configuration](https://hoangsnowy.github.io/FlowOrchestrator/articles/configuration.html) |
 | Architecture | [architecture](https://hoangsnowy.github.io/FlowOrchestrator/articles/architecture.html) |
 | Observability | [observability](https://hoangsnowy.github.io/FlowOrchestrator/articles/observability.html) |
+| Mermaid export | [mermaid-export](https://hoangsnowy.github.io/FlowOrchestrator/articles/mermaid-export.html) |
+
+---
+
+## Visualize any flow with one line
+
+`flow.ToMermaid()` returns a Mermaid flowchart string that renders in GitHub
+READMEs, Notion, Confluence, and any modern Markdown surface — no running app
+required. Here is the sample `OrderFulfillmentFlow`:
+
+```mermaid
+flowchart TD
+    classDef trigger fill:#e1f5ff,stroke:#0288d1
+    classDef entry fill:#c8e6c9,stroke:#388e3c
+    classDef polling fill:#fff9c4,stroke:#f57f17
+    classDef loop fill:#f3e5f5,stroke:#7b1fa2
+
+    T_manual["⚡ manual<br/>Manual"]:::trigger
+    T_webhook["⚡ webhook<br/>Webhook /order-fulfillment"]:::trigger
+
+    fetch_orders["fetch_orders<br/><i>QueryDatabase</i>"]:::entry
+    submit_to_wms["submit_to_wms<br/><i>CallExternalApi</i>"]:::polling
+    save_result["save_result<br/><i>SaveResult</i>"]
+
+    T_manual --> fetch_orders
+    T_webhook --> fetch_orders
+    fetch_orders -- Succeeded --> submit_to_wms
+    submit_to_wms -- Succeeded --> save_result
+```
+
+The dashboard ships a Copy Mermaid button on every flow detail page, and the
+sample app exposes `--export-mermaid <flowId>` for CI integrations.
 
 ---
 

--- a/docs/articles/mermaid-export.md
+++ b/docs/articles/mermaid-export.md
@@ -1,0 +1,136 @@
+# Mermaid Diagram Export
+
+`FlowOrchestrator.Core` ships with a one-line exporter that converts a flow's
+manifest into a [Mermaid](https://mermaid.js.org) `flowchart` definition.
+The output is plain text that renders directly in any Markdown surface that
+understands Mermaid — GitHub READMEs and PRs, Notion, Obsidian, Confluence,
+GitLab, dev.to — without spinning up the dashboard or any other process.
+
+## Quick start
+
+```csharp
+using FlowOrchestrator.Core.Diagnostics;
+
+var flow = new OrderFulfillmentFlow();
+Console.WriteLine(flow.ToMermaid());
+```
+
+The same extension is available on `FlowManifest` directly when you hold the
+manifest without a flow definition wrapper.
+
+## Options
+
+`MermaidExportOptions` exposes four knobs:
+
+| Option            | Default | Description                                                                |
+|-------------------|---------|----------------------------------------------------------------------------|
+| `Direction`       | `TD`    | Mermaid direction header. `TD`, `LR`, `BT`, `RL`.                          |
+| `IncludeTriggers` | `true`  | Emits one node per trigger and connects each to the entry steps.           |
+| `ShowStepTypes`   | `true`  | Renders the handler `Type` as italic text below each step key.             |
+| `ApplyStyling`    | `true`  | Adds `classDef` blocks so triggers, entry, polling, and loop steps differ. |
+
+## Worked examples
+
+### 1. Linear flow
+
+```csharp
+new FlowManifest
+{
+    Triggers = { ["manual"] = new() { Type = TriggerType.Manual } },
+    Steps =
+    {
+        ["a"] = new() { Type = "TypeA" },
+        ["b"] = new() { Type = "TypeB", RunAfter = { ["a"] = [StepStatus.Succeeded] } },
+        ["c"] = new() { Type = "TypeC", RunAfter = { ["b"] = [StepStatus.Succeeded] } }
+    }
+}
+.ToMermaid();
+```
+
+```mermaid
+flowchart TD
+    classDef trigger fill:#e1f5ff,stroke:#0288d1
+    classDef entry fill:#c8e6c9,stroke:#388e3c
+    classDef polling fill:#fff9c4,stroke:#f57f17
+    classDef loop fill:#f3e5f5,stroke:#7b1fa2
+
+    T_manual["⚡ manual<br/>Manual"]:::trigger
+    a["a<br/><i>TypeA</i>"]:::entry
+    b["b<br/><i>TypeB</i>"]
+    c["c<br/><i>TypeC</i>"]
+
+    T_manual --> a
+    a -- Succeeded --> b
+    b -- Succeeded --> c
+```
+
+### 2. Fan-out / fan-in
+
+A single root branches into three workers that join at a single leaf.
+
+```mermaid
+flowchart TD
+    root["root"]:::entry
+    a["a"]
+    b["b"]
+    c["c"]
+    join["join"]
+
+    root -- Succeeded --> a
+    root -- Succeeded --> b
+    root -- Succeeded --> c
+    a -- Succeeded --> join
+    b -- Succeeded --> join
+    c -- Succeeded --> join
+```
+
+### 3. Polling step
+
+When a step's `Inputs` carries `pollEnabled = true`, the exporter applies the
+`polling` class so it stands out from regular steps.
+
+```mermaid
+flowchart TD
+    fetch["fetch_orders"]:::entry
+    submit["submit_to_wms<br/><i>CallExternalApi</i>"]:::polling
+
+    fetch -- Succeeded --> submit
+```
+
+### 4. ForEach loop
+
+`LoopStepMetadata` becomes a Mermaid `subgraph` containing the child steps.
+
+```mermaid
+flowchart TD
+    fetch["fetch_orders"]:::entry
+    process_each["process_each_orders"]:::loop
+    fetch -- Succeeded --> process_each
+
+    subgraph subgraph_process_each["🔁 process_each_orders (ForEach)"]
+        validate["validate"]
+    end
+
+    process_each --> subgraph_process_each
+```
+
+## Using it from the dashboard
+
+Open any flow's detail page, switch to the **Mermaid** tab, and click
+**Copy Mermaid**. The same content is also available via the REST endpoint:
+
+```
+GET /flows/api/flows/{id}/mermaid
+Accept: text/plain
+```
+
+## Using it from CI
+
+The sample app accepts a `--export-mermaid <flowId|flowName>` flag that prints
+the diagram and exits without starting the web host. Wire this into a CI job
+that comments the new diagram on a pull request whenever a manifest changes:
+
+```bash
+dotnet run --project samples/FlowOrchestrator.SampleApp -- \
+    --export-mermaid OrderFulfillmentFlow > order-fulfillment.mmd
+```

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -28,6 +28,9 @@
 - name: Dashboard
   href: dashboard.md
 
+- name: Mermaid Diagram Export
+  href: mermaid-export.md
+
 - name: Observability
   href: observability.md
 

--- a/samples/FlowOrchestrator.SampleApp/MermaidExportCli.cs
+++ b/samples/FlowOrchestrator.SampleApp/MermaidExportCli.cs
@@ -1,0 +1,93 @@
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Diagnostics;
+
+namespace FlowOrchestrator.SampleApp;
+
+/// <summary>
+/// CLI handler for <c>--export-mermaid &lt;flowId|flowName&gt;</c>. When the flag is present,
+/// prints the Mermaid flowchart for the requested flow to stdout and signals the host
+/// to exit without starting the web server. Useful for CI workflows that comment a
+/// flow diagram on a pull request.
+/// </summary>
+internal static class MermaidExportCli
+{
+    private const string Flag = "--export-mermaid";
+
+    /// <summary>
+    /// Detects the <c>--export-mermaid</c> flag and, if present, writes the diagram and sets <paramref name="exitCode"/>.
+    /// </summary>
+    /// <param name="args">Raw process arguments.</param>
+    /// <param name="exitCode">Resulting process exit code: <c>0</c> on success, <c>1</c> when the flow was not found.</param>
+    /// <returns><see langword="true"/> when the flag was handled and the host should exit; <see langword="false"/> to continue normal startup.</returns>
+    public static bool TryHandle(string[] args, out int exitCode)
+    {
+        exitCode = 0;
+
+        if (!TryGetTarget(args, out var target))
+        {
+            return false;
+        }
+
+        var flows = DiscoverFlows();
+        var match = flows.FirstOrDefault(f =>
+            string.Equals(f.GetType().Name, target, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(f.Id.ToString(), target, StringComparison.OrdinalIgnoreCase));
+
+        if (match is null)
+        {
+            Console.Error.WriteLine($"Flow not found: '{target}'.");
+            Console.Error.WriteLine("Available flows:");
+            foreach (var f in flows)
+            {
+                Console.Error.WriteLine($"  {f.GetType().Name} ({f.Id})");
+            }
+            exitCode = 1;
+            return true;
+        }
+
+        Console.WriteLine(match.ToMermaid());
+        return true;
+    }
+
+    private static bool TryGetTarget(string[] args, out string target)
+    {
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+
+            if (arg == Flag && i + 1 < args.Length)
+            {
+                target = args[i + 1];
+                return true;
+            }
+
+            var prefix = Flag + "=";
+            if (arg.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                target = arg[prefix.Length..];
+                return true;
+            }
+        }
+
+        target = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Reflects over the sample app's assembly to instantiate every concrete
+    /// <see cref="IFlowDefinition"/> with a public parameterless constructor.
+    /// Eliminates the need to maintain a hardcoded list parallel to <c>options.AddFlow&lt;T&gt;()</c>.
+    /// </summary>
+    private static IReadOnlyList<IFlowDefinition> DiscoverFlows()
+    {
+        return typeof(MermaidExportCli).Assembly
+            .GetTypes()
+            .Where(t => !t.IsAbstract
+                && !t.IsInterface
+                && typeof(IFlowDefinition).IsAssignableFrom(t)
+                && t.GetConstructor(Type.EmptyTypes) is not null)
+            .Select(t => (IFlowDefinition)Activator.CreateInstance(t)!)
+            .OrderBy(f => f.GetType().Name, StringComparer.Ordinal)
+            .ToList();
+    }
+}

--- a/samples/FlowOrchestrator.SampleApp/Program.cs
+++ b/samples/FlowOrchestrator.SampleApp/Program.cs
@@ -13,6 +13,12 @@ using OpenTelemetry.Trace;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 
+// Short-circuit `--export-mermaid <flowId|flowName>` before standing up the host.
+if (MermaidExportCli.TryHandle(args, out var exitCode))
+{
+    return exitCode;
+}
+
 var builder = WebApplication.CreateBuilder(args);
 
 // ── Storage backend selection ─────────────────────────────────────────────────
@@ -200,3 +206,5 @@ app.MapGet("/", () =>
     $"OrderHub [runtime={runtime}, storage={storageBackend}] is running. Visit /flows for the dashboard.");
 
 app.Run();
+
+return 0;

--- a/src/FlowOrchestrator.Core/Diagnostics/FlowMermaidExporter.cs
+++ b/src/FlowOrchestrator.Core/Diagnostics/FlowMermaidExporter.cs
@@ -1,0 +1,281 @@
+using System.Text;
+using FlowOrchestrator.Core.Abstractions;
+
+namespace FlowOrchestrator.Core.Diagnostics;
+
+/// <summary>
+/// Converts a <see cref="FlowManifest"/> into a Mermaid <c>flowchart</c> definition.
+/// The returned string can be embedded in any Markdown surface that renders Mermaid
+/// (GitHub README, Confluence, Notion, dev.to, …) without requiring a running app.
+/// </summary>
+public static class FlowMermaidExporter
+{
+    /// <summary>
+    /// Generates a Mermaid flowchart for the given flow definition.
+    /// </summary>
+    /// <param name="flow">The flow whose <see cref="IFlowDefinition.Manifest"/> will be rendered.</param>
+    /// <param name="options">Optional rendering options; falls back to defaults when <see langword="null"/>.</param>
+    /// <returns>A Mermaid <c>flowchart</c> string suitable for direct Markdown embedding.</returns>
+    public static string ToMermaid(this IFlowDefinition flow, MermaidExportOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(flow);
+        return ToMermaid(flow.Manifest, options);
+    }
+
+    /// <summary>
+    /// Generates a Mermaid flowchart for the given manifest.
+    /// </summary>
+    /// <param name="manifest">The manifest to render.</param>
+    /// <param name="options">Optional rendering options; falls back to defaults when <see langword="null"/>.</param>
+    /// <returns>A Mermaid <c>flowchart</c> string suitable for direct Markdown embedding.</returns>
+    public static string ToMermaid(this FlowManifest manifest, MermaidExportOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+        var opts = options ?? new MermaidExportOptions();
+
+        var sb = new StringBuilder();
+        sb.Append("flowchart ").AppendLine(opts.Direction);
+
+        if (opts.ApplyStyling)
+        {
+            sb.AppendLine("    classDef trigger fill:#e1f5ff,stroke:#0288d1");
+            sb.AppendLine("    classDef entry fill:#c8e6c9,stroke:#388e3c");
+            sb.AppendLine("    classDef polling fill:#fff9c4,stroke:#f57f17");
+            sb.AppendLine("    classDef loop fill:#f3e5f5,stroke:#7b1fa2");
+            sb.AppendLine();
+        }
+
+        if (opts.IncludeTriggers && manifest.Triggers.Count > 0)
+        {
+            EmitTriggerNodes(sb, manifest, opts);
+            sb.AppendLine();
+        }
+
+        EmitStepNodes(sb, manifest.Steps, opts);
+
+        if (opts.IncludeTriggers && manifest.Triggers.Count > 0)
+        {
+            sb.AppendLine();
+            EmitTriggerEdges(sb, manifest);
+        }
+
+        sb.AppendLine();
+        EmitStepEdges(sb, manifest.Steps);
+
+        return sb.ToString().TrimEnd() + "\n";
+    }
+
+    private static void EmitTriggerNodes(StringBuilder sb, FlowManifest manifest, MermaidExportOptions opts)
+    {
+        foreach (var (name, trigger) in manifest.Triggers)
+        {
+            var id = "T_" + SafeId(name);
+            var label = BuildTriggerLabel(name, trigger);
+            sb.Append("    ").Append(id).Append("[\"").Append(label).Append("\"]");
+            if (opts.ApplyStyling)
+            {
+                sb.Append(":::trigger");
+            }
+            sb.AppendLine();
+        }
+    }
+
+    private static void EmitStepNodes(StringBuilder sb, StepCollection steps, MermaidExportOptions opts)
+    {
+        foreach (var (key, metadata) in steps)
+        {
+            if (metadata is LoopStepMetadata loop)
+            {
+                EmitLoopSubgraph(sb, key, loop, opts);
+                continue;
+            }
+
+            EmitStepNode(sb, key, metadata, opts, indent: "    ");
+        }
+    }
+
+    private static void EmitStepNode(
+        StringBuilder sb,
+        string key,
+        StepMetadata metadata,
+        MermaidExportOptions opts,
+        string indent)
+    {
+        var id = SafeId(key);
+        var label = BuildStepLabel(key, metadata, opts);
+        sb.Append(indent).Append(id).Append("[\"").Append(label).Append("\"]");
+
+        if (opts.ApplyStyling)
+        {
+            var className = ResolveStepClass(metadata);
+            if (className is not null)
+            {
+                sb.Append(":::").Append(className);
+            }
+        }
+
+        sb.AppendLine();
+    }
+
+    private static void EmitLoopSubgraph(
+        StringBuilder sb,
+        string key,
+        LoopStepMetadata loop,
+        MermaidExportOptions opts)
+    {
+        var id = SafeId(key);
+        var subgraphId = "subgraph_" + id;
+        var titleType = string.IsNullOrEmpty(loop.Type) ? "ForEach" : EscapeLabel(loop.Type);
+        var title = $"🔁 {EscapeLabel(key)} ({titleType})";
+
+        // The subgraph header itself stands in for the loop step in edges,
+        // but we ALSO emit the loop's "outer" node id so callers can wire RunAfter
+        // edges to the loop's key directly.
+        sb.Append("    ").Append(id).Append("[\"").Append(BuildStepLabel(key, loop, opts)).Append("\"]");
+        if (opts.ApplyStyling)
+        {
+            sb.Append(":::loop");
+        }
+        sb.AppendLine();
+
+        sb.Append("    subgraph ").Append(subgraphId).Append("[\"").Append(title).Append("\"]").AppendLine();
+        foreach (var (childKey, childMeta) in loop.Steps)
+        {
+            EmitStepNode(sb, childKey, childMeta, opts, indent: "        ");
+        }
+        sb.AppendLine("    end");
+
+        // Wire the loop entry node into its subgraph for visual grouping.
+        sb.Append("    ").Append(id).Append(" --> ").Append(subgraphId).AppendLine();
+    }
+
+    private static void EmitTriggerEdges(StringBuilder sb, FlowManifest manifest)
+    {
+        var entrySteps = manifest.Steps
+            .Where(kvp => kvp.Value.RunAfter.Count == 0)
+            .Select(kvp => kvp.Key)
+            .ToArray();
+
+        if (entrySteps.Length == 0)
+        {
+            return;
+        }
+
+        foreach (var triggerName in manifest.Triggers.Keys)
+        {
+            var triggerId = "T_" + SafeId(triggerName);
+            foreach (var entry in entrySteps)
+            {
+                sb.Append("    ").Append(triggerId).Append(" --> ").Append(SafeId(entry)).AppendLine();
+            }
+        }
+    }
+
+    private static void EmitStepEdges(StringBuilder sb, StepCollection steps)
+    {
+        foreach (var (key, metadata) in steps)
+        {
+            foreach (var (predecessorKey, statuses) in metadata.RunAfter)
+            {
+                if (statuses is null || statuses.Length == 0)
+                {
+                    continue;
+                }
+
+                var label = string.Join('|', statuses.Select(s => s.ToString()));
+                sb.Append("    ")
+                  .Append(SafeId(predecessorKey))
+                  .Append(" -- ").Append(label).Append(" --> ")
+                  .Append(SafeId(key))
+                  .AppendLine();
+            }
+        }
+    }
+
+    private static string BuildTriggerLabel(string name, TriggerMetadata trigger)
+    {
+        var detail = trigger.Type switch
+        {
+            TriggerType.Manual => "Manual",
+            TriggerType.Cron => trigger.Inputs.TryGetValue("cronExpression", out var cron) && cron is not null
+                ? $"Cron {EscapeLabel(cron.ToString() ?? string.Empty)}"
+                : "Cron",
+            TriggerType.Webhook => trigger.Inputs.TryGetValue("webhookSlug", out var slug) && slug is not null
+                ? $"Webhook /{EscapeLabel(slug.ToString() ?? string.Empty)}"
+                : "Webhook",
+            _ => trigger.Type.ToString()
+        };
+
+        return $"⚡ {EscapeLabel(name)}<br/>{detail}";
+    }
+
+    private static string BuildStepLabel(string key, StepMetadata metadata, MermaidExportOptions opts)
+    {
+        if (!opts.ShowStepTypes || string.IsNullOrEmpty(metadata.Type))
+        {
+            return EscapeLabel(key);
+        }
+
+        return $"{EscapeLabel(key)}<br/><i>{EscapeLabel(metadata.Type)}</i>";
+    }
+
+    private static string? ResolveStepClass(StepMetadata metadata)
+    {
+        if (metadata is LoopStepMetadata)
+        {
+            return "loop";
+        }
+
+        if (IsPollingStep(metadata))
+        {
+            return "polling";
+        }
+
+        if (metadata.RunAfter.Count == 0)
+        {
+            return "entry";
+        }
+
+        return null;
+    }
+
+    private static bool IsPollingStep(StepMetadata metadata)
+    {
+        if (!metadata.Inputs.TryGetValue("pollEnabled", out var value) || value is null)
+        {
+            return false;
+        }
+
+        return value switch
+        {
+            bool b => b,
+            string s => bool.TryParse(s, out var parsed) && parsed,
+            _ => false
+        };
+    }
+
+    private static string SafeId(string key)
+    {
+        var sb = new StringBuilder(key.Length);
+        foreach (var ch in key)
+        {
+            sb.Append(char.IsLetterOrDigit(ch) || ch == '_' ? ch : '_');
+        }
+
+        // Mermaid identifiers must start with a letter; prefix if numeric.
+        if (sb.Length == 0 || char.IsDigit(sb[0]))
+        {
+            sb.Insert(0, '_');
+        }
+
+        return sb.ToString();
+    }
+
+    private static string EscapeLabel(string value)
+    {
+        // Inside a "..."-wrapped Mermaid label, " breaks the parser. Use Mermaid's
+        // HTML-style escape so the character still renders. Pipes and angle
+        // brackets are left as-is since labels support a small HTML subset.
+        return value.Replace("\"", "#quot;");
+    }
+}

--- a/src/FlowOrchestrator.Core/Diagnostics/MermaidExportOptions.cs
+++ b/src/FlowOrchestrator.Core/Diagnostics/MermaidExportOptions.cs
@@ -1,0 +1,32 @@
+namespace FlowOrchestrator.Core.Diagnostics;
+
+/// <summary>
+/// Configuration knobs for <see cref="FlowMermaidExporter"/>.
+/// </summary>
+public sealed class MermaidExportOptions
+{
+    /// <summary>
+    /// Diagram direction passed to Mermaid's <c>flowchart</c> header.
+    /// Valid values are <c>TD</c> (top-down), <c>LR</c> (left-right), <c>BT</c>, and <c>RL</c>.
+    /// </summary>
+    public string Direction { get; set; } = "TD";
+
+    /// <summary>
+    /// When <see langword="true"/>, emits one trigger node per entry in
+    /// <see cref="Abstractions.FlowManifest.Triggers"/> and connects it to all entry steps.
+    /// </summary>
+    public bool IncludeTriggers { get; set; } = true;
+
+    /// <summary>
+    /// When <see langword="true"/>, the step's <see cref="Abstractions.StepMetadata.Type"/>
+    /// is rendered as italic text below the step key inside each node label.
+    /// </summary>
+    public bool ShowStepTypes { get; set; } = true;
+
+    /// <summary>
+    /// When <see langword="true"/>, emits <c>classDef</c> blocks and applies
+    /// <c>:::trigger</c>, <c>:::entry</c>, <c>:::polling</c>, and <c>:::loop</c>
+    /// classes to differentiate node roles visually.
+    /// </summary>
+    public bool ApplyStyling { get; set; } = true;
+}

--- a/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
@@ -464,6 +464,7 @@ button{font-family:inherit;cursor:pointer;border:none;outline:none}
         <div class="detail-tab" data-tab="fd-triggers" onclick="switchFlowTab('fd-triggers')">Triggers</div>
         <div class="detail-tab" data-tab="fd-schedule" onclick="switchFlowTab('fd-schedule')">Schedule</div>
         <div class="detail-tab" data-tab="fd-dag" onclick="switchFlowTab('fd-dag')">DAG</div>
+        <div class="detail-tab" data-tab="fd-mermaid" onclick="switchFlowTab('fd-mermaid')">Mermaid</div>
         <div class="detail-tab" data-tab="fd-json" onclick="switchFlowTab('fd-json')">Raw JSON</div>
       </div>
       <div class="tab-content active" id="fd-manifest"></div>
@@ -471,6 +472,7 @@ button{font-family:inherit;cursor:pointer;border:none;outline:none}
       <div class="tab-content" id="fd-triggers"></div>
       <div class="tab-content" id="fd-schedule"></div>
       <div class="tab-content" id="fd-dag"></div>
+      <div class="tab-content" id="fd-mermaid"></div>
       <div class="tab-content" id="fd-json"></div>
     </div>
   </div>
@@ -893,6 +895,36 @@ function renderFlowDetail() {
 
   // Raw JSON tab
   $('fd-json').innerHTML = '<div class="json-viewer">'+(m ? esc(JSON.stringify(m, null, 2)) : 'No manifest data.')+'</div>';
+
+  // Mermaid tab — fetched lazily from /api/flows/{id}/mermaid
+  renderMermaidTab(f.id);
+}
+
+function renderMermaidTab(flowId) {
+  const host = $('fd-mermaid');
+  host.innerHTML = '<div class="empty-msg">Loading Mermaid…</div>';
+  fetch('{{BASE_PATH}}/api/flows/'+flowId+'/mermaid', { headers: { 'Accept': 'text/plain' } })
+    .then(r => r.ok ? r.text() : Promise.reject(r.statusText))
+    .then(text => {
+      const safe = esc(text);
+      host.innerHTML =
+        '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">'
+        +'<div style="font-size:12px;color:var(--text-dim)">Paste into any Markdown surface that renders Mermaid (GitHub, Notion, Confluence, …).</div>'
+        +'<button class="btn-copy" onclick="copyMermaid(this)" data-mermaid="'+safe.replace(/"/g,'&quot;')+'">'
+          +'<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>'
+          +'Copy Mermaid'
+        +'</button>'
+        +'</div>'
+        +'<div class="json-viewer">'+safe+'</div>';
+    })
+    .catch(err => { host.innerHTML = '<div class="empty-msg">Failed to load Mermaid: '+esc(String(err))+'</div>'; });
+}
+
+function copyMermaid(btn) {
+  const tmp = document.createElement('textarea');
+  tmp.innerHTML = btn.dataset.mermaid;
+  const text = tmp.value;
+  navigator.clipboard.writeText(text).then(() => showToast('Mermaid copied!')).catch(() => alert('Copy failed'));
 }
 
 function renderDAG(manifest) {

--- a/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Diagnostics;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Storage;
 using Microsoft.AspNetCore.Builder;
@@ -119,6 +120,21 @@ public static class DashboardServiceCollectionExtensions
                 return;
             }
             await WriteJsonAsync(http.Response,flow);
+        });
+
+        group.MapGet("/api/flows/{id:guid}/mermaid", async (HttpContext http, IFlowRepository repo, Guid id) =>
+        {
+            var flow = (await repo.GetAllFlowsAsync()).FirstOrDefault(f => f.Id == id);
+            if (flow is null)
+            {
+                http.Response.StatusCode = StatusCodes.Status404NotFound;
+                http.Response.ContentType = "text/plain; charset=utf-8";
+                await http.Response.WriteAsync($"Flow '{id}' not found.");
+                return;
+            }
+
+            http.Response.ContentType = "text/plain; charset=utf-8";
+            await http.Response.WriteAsync(flow.ToMermaid());
         });
 
         group.MapPost("/api/flows/{id:guid}/enable", async (HttpContext http, IFlowStore store, IRecurringTriggerSync triggerSync, Guid id) =>

--- a/tests/FlowOrchestrator.Core.Tests/Diagnostics/FlowMermaidExporterTests.cs
+++ b/tests/FlowOrchestrator.Core.Tests/Diagnostics/FlowMermaidExporterTests.cs
@@ -1,0 +1,405 @@
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Diagnostics;
+
+namespace FlowOrchestrator.Core.Tests.Diagnostics;
+
+public class FlowMermaidExporterTests
+{
+    [Fact]
+    public void Linear_three_steps_emits_two_edges()
+    {
+        // Arrange
+        var manifest = new FlowManifest
+        {
+            Triggers = new FlowTriggerCollection
+            {
+                ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+            },
+            Steps = new StepCollection
+            {
+                ["a"] = new StepMetadata { Type = "TypeA" },
+                ["b"] = new StepMetadata
+                {
+                    Type = "TypeB",
+                    RunAfter = new RunAfterCollection { ["a"] = new[] { StepStatus.Succeeded } }
+                },
+                ["c"] = new StepMetadata
+                {
+                    Type = "TypeC",
+                    RunAfter = new RunAfterCollection { ["b"] = new[] { StepStatus.Succeeded } }
+                }
+            }
+        };
+
+        // Act
+        var result = manifest.ToMermaid();
+
+        // Assert
+        Assert.Contains("flowchart TD", result);
+        Assert.Contains("a -- Succeeded --> b", result);
+        Assert.Contains("b -- Succeeded --> c", result);
+    }
+
+    [Fact]
+    public void Header_respects_Direction_option()
+    {
+        // Arrange
+        var manifest = new FlowManifest
+        {
+            Steps = new StepCollection { ["a"] = new StepMetadata { Type = "TypeA" } }
+        };
+
+        // Act
+        var result = manifest.ToMermaid(new MermaidExportOptions { Direction = "LR" });
+
+        // Assert
+        Assert.Contains("flowchart LR", result);
+    }
+
+    [Fact]
+    public void FanOut_emits_one_edge_per_dependent_step()
+    {
+        // Arrange
+        var manifest = new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                ["root"] = new StepMetadata { Type = "Root" },
+                ["a"] = new StepMetadata
+                {
+                    Type = "A",
+                    RunAfter = new RunAfterCollection { ["root"] = new[] { StepStatus.Succeeded } }
+                },
+                ["b"] = new StepMetadata
+                {
+                    Type = "B",
+                    RunAfter = new RunAfterCollection { ["root"] = new[] { StepStatus.Succeeded } }
+                },
+                ["c"] = new StepMetadata
+                {
+                    Type = "C",
+                    RunAfter = new RunAfterCollection { ["root"] = new[] { StepStatus.Succeeded } }
+                }
+            }
+        };
+
+        // Act
+        var result = manifest.ToMermaid();
+
+        // Assert
+        Assert.Contains("root -- Succeeded --> a", result);
+        Assert.Contains("root -- Succeeded --> b", result);
+        Assert.Contains("root -- Succeeded --> c", result);
+    }
+
+    [Fact]
+    public void FanIn_emits_one_edge_from_each_predecessor_to_join()
+    {
+        // Arrange
+        var manifest = new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                ["a"] = new StepMetadata { Type = "A" },
+                ["b"] = new StepMetadata { Type = "B" },
+                ["c"] = new StepMetadata { Type = "C" },
+                ["join"] = new StepMetadata
+                {
+                    Type = "Join",
+                    RunAfter = new RunAfterCollection
+                    {
+                        ["a"] = new[] { StepStatus.Succeeded },
+                        ["b"] = new[] { StepStatus.Succeeded },
+                        ["c"] = new[] { StepStatus.Succeeded }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var result = manifest.ToMermaid();
+
+        // Assert
+        Assert.Contains("a -- Succeeded --> join", result);
+        Assert.Contains("b -- Succeeded --> join", result);
+        Assert.Contains("c -- Succeeded --> join", result);
+    }
+
+    [Fact]
+    public void MultipleTriggers_emit_one_node_per_trigger_each_pointing_to_entry_steps()
+    {
+        // Arrange
+        var manifest = new FlowManifest
+        {
+            Triggers = new FlowTriggerCollection
+            {
+                ["manual"] = new TriggerMetadata { Type = TriggerType.Manual },
+                ["webhook"] = new TriggerMetadata
+                {
+                    Type = TriggerType.Webhook,
+                    Inputs = new Dictionary<string, object?> { ["webhookSlug"] = "order-fulfillment" }
+                }
+            },
+            Steps = new StepCollection
+            {
+                ["fetch"] = new StepMetadata { Type = "Fetch" }
+            }
+        };
+
+        // Act
+        var result = manifest.ToMermaid();
+
+        // Assert
+        Assert.Contains("T_manual", result);
+        Assert.Contains("T_webhook", result);
+        Assert.Contains("T_manual --> fetch", result);
+        Assert.Contains("T_webhook --> fetch", result);
+        Assert.Contains("order-fulfillment", result);
+    }
+
+    [Fact]
+    public void LoopStep_emits_subgraph_with_child_steps()
+    {
+        // Arrange
+        var manifest = new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                ["fetch"] = new StepMetadata { Type = "Fetch" },
+                ["process_each"] = new LoopStepMetadata
+                {
+                    Type = "ForEach",
+                    ForEach = "@triggerBody()?.items",
+                    RunAfter = new RunAfterCollection { ["fetch"] = new[] { StepStatus.Succeeded } },
+                    Steps = new StepCollection
+                    {
+                        ["validate"] = new StepMetadata { Type = "Validate" }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var result = manifest.ToMermaid();
+
+        // Assert
+        Assert.Contains("subgraph", result);
+        Assert.Contains("process_each", result);
+        Assert.Contains("validate", result);
+        Assert.Contains("end", result);
+    }
+
+    [Fact]
+    public void RunAfter_with_multiple_statuses_emits_combined_label()
+    {
+        // Arrange
+        var manifest = new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                ["upstream"] = new StepMetadata { Type = "Upstream" },
+                ["downstream"] = new StepMetadata
+                {
+                    Type = "Down",
+                    RunAfter = new RunAfterCollection
+                    {
+                        ["upstream"] = new[] { StepStatus.Succeeded, StepStatus.Failed }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var result = manifest.ToMermaid();
+
+        // Assert
+        // Combined label: e.g. "upstream -- Succeeded|Failed --> downstream"
+        Assert.Matches(@"upstream -- Succeeded\|Failed --> downstream", result);
+    }
+
+    [Fact]
+    public void StepKey_with_hyphens_uses_safe_node_id_but_preserves_label()
+    {
+        // Arrange
+        var manifest = new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                ["my-step"] = new StepMetadata { Type = "TypeA" },
+                ["next"] = new StepMetadata
+                {
+                    Type = "TypeB",
+                    RunAfter = new RunAfterCollection { ["my-step"] = new[] { StepStatus.Succeeded } }
+                }
+            }
+        };
+
+        // Act
+        var result = manifest.ToMermaid();
+
+        // Assert
+        // Safe ID for "my-step" must not contain a hyphen — Mermaid treats it as a token.
+        Assert.Contains("my_step", result);
+        // Display label (inside quotes) must keep the original key.
+        Assert.Contains("\"my-step", result);
+        Assert.Contains("my_step -- Succeeded --> next", result);
+    }
+
+    [Fact]
+    public void StepType_with_quote_is_escaped_in_label()
+    {
+        // Arrange
+        var manifest = new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                ["a"] = new StepMetadata { Type = "Has\"Quote" }
+            }
+        };
+
+        // Act
+        var result = manifest.ToMermaid();
+
+        // Assert
+        // A bare " inside a Mermaid label breaks the parser.
+        // Either escape with #quot; or strip — the only requirement is it must NOT be a raw " inside the label.
+        Assert.DoesNotContain("Has\"Quote", result);
+    }
+
+    [Fact]
+    public void Polling_step_gets_polling_class_when_styling_enabled()
+    {
+        // Arrange
+        var manifest = new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                ["poll"] = new StepMetadata
+                {
+                    Type = "CallExternalApi",
+                    Inputs = new Dictionary<string, object?> { ["pollEnabled"] = true }
+                }
+            }
+        };
+
+        // Act
+        var result = manifest.ToMermaid();
+
+        // Assert
+        Assert.Contains(":::polling", result);
+    }
+
+    [Fact]
+    public void Entry_step_gets_entry_class_when_styling_enabled()
+    {
+        // Arrange
+        var manifest = new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                ["a"] = new StepMetadata { Type = "TypeA" }
+            }
+        };
+
+        // Act
+        var result = manifest.ToMermaid();
+
+        // Assert
+        Assert.Contains(":::entry", result);
+    }
+
+    [Fact]
+    public void ApplyStyling_false_omits_classDef_lines()
+    {
+        // Arrange
+        var manifest = new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                ["a"] = new StepMetadata { Type = "TypeA" }
+            }
+        };
+
+        // Act
+        var result = manifest.ToMermaid(new MermaidExportOptions { ApplyStyling = false });
+
+        // Assert
+        Assert.DoesNotContain("classDef", result);
+        Assert.DoesNotContain(":::entry", result);
+    }
+
+    [Fact]
+    public void IncludeTriggers_false_omits_trigger_nodes_and_edges()
+    {
+        // Arrange
+        var manifest = new FlowManifest
+        {
+            Triggers = new FlowTriggerCollection
+            {
+                ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+            },
+            Steps = new StepCollection
+            {
+                ["a"] = new StepMetadata { Type = "TypeA" }
+            }
+        };
+
+        // Act
+        var result = manifest.ToMermaid(new MermaidExportOptions { IncludeTriggers = false });
+
+        // Assert
+        Assert.DoesNotContain("T_manual", result);
+    }
+
+    [Fact]
+    public void ShowStepTypes_false_omits_type_label_text()
+    {
+        // Arrange
+        var manifest = new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                ["a"] = new StepMetadata { Type = "TypeA" }
+            }
+        };
+
+        // Act
+        var result = manifest.ToMermaid(new MermaidExportOptions { ShowStepTypes = false });
+
+        // Assert
+        Assert.DoesNotContain("TypeA", result);
+        Assert.DoesNotContain("<i>", result);
+    }
+
+    [Fact]
+    public void IFlowDefinition_extension_delegates_to_manifest()
+    {
+        // Arrange
+        var flow = new SampleFlow();
+
+        // Act
+        var fromFlow = flow.ToMermaid();
+        var fromManifest = flow.Manifest.ToMermaid();
+
+        // Assert
+        Assert.Equal(fromManifest, fromFlow);
+    }
+
+    private sealed class SampleFlow : IFlowDefinition
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+        public string Version => "1.0";
+        public FlowManifest Manifest { get; set; } = new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                ["a"] = new StepMetadata { Type = "TypeA" },
+                ["b"] = new StepMetadata
+                {
+                    Type = "TypeB",
+                    RunAfter = new RunAfterCollection { ["a"] = new[] { StepStatus.Succeeded } }
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- New `FlowMermaidExporter` + `MermaidExportOptions` in `FlowOrchestrator.Core.Diagnostics` — `flow.ToMermaid()` returns a Mermaid `flowchart` string that renders directly in GitHub, Notion, Confluence, and any modern Markdown surface, with no running app required.
- Sample app gains a `--export-mermaid <flowId|flowName>` short-circuit CLI (handy for CI workflows that comment a diagram on PRs); flows are discovered via reflection so adding new ones doesn't require touching the CLI.
- Dashboard exposes a "Mermaid" tab with a Copy button on every flow detail page, served by `GET /flows/api/flows/{id}/mermaid`.

Implements [.claude/plans/03-mermaid-export.md](.claude/plans/03-mermaid-export.md).

### Live preview (rendered by GitHub from this PR's README)

```mermaid
flowchart TD
    classDef trigger fill:#e1f5ff,stroke:#0288d1
    classDef entry fill:#c8e6c9,stroke:#388e3c
    classDef polling fill:#fff9c4,stroke:#f57f17

    T_manual["⚡ manual<br/>Manual"]:::trigger
    T_webhook["⚡ webhook<br/>Webhook /order-fulfillment"]:::trigger
    fetch_orders["fetch_orders<br/><i>QueryDatabase</i>"]:::entry
    submit_to_wms["submit_to_wms<br/><i>CallExternalApi</i>"]:::polling
    save_result["save_result<br/><i>SaveResult</i>"]

    T_manual --> fetch_orders
    T_webhook --> fetch_orders
    fetch_orders -- Succeeded --> submit_to_wms
    submit_to_wms -- Succeeded --> save_result
```

## Test plan

- [x] `dotnet build` — 0 errors (38 pre-existing OpenTelemetry CVE warnings, unrelated)
- [x] `dotnet test` — all green across 6 projects × 3 TFMs (net8/9/10)
  - Core: 121 passed (15 new `FlowMermaidExporterTests` covering linear, fan-out, fan-in, multi-trigger, ForEach subgraph, multi-status edges, hyphen-key sanitization, type-quote escaping, polling/entry class detection, all four options, and the `IFlowDefinition` extension)
  - Dashboard: 68 passed
  - InMemory / Hangfire / SqlServer / PostgreSQL: all passed
- [x] CLI smoke test — `--export-mermaid OrderFulfillmentFlow` and `--export-mermaid OrderBatchFlow` (loop with subgraph) emit valid Mermaid
- [x] CLI not-found error path lists all 10 discovered flows
- [x] Verify the README diagram renders as SVG on GitHub once merged (a one-off scheduled agent will check this in 7 days and open an issue if it breaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)