### PR TITLE
feat: WaitForSignal step + dashboard signal endpoint (Plan 07, v1.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.18.0] - 2026-05-01
+
+### Added
+
+- **`WaitForSignal` built-in step type for human-in-the-loop workflows.** A step parks
+  in `StepStatus.Pending` until an external HTTP signal is delivered, then resumes with
+  the signal's JSON payload as its output — available to downstream steps via
+  `@steps('wait_for_approval').output.fieldName`. This unlocks the entire approval
+  workflow category (order fulfillment, content moderation, contract sign-off, manual
+  QA gates) without forcing users to fake it via long-polling steps.
+  - New `IFlowSignalStore` abstraction (Core) with implementations for in-memory, SQL
+    Server, and PostgreSQL. Migrations add `FlowSignalWaiters` / `flow_signal_waiters`
+    idempotently on existing databases — no data loss.
+  - New `IFlowSignalDispatcher` service plus `POST /flows/api/runs/{runId}/signals/{signalName}`
+    endpoint with the documented status-code matrix (200 / 400 / 404 / 409).
+  - Dashboard run-detail page renders a **Send Signal** button on every parked
+    `WaitForSignal` step; the button auto-resolves the configured signal name from the
+    step input so users do not need to know it.
+  - Optional `timeoutSeconds` input transitions the step to `Failed` with a descriptive
+    reason when no signal arrives in time. The handler is idempotent across stale
+    re-dispatches: leaving the waiter row as a tombstone after delivery / expiry
+    prevents the polling loop from re-registering a fresh waiter.
+  - Sample: `samples/FlowOrchestrator.SampleApp/Flows/ApprovalWorkflowFlow.cs`.
+  - Documentation: [WaitForSignal](docs/articles/wait-for-signal.md).
+
 ## [1.17.0] - 2026-05-01
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <RepositoryUrl>https://github.com/hoangsnowy/FlowOrchestrator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/hoangsnowy/FlowOrchestrator</PackageProjectUrl>
-    <VersionPrefix>1.17.0</VersionPrefix>
+    <VersionPrefix>1.18.0</VersionPrefix>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -22,6 +22,9 @@
 - name: Polling Steps
   href: polling.md
 
+- name: WaitForSignal
+  href: wait-for-signal.md
+
 - name: ForEach Loops
   href: foreach.md
 

--- a/docs/articles/wait-for-signal.md
+++ b/docs/articles/wait-for-signal.md
@@ -1,0 +1,201 @@
+# `WaitForSignal` Step — Human-in-the-Loop Workflows
+
+The built-in `WaitForSignal` step parks a flow indefinitely until an external HTTP signal is delivered. Use it for approval workflows, content moderation gates, manual QA sign-off, or any "pause until a human (or external system) says go" pattern — without burning a worker thread on a polling loop.
+
+It is the smallest possible primitive that unlocks the entire **approval workflow** category: ship value in a weekend, not a quarter.
+
+## When To Use It vs. Polling
+
+| Pattern | Use case | Mechanism |
+|---|---|---|
+| `PollableStepHandler<T>` | Wait for an external system that *will* eventually respond on its own (job status, file appearance, blob upload completion). | Step re-runs on a fixed cadence; you write the fetch + condition. |
+| `WaitForSignal` | Wait for an external system or human that will *push* a notification when ready (manager approval, webhook from third party, async batch completion). | Step parks; an HTTP POST wakes it up. |
+
+Rule of thumb: if you'd hit a rate limit polling once a minute, `WaitForSignal` is the right choice.
+
+## Manifest
+
+```csharp
+["wait_for_approval"] = new StepMetadata
+{
+    Type = "WaitForSignal",
+    RunAfter = new RunAfterCollection { ["submit_request"] = [StepStatus.Succeeded] },
+    Inputs = new Dictionary<string, object?>
+    {
+        ["signalName"]     = "approval",
+        ["timeoutSeconds"] = 86400        // optional; null/omitted = wait indefinitely
+    }
+}
+```
+
+Fields:
+
+- `signalName` (required) — the logical name addressed by the signal endpoint. Must be unique among the parked `WaitForSignal` steps in the same run.
+- `timeoutSeconds` (optional) — absolute deadline. When elapsed without delivery, the step transitions to `Failed` with a descriptive reason. `null` or non-positive values mean "wait forever".
+
+## End-to-End Example
+
+```csharp
+public sealed class ApprovalFlow : IFlowDefinition
+{
+    public Guid Id { get; } = new("00000000-0000-0000-0000-000000000007");
+    public string Version => "1.0";
+    public FlowManifest Manifest { get; set; } = new()
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            ["submit"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                Inputs = new() { ["message"] = "Awaiting manager approval" }
+            },
+            ["wait_for_approval"] = new StepMetadata
+            {
+                Type = "WaitForSignal",
+                RunAfter = new() { ["submit"] = [StepStatus.Succeeded] },
+                Inputs = new()
+                {
+                    ["signalName"]     = "approval",
+                    ["timeoutSeconds"] = 86400
+                }
+            },
+            ["finalize"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                RunAfter = new() { ["wait_for_approval"] = [StepStatus.Succeeded] },
+                Inputs = new()
+                {
+                    ["message"] = "@steps('wait_for_approval').output.approver"
+                }
+            }
+        }
+    };
+}
+```
+
+Wake the parked step from `curl`:
+
+```bash
+curl -X POST http://localhost:5000/flows/api/runs/<runId>/signals/approval \
+     -H "Content-Type: application/json" \
+     -d '{"approver":"alice@example.com","approved":true}'
+```
+
+Response on success:
+
+```json
+{
+  "delivered": true,
+  "stepKey": "wait_for_approval",
+  "deliveredAt": "2026-05-01T14:33:21+00:00"
+}
+```
+
+Downstream steps consume the payload via the same expression syntax used for any step output:
+
+```csharp
+["message"] = "@steps('wait_for_approval').output.approver"
+```
+
+## Endpoint Status Codes
+
+| Status | Meaning |
+|---|---|
+| `200` | Signal delivered. Body includes `stepKey` and `deliveredAt`. |
+| `404` | Run does not exist, or no waiter is registered for that signal name on the run. |
+| `409` | A signal has already been delivered for this waiter — second delivery rejected. |
+| `400` | Body is not valid JSON, or run is no longer in `Running` status. |
+
+## Timeout Patterns
+
+Set `timeoutSeconds` to fail the step (and therefore the run, unless you wire a recovery branch with a downstream step that runs on `[StepStatus.Failed]`) after a deadline:
+
+```csharp
+["wait_for_approval"] = new StepMetadata
+{
+    Type = "WaitForSignal",
+    RunAfter = new() { ["submit"] = [StepStatus.Succeeded] },
+    Inputs = new()
+    {
+        ["signalName"]     = "approval",
+        ["timeoutSeconds"] = 3600   // 1 hour
+    }
+},
+["escalate_to_director"] = new StepMetadata
+{
+    Type = "NotifyDirector",
+    RunAfter = new() { ["wait_for_approval"] = [StepStatus.Failed] }
+}
+```
+
+The step's `FailedReason` reads `Signal '<name>' not received within <n>s.` so it is easy to distinguish from a handler exception in the dashboard.
+
+## Multi-Signal Patterns
+
+A run may have multiple `WaitForSignal` steps, each with its own `signalName`. They can run in parallel (no `runAfter` between them) or in sequence.
+
+**Both manager and finance must approve:** two parallel waiters, both must succeed:
+
+```csharp
+["wait_manager"] = new StepMetadata
+{
+    Type = "WaitForSignal",
+    Inputs = new() { ["signalName"] = "manager-approval" }
+},
+["wait_finance"] = new StepMetadata
+{
+    Type = "WaitForSignal",
+    Inputs = new() { ["signalName"] = "finance-approval" }
+},
+["finalize"] = new StepMetadata
+{
+    Type = "Echo",
+    RunAfter = new()
+    {
+        ["wait_manager"] = [StepStatus.Succeeded],
+        ["wait_finance"] = [StepStatus.Succeeded]
+    }
+}
+```
+
+Manager and finance each POST to their respective signal name; only when both have arrived does `finalize` run.
+
+## Security
+
+The signal endpoint accepts any JSON body and is **not** authenticated by default. Production deployments should:
+
+1. Wrap the dashboard route group in your standard auth middleware (`UseAuthentication()` / `UseAuthorization()` before `MapFlowDashboard()`).
+2. Or front the dashboard with API gateway / mTLS / service-mesh policy that verifies the caller has authority to deliver signals.
+
+The endpoint enforces only one structural check beyond your middleware: the run must be in `Running` status. A delivered signal cannot resurrect a cancelled or completed run.
+
+## Observability
+
+When event persistence is enabled (`builder.Observability.EnableEventPersistence = true`), the engine emits these events for each `WaitForSignal` step:
+
+- `step.started` on every invocation (initial park, signal arrival, timeout fire).
+- `step.pending` after the first invocation parks the step.
+- `step.completed` on successful delivery.
+- `step.failed` on timeout.
+
+The dashboard run detail page shows the events in chronological order, plus the resolved input/output and any handler logs surfaced through `IExecutionContext`.
+
+## Restart Safety
+
+Waiters live in your configured storage (`FlowSignalWaiters` table for SQL Server, `flow_signal_waiters` for PostgreSQL, `ConcurrentDictionary` for in-memory). A process restart does not lose pending waits: when the worker comes back up, `FlowRunRecoveryHostedService` restores active runs, and the next invocation of the parked step picks up the persisted waiter row. In-memory storage is lost on restart, by design.
+
+## Out of Scope
+
+For deliberate simplicity, this primitive does **not** include:
+
+- HMAC-signed signal endpoints. Use auth middleware instead.
+- Broadcast multi-recipient signals. Each waiter is identified by `(RunId, StepKey)`; one signal targets one waiter.
+- Signal cancellation API. Cancel the run instead.
+- Long-poll API for callers waiting for delivery confirmation.
+- Persistent signal queues for signals that arrive before a step is ready to receive them.
+
+If you find yourself needing one of these, you've outgrown the primitive — consider modeling the workflow as a separate service that triggers FlowOrchestrator, rather than driving FlowOrchestrator from the wait point.

--- a/samples/FlowOrchestrator.SampleApp/Flows/ApprovalWorkflowFlow.cs
+++ b/samples/FlowOrchestrator.SampleApp/Flows/ApprovalWorkflowFlow.cs
@@ -1,0 +1,64 @@
+using FlowOrchestrator.Core.Abstractions;
+
+namespace FlowOrchestrator.SampleApp.Flows;
+
+/// <summary>
+/// ApprovalWorkflowFlow — Demonstrates the built-in <c>WaitForSignal</c> step type for
+/// human-in-the-loop workflows.
+///
+/// Flow shape:
+///   submit_request          → LogMessage (records the incoming request)
+///   wait_for_approval       → WaitForSignal (parks until the dashboard / API delivers a signal)
+///   notify_approver         → LogMessage (uses the signal payload via @steps('wait_for_approval'))
+///
+/// To trigger a manual run from the dashboard at <c>/flows</c>: click "Trigger". To deliver the
+/// signal, open the run page and click "Send Signal" on the parked <c>wait_for_approval</c> step,
+/// or POST directly:
+/// <code>
+/// curl -X POST http://localhost:&lt;port&gt;/flows/api/runs/{runId}/signals/approval \
+///      -H "Content-Type: application/json" \
+///      -d '{"approved":true,"approver":"manager@example.com"}'
+/// </code>
+/// </summary>
+public sealed class ApprovalWorkflowFlow : IFlowDefinition
+{
+    public Guid Id { get; } = new Guid("00000000-0000-0000-0000-000000000007");
+    public string Version => "1.0";
+    public FlowManifest Manifest { get; set; } = new FlowManifest
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            ["submit_request"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "Approval request submitted; awaiting manager review."
+                }
+            },
+            ["wait_for_approval"] = new StepMetadata
+            {
+                Type = "WaitForSignal",
+                RunAfter = new RunAfterCollection { ["submit_request"] = [StepStatus.Succeeded] },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["signalName"] = "approval",
+                    ["timeoutSeconds"] = 86400  // 24 hours
+                }
+            },
+            ["notify_approver"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                RunAfter = new RunAfterCollection { ["wait_for_approval"] = [StepStatus.Succeeded] },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "@steps('wait_for_approval').output.approver"
+                }
+            }
+        }
+    };
+}

--- a/samples/FlowOrchestrator.SampleApp/Program.cs
+++ b/samples/FlowOrchestrator.SampleApp/Program.cs
@@ -149,6 +149,11 @@ builder.Services.AddFlowOrchestrator(options =>
     // Trigger with { "amount": 1500 } → high_value_approve runs; { "amount": 500 } → auto_approve runs.
     options.AddFlow<AmountThresholdFlow>();
 
+    // WaitForSignal demo — submit_request → wait_for_approval (parked) → notify_approver.
+    // Drive it by clicking "Send Signal" on the parked step in the dashboard, or POSTing to
+    // /flows/api/runs/{runId}/signals/approval with a JSON body like {"approver":"manager"}.
+    options.AddFlow<ApprovalWorkflowFlow>();
+
     if (storageBackend == "sqlserver")
         options.AddFlow<OrderFulfillmentFlow>();
 });

--- a/src/FlowOrchestrator.Core/Execution/FlowSignalDispatcher.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowSignalDispatcher.cs
@@ -1,0 +1,116 @@
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Storage;
+
+namespace FlowOrchestrator.Core.Execution;
+
+/// <summary>
+/// Application-facing entry point for delivering signals to parked <c>WaitForSignal</c> steps.
+/// Used by the dashboard signal endpoint and by tests/applications that prefer not to talk to HTTP.
+/// </summary>
+public interface IFlowSignalDispatcher
+{
+    /// <summary>
+    /// Validates the run, persists the payload on the matching waiter, and nudges the engine
+    /// to re-execute the parked step so it observes the delivered payload.
+    /// </summary>
+    /// <param name="runId">The run whose <c>WaitForSignal</c> step should receive the signal.</param>
+    /// <param name="signalName">Logical signal name configured on the step's <c>signalName</c> input.</param>
+    /// <param name="payloadJson">Pre-serialised JSON payload supplied by the caller.</param>
+    /// <param name="ct">Cancellation token.</param>
+    ValueTask<SignalDeliveryResult> DispatchAsync(
+        Guid runId,
+        string signalName,
+        string payloadJson,
+        CancellationToken ct = default);
+}
+
+/// <summary>Default implementation that delegates persistence to <see cref="IFlowSignalStore"/> and
+/// re-dispatch to <see cref="IStepDispatcher.ScheduleStepAsync"/>.</summary>
+public sealed class FlowSignalDispatcher : IFlowSignalDispatcher
+{
+    private static readonly TimeSpan ResumeDelay = TimeSpan.FromMilliseconds(500);
+
+    private readonly IFlowSignalStore _signalStore;
+    private readonly IFlowRunStore _runStore;
+    private readonly IFlowRepository _flowRepository;
+    private readonly IStepDispatcher _dispatcher;
+    private readonly IOutputsRepository _outputsRepository;
+
+    /// <summary>Initialises the dispatcher with its dependencies.</summary>
+    public FlowSignalDispatcher(
+        IFlowSignalStore signalStore,
+        IFlowRunStore runStore,
+        IFlowRepository flowRepository,
+        IStepDispatcher dispatcher,
+        IOutputsRepository outputsRepository)
+    {
+        _signalStore = signalStore;
+        _runStore = runStore;
+        _flowRepository = flowRepository;
+        _dispatcher = dispatcher;
+        _outputsRepository = outputsRepository;
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask<SignalDeliveryResult> DispatchAsync(
+        Guid runId,
+        string signalName,
+        string payloadJson,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(signalName))
+        {
+            return new SignalDeliveryResult(SignalDeliveryStatus.NotFound, null, null);
+        }
+
+        var result = await _signalStore.DeliverSignalAsync(runId, signalName.Trim(), payloadJson, ct).ConfigureAwait(false);
+        if (result.Status != SignalDeliveryStatus.Delivered || result.StepKey is null)
+        {
+            return result;
+        }
+
+        var run = await _runStore.GetRunDetailAsync(runId).ConfigureAwait(false);
+        if (run is null)
+        {
+            return new SignalDeliveryResult(SignalDeliveryStatus.NotFound, null, null);
+        }
+
+        var flows = await _flowRepository.GetAllFlowsAsync().ConfigureAwait(false);
+        var flow = flows.FirstOrDefault(f => f.Id == run.FlowId);
+        if (flow is null)
+        {
+            return result;
+        }
+
+        var stepMeta = flow.Manifest.Steps.FindStep(result.StepKey);
+        if (stepMeta is null)
+        {
+            return result;
+        }
+
+        var ctx = new ExecutionContext { RunId = runId };
+        ctx.TriggerData = await _outputsRepository.GetTriggerDataAsync(runId).ConfigureAwait(false);
+        ctx.TriggerHeaders = await _outputsRepository.GetTriggerHeadersAsync(runId).ConfigureAwait(false);
+
+        var step = new StepInstance(result.StepKey, stepMeta.Type)
+        {
+            RunId = runId,
+            ScheduledTime = DateTimeOffset.UtcNow + ResumeDelay,
+            Inputs = new Dictionary<string, object?>(stepMeta.Inputs)
+        };
+
+        // Best-effort: a 500ms delay lets the prior Pending invocation release its dispatch claim
+        // before the resume attempt re-acquires it. We swallow dispatcher errors and surface the
+        // delivery status — the timeout safety-net invocation will catch up either way.
+        try
+        {
+            await _dispatcher.ScheduleStepAsync(ctx, flow, step, ResumeDelay, ct).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Intentionally swallowed; signal is still delivered, handler will observe on next dispatch.
+        }
+
+        return result;
+    }
+}

--- a/src/FlowOrchestrator.Core/Execution/WaitForSignalHandler.cs
+++ b/src/FlowOrchestrator.Core/Execution/WaitForSignalHandler.cs
@@ -1,0 +1,158 @@
+using System.Text.Json;
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Storage;
+
+namespace FlowOrchestrator.Core.Execution;
+
+/// <summary>
+/// Strongly-typed inputs for the built-in <c>WaitForSignal</c> step type.
+/// </summary>
+public sealed class WaitForSignalInput
+{
+    /// <summary>
+    /// Logical signal name addressed by callers when posting to the signal endpoint.
+    /// Must be unique among the <c>WaitForSignal</c> steps active in the same run.
+    /// </summary>
+    public string SignalName { get; set; } = "default";
+
+    /// <summary>
+    /// Maximum time to wait, in seconds. <c>null</c> or non-positive means wait indefinitely.
+    /// When the deadline passes, the step transitions to <see cref="StepStatus.Failed"/>.
+    /// </summary>
+    public int? TimeoutSeconds { get; set; }
+}
+
+/// <summary>
+/// Built-in handler for the <c>WaitForSignal</c> step type. Parks the step in
+/// <see cref="StepStatus.Pending"/> until either an external signal is delivered via
+/// <see cref="IFlowSignalStore.DeliverSignalAsync"/> or the configured timeout elapses.
+/// </summary>
+/// <remarks>
+/// This handler is invoked at least three times in the happy path:
+/// <list type="number">
+///   <item>First invocation registers the waiter and returns <see cref="StepStatus.Pending"/>.</item>
+///   <item>The signal endpoint persists a payload then nudges this step via <c>IStepDispatcher.ScheduleStepAsync</c>.</item>
+///   <item>Second invocation observes <c>DeliveredAt</c> on the waiter and returns <see cref="StepStatus.Succeeded"/>.</item>
+/// </list>
+/// On timeout, the third invocation (scheduled during the first) observes the expired waiter and returns <see cref="StepStatus.Failed"/>.
+/// </remarks>
+public sealed class WaitForSignalHandler : IStepHandler<WaitForSignalInput>
+{
+    private static readonly TimeSpan IndefiniteParkInterval = TimeSpan.FromHours(24);
+
+    private readonly IFlowSignalStore _signalStore;
+    private readonly TimeProvider _clock;
+
+    /// <summary>Initialises the handler with its dependencies.</summary>
+    public WaitForSignalHandler(IFlowSignalStore signalStore, TimeProvider? clock = null)
+    {
+        _signalStore = signalStore;
+        _clock = clock ?? TimeProvider.System;
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask<object?> ExecuteAsync(
+        IExecutionContext context, IFlowDefinition flow, IStepInstance<WaitForSignalInput> step)
+    {
+        var input = step.Inputs ?? new WaitForSignalInput();
+        if (string.IsNullOrWhiteSpace(input.SignalName))
+        {
+            return new StepResult
+            {
+                Key = step.Key,
+                Status = StepStatus.Failed,
+                FailedReason = "WaitForSignal step requires a non-empty 'signalName' input."
+            };
+        }
+
+        var now = _clock.GetUtcNow();
+        var waiter = await _signalStore.GetWaiterAsync(context.RunId, step.Key).ConfigureAwait(false);
+
+        // ── Branch 1: signal already delivered → succeed and emit payload as output ───────────
+        // The waiter row is intentionally NOT removed here. Leaving it as a tombstone makes the
+        // handler idempotent if the engine re-invokes the step later (e.g. a stale polling
+        // reschedule queued before delivery): subsequent invocations re-enter this branch and
+        // return Succeeded again instead of re-registering a fresh waiter and re-parking.
+        if (waiter is { DeliveredAt: not null })
+        {
+            var payload = ParsePayload(waiter.PayloadJson);
+            return new StepResult
+            {
+                Key = step.Key,
+                Status = StepStatus.Succeeded,
+                Result = payload
+            };
+        }
+
+        // ── Branch 2: waiter expired without delivery → fail with descriptive reason ──────────
+        // Same idempotency reasoning: leave the row with ExpiresAt < now so a stale re-invocation
+        // returns Failed again rather than registering a brand-new waiter.
+        if (waiter is { ExpiresAt: { } expiresAt } && now >= expiresAt)
+        {
+            var elapsed = (int)Math.Round((expiresAt - waiter.CreatedAt).TotalSeconds, MidpointRounding.AwayFromZero);
+            return new StepResult
+            {
+                Key = step.Key,
+                Status = StepStatus.Failed,
+                FailedReason = $"Signal '{waiter.SignalName}' not received within {elapsed}s."
+            };
+        }
+
+        // ── Branch 3: not yet registered → register and pend (with timeout schedule if any) ───
+        if (waiter is null)
+        {
+            DateTimeOffset? expiry = input.TimeoutSeconds is { } seconds && seconds > 0
+                ? now + TimeSpan.FromSeconds(seconds)
+                : null;
+
+            await _signalStore
+                .RegisterWaiterAsync(context.RunId, step.Key, input.SignalName.Trim(), expiry)
+                .ConfigureAwait(false);
+
+            // Park the step. If a timeout is configured, schedule the engine to re-invoke us
+            // shortly after the deadline so we can observe the expiry. Otherwise park for a
+            // long but bounded interval so the engine still considers the run live in metrics.
+            var delay = expiry is { } at
+                ? Max(at - now + TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1))
+                : IndefiniteParkInterval;
+
+            return new StepResult
+            {
+                Key = step.Key,
+                Status = StepStatus.Pending,
+                DelayNextStep = delay
+            };
+        }
+
+        // ── Branch 4: already registered, neither delivered nor expired → keep waiting ───────
+        var remainingDelay = waiter.ExpiresAt is { } absoluteExpiry
+            ? Max(absoluteExpiry - now + TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1))
+            : IndefiniteParkInterval;
+        return new StepResult
+        {
+            Key = step.Key,
+            Status = StepStatus.Pending,
+            DelayNextStep = remainingDelay
+        };
+    }
+
+    private static TimeSpan Max(TimeSpan a, TimeSpan b) => a > b ? a : b;
+
+    private static object? ParsePayload(string? payloadJson)
+    {
+        if (string.IsNullOrWhiteSpace(payloadJson))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(payloadJson);
+            return doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            return payloadJson;
+        }
+    }
+}

--- a/src/FlowOrchestrator.Core/Storage/FlowSignalWaiter.cs
+++ b/src/FlowOrchestrator.Core/Storage/FlowSignalWaiter.cs
@@ -1,0 +1,51 @@
+namespace FlowOrchestrator.Core.Storage;
+
+/// <summary>
+/// Persisted record of a <c>WaitForSignal</c> step that is currently parked, awaiting an external signal.
+/// One row per (RunId, StepKey).
+/// </summary>
+public sealed class FlowSignalWaiter
+{
+    /// <summary>The run that owns the parked step.</summary>
+    public Guid RunId { get; set; }
+
+    /// <summary>The step key (matches the manifest step name).</summary>
+    public string StepKey { get; set; } = default!;
+
+    /// <summary>Logical signal name used to address this waiter from the signal endpoint.</summary>
+    public string SignalName { get; set; } = default!;
+
+    /// <summary>Time the waiter was first registered.</summary>
+    public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>Optional absolute deadline; once <see cref="DateTimeOffset.UtcNow"/> passes this, the step fails.</summary>
+    public DateTimeOffset? ExpiresAt { get; set; }
+
+    /// <summary>Set when <see cref="IFlowSignalStore.DeliverSignalAsync"/> succeeds.</summary>
+    public DateTimeOffset? DeliveredAt { get; set; }
+
+    /// <summary>JSON payload supplied by the caller when the signal was delivered.</summary>
+    public string? PayloadJson { get; set; }
+}
+
+/// <summary>Outcome of a <see cref="IFlowSignalStore.DeliverSignalAsync"/> attempt.</summary>
+public enum SignalDeliveryStatus
+{
+    /// <summary>Payload was persisted on the matching waiter.</summary>
+    Delivered,
+
+    /// <summary>No waiter is registered for the (run, signal name) pair.</summary>
+    NotFound,
+
+    /// <summary>A waiter exists but already received a signal — second delivery rejected.</summary>
+    AlreadyDelivered
+}
+
+/// <summary>Result of <see cref="IFlowSignalStore.DeliverSignalAsync"/>.</summary>
+/// <param name="Status">Disposition of the delivery attempt.</param>
+/// <param name="StepKey">When <see cref="SignalDeliveryStatus.Delivered"/>, the step key whose waiter received the payload.</param>
+/// <param name="DeliveredAt">When <see cref="SignalDeliveryStatus.Delivered"/>, the timestamp recorded on the waiter row.</param>
+public readonly record struct SignalDeliveryResult(
+    SignalDeliveryStatus Status,
+    string? StepKey,
+    DateTimeOffset? DeliveredAt);

--- a/src/FlowOrchestrator.Core/Storage/IFlowSignalStore.cs
+++ b/src/FlowOrchestrator.Core/Storage/IFlowSignalStore.cs
@@ -1,0 +1,62 @@
+namespace FlowOrchestrator.Core.Storage;
+
+/// <summary>
+/// Persistence contract for <c>WaitForSignal</c> step waiters: parked steps that resume only when an
+/// external signal is delivered via the dashboard signal endpoint or programmatic call.
+/// </summary>
+/// <remarks>
+/// Backends must guarantee atomic delivery semantics: a single signal is either persisted exactly once
+/// on the matching waiter row, or rejected as <see cref="SignalDeliveryStatus.AlreadyDelivered"/>. The
+/// in-memory backend uses <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey, TValue}.TryUpdate"/>;
+/// SQL backends use a conditional <c>UPDATE … WHERE DeliveredAt IS NULL</c> with row-count detection.
+/// </remarks>
+public interface IFlowSignalStore
+{
+    /// <summary>
+    /// Registers a new waiter for <paramref name="runId"/> + <paramref name="stepKey"/>. Idempotent —
+    /// a duplicate register on the same key updates the signal name / expiry without resetting <c>CreatedAt</c>.
+    /// </summary>
+    /// <param name="runId">The run that owns the parked step.</param>
+    /// <param name="stepKey">The step key as authored in the flow manifest.</param>
+    /// <param name="signalName">Logical signal name to address the waiter from the signal endpoint.</param>
+    /// <param name="expiresAt">Optional absolute deadline; <see langword="null"/> waits indefinitely.</param>
+    /// <param name="ct">Cancellation token.</param>
+    ValueTask RegisterWaiterAsync(
+        Guid runId,
+        string stepKey,
+        string signalName,
+        DateTimeOffset? expiresAt,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Atomically attempts to deliver a payload to the waiter matching (<paramref name="runId"/>, <paramref name="signalName"/>).
+    /// </summary>
+    /// <param name="runId">The run whose waiter should receive the payload.</param>
+    /// <param name="signalName">Signal name to look up.</param>
+    /// <param name="payloadJson">Pre-serialised JSON payload supplied by the caller.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// <see cref="SignalDeliveryStatus.Delivered"/> with the resolved <c>StepKey</c> on success;
+    /// <see cref="SignalDeliveryStatus.NotFound"/> when no waiter matches;
+    /// <see cref="SignalDeliveryStatus.AlreadyDelivered"/> when a payload is already recorded.
+    /// </returns>
+    ValueTask<SignalDeliveryResult> DeliverSignalAsync(
+        Guid runId,
+        string signalName,
+        string payloadJson,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the waiter for the given run + step key, or <see langword="null"/> if none is registered.
+    /// </summary>
+    ValueTask<FlowSignalWaiter?> GetWaiterAsync(
+        Guid runId,
+        string stepKey,
+        CancellationToken ct = default);
+
+    /// <summary>Removes the waiter row. Called by the handler when the wait is over (delivered, expired, or cancelled).</summary>
+    ValueTask RemoveWaiterAsync(
+        Guid runId,
+        string stepKey,
+        CancellationToken ct = default);
+}

--- a/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardHtml.cs
@@ -1802,6 +1802,7 @@ function renderTimeline(steps, runId) {
       +'<div style="display:flex;align-items:center;gap:6px"><span class="step-badge '+s.status+'">'+stepStatusLabel(s.status)+'</span>'
       +(attemptCount>1?'<span class="step-badge Pending">x'+attemptCount+' attempts</span>':'')
       +(s.status==='Failed'?'<button class="btn-retry" onclick="retryStep(\''+runId+'\',\''+esc(s.stepKey)+'\')">&#8635; Retry</button>':'')
+      +(s.status==='Pending' && s.stepType==='WaitForSignal'?'<button class="btn-retry" onclick="sendSignal(\''+runId+'\',\''+esc(s.stepKey)+'\')">Send Signal</button>':'')
       +(s.status!=='Skipped'?'<button class="btn-copy-icon" onclick="copyStepLink(\''+runId+'\',\''+esc(s.stepKey)+'\')" title="Copy step link"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="2" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>':'')
       +'</div></div>'
       +(s.status==='Skipped'?'':('<div class="step-timing"><span>Start: '+fmt(s.startedAt)+'</span><span>End: '+fmt(s.completedAt)+'</span><span>Duration: '+duration(s.startedAt,s.completedAt)+'</span></div>'))
@@ -1822,6 +1823,43 @@ async function retryStep(runId, stepKey) {
       alert(data.error || 'Retry failed.');
     }
   } catch(e) { alert('Failed to retry step: '+e.message); }
+}
+
+async function sendSignal(runId, stepKey) {
+  // Resolve the configured signalName from the step input so the user does not have to know it.
+  // BASE already ends in '/api' — do NOT prefix '/api/' again.
+  let signalName = stepKey;
+  try {
+    const detail = await (await fetch(BASE+'/runs/'+runId)).json();
+    const step = (detail.steps||[]).find(x=>x.stepKey===stepKey);
+    if (step && step.inputJson) {
+      try { const inputs = JSON.parse(step.inputJson); if (inputs && inputs.signalName) signalName = inputs.signalName; }
+      catch {}
+    }
+  } catch {}
+
+  const raw = prompt('Payload JSON for signal "'+signalName+'":', '{"approved":true}');
+  if (raw === null) return;
+
+  let body = raw && raw.trim() ? raw : '{}';
+  try { JSON.parse(body); }
+  catch (e) { alert('Invalid JSON: '+e.message); return; }
+
+  try {
+    const res = await fetch(BASE+'/runs/'+runId+'/signals/'+encodeURIComponent(signalName), {
+      method: 'POST',
+      headers: {'Content-Type':'application/json'},
+      body: body
+    });
+    const data = await res.json();
+    if (res.ok && data.delivered) {
+      await selectRun(runId);
+    } else if (res.status === 409) {
+      alert('Signal was already delivered to step "'+(data.stepKey||stepKey)+'".');
+    } else {
+      alert(data.error || ('Signal delivery failed (status '+res.status+').'));
+    }
+  } catch(e) { alert('Failed to send signal: '+e.message); }
 }
 
 // Scheduled Jobs

--- a/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
@@ -512,6 +512,72 @@ public static class DashboardServiceCollectionExtensions
             await WriteJsonAsync(http.Response,new { success = true, message = $"Step '{stepKey}' retry enqueued." });
         });
 
+        group.MapPost("/api/runs/{runId:guid}/signals/{signalName}", async (HttpContext http, IFlowRunStore runStore, IFlowSignalDispatcher signals, Guid runId, string signalName) =>
+        {
+            if (string.IsNullOrWhiteSpace(signalName))
+            {
+                http.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await WriteJsonAsync(http.Response, new { error = "Signal name is required." });
+                return;
+            }
+
+            string body;
+            using (var reader = new StreamReader(http.Request.Body, Encoding.UTF8))
+            {
+                body = await reader.ReadToEndAsync();
+            }
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                body = "{}";
+            }
+
+            try
+            {
+                using var _ = JsonDocument.Parse(body);
+            }
+            catch (JsonException)
+            {
+                http.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await WriteJsonAsync(http.Response, new { error = "Request body must be valid JSON." });
+                return;
+            }
+
+            var run = await runStore.GetRunDetailAsync(runId);
+            if (run is null)
+            {
+                http.Response.StatusCode = StatusCodes.Status404NotFound;
+                await WriteJsonAsync(http.Response, new { error = "Run not found." });
+                return;
+            }
+            if (!string.Equals(run.Status, "Running", StringComparison.OrdinalIgnoreCase))
+            {
+                http.Response.StatusCode = StatusCodes.Status400BadRequest;
+                await WriteJsonAsync(http.Response, new { error = $"Run is not active (status: {run.Status})." });
+                return;
+            }
+
+            var result = await signals.DispatchAsync(runId, signalName, body, http.RequestAborted);
+            switch (result.Status)
+            {
+                case SignalDeliveryStatus.Delivered:
+                    await WriteJsonAsync(http.Response, new
+                    {
+                        delivered = true,
+                        stepKey = result.StepKey,
+                        deliveredAt = result.DeliveredAt
+                    });
+                    return;
+                case SignalDeliveryStatus.AlreadyDelivered:
+                    http.Response.StatusCode = StatusCodes.Status409Conflict;
+                    await WriteJsonAsync(http.Response, new { error = "Signal already delivered.", stepKey = result.StepKey });
+                    return;
+                default:
+                    http.Response.StatusCode = StatusCodes.Status404NotFound;
+                    await WriteJsonAsync(http.Response, new { error = $"No waiter registered for signal '{signalName}' on this run." });
+                    return;
+            }
+        });
+
         group.MapPost("/api/runs/{runId:guid}/rerun", async (HttpContext http, IFlowRunStore runStore, IFlowRepository repo, IFlowOrchestrator engine, Guid runId) =>
         {
             var run = await runStore.GetRunDetailAsync(runId);

--- a/src/FlowOrchestrator.Hangfire/FlowOrchestratorServiceCollectionExtensions.cs
+++ b/src/FlowOrchestrator.Hangfire/FlowOrchestratorServiceCollectionExtensions.cs
@@ -91,6 +91,8 @@ public static class FlowOrchestratorServiceCollectionExtensions
         }
 
         services.AddStepHandler<ForEachStepHandler>("ForEach");
+        services.AddStepHandler<WaitForSignalHandler>("WaitForSignal");
+        services.TryAddSingleton<IFlowSignalDispatcher, FlowSignalDispatcher>();
 
         return builder;
     }

--- a/src/FlowOrchestrator.InMemory/InMemoryFlowSignalStore.cs
+++ b/src/FlowOrchestrator.InMemory/InMemoryFlowSignalStore.cs
@@ -1,0 +1,91 @@
+using System.Collections.Concurrent;
+using FlowOrchestrator.Core.Storage;
+
+namespace FlowOrchestrator.InMemory;
+
+/// <summary>
+/// In-process <see cref="IFlowSignalStore"/> backed by a <see cref="ConcurrentDictionary{TKey, TValue}"/>.
+/// Used by tests and by the in-memory runtime; data does not survive process restart.
+/// </summary>
+public sealed class InMemoryFlowSignalStore : IFlowSignalStore
+{
+    private readonly ConcurrentDictionary<(Guid RunId, string StepKey), FlowSignalWaiter> _waiters = new();
+
+    /// <inheritdoc/>
+    public ValueTask RegisterWaiterAsync(
+        Guid runId,
+        string stepKey,
+        string signalName,
+        DateTimeOffset? expiresAt,
+        CancellationToken ct = default)
+    {
+        var key = (runId, stepKey);
+        var now = DateTimeOffset.UtcNow;
+        _waiters.AddOrUpdate(
+            key,
+            _ => new FlowSignalWaiter
+            {
+                RunId = runId,
+                StepKey = stepKey,
+                SignalName = signalName,
+                CreatedAt = now,
+                ExpiresAt = expiresAt
+            },
+            (_, existing) =>
+            {
+                existing.SignalName = signalName;
+                existing.ExpiresAt = expiresAt;
+                return existing;
+            });
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public ValueTask<SignalDeliveryResult> DeliverSignalAsync(
+        Guid runId,
+        string signalName,
+        string payloadJson,
+        CancellationToken ct = default)
+    {
+        var match = _waiters.Values
+            .Where(w => w.RunId == runId &&
+                        string.Equals(w.SignalName, signalName, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(w => w.CreatedAt)
+            .FirstOrDefault();
+
+        if (match is null)
+        {
+            return ValueTask.FromResult(new SignalDeliveryResult(SignalDeliveryStatus.NotFound, null, null));
+        }
+
+        // Lock at the waiter level — concurrent DeliverSignal calls for the same step must be serialised.
+        lock (match)
+        {
+            if (match.DeliveredAt is not null)
+            {
+                return ValueTask.FromResult(
+                    new SignalDeliveryResult(SignalDeliveryStatus.AlreadyDelivered, match.StepKey, match.DeliveredAt));
+            }
+
+            var deliveredAt = DateTimeOffset.UtcNow;
+            match.DeliveredAt = deliveredAt;
+            match.PayloadJson = payloadJson;
+            return ValueTask.FromResult(
+                new SignalDeliveryResult(SignalDeliveryStatus.Delivered, match.StepKey, deliveredAt));
+        }
+    }
+
+    /// <inheritdoc/>
+    public ValueTask<FlowSignalWaiter?> GetWaiterAsync(Guid runId, string stepKey, CancellationToken ct = default)
+    {
+        _waiters.TryGetValue((runId, stepKey), out var waiter);
+        return ValueTask.FromResult(waiter);
+    }
+
+    /// <inheritdoc/>
+    public ValueTask RemoveWaiterAsync(Guid runId, string stepKey, CancellationToken ct = default)
+    {
+        _waiters.TryRemove((runId, stepKey), out _);
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/FlowOrchestrator.InMemory/InMemoryServiceCollectionExtensions.cs
+++ b/src/FlowOrchestrator.InMemory/InMemoryServiceCollectionExtensions.cs
@@ -30,6 +30,8 @@ public static class InMemoryServiceCollectionExtensions
         builder.Services.AddSingleton<IOutputsRepository>(sp => sp.GetRequiredService<InMemoryOutputsRepository>());
         builder.Services.AddSingleton<IFlowEventReader>(sp => sp.GetRequiredService<InMemoryOutputsRepository>());
 
+        builder.Services.AddSingleton<IFlowSignalStore, InMemoryFlowSignalStore>();
+
         builder.Services.AddSingleton<IFlowScheduleStateStore, InMemoryFlowScheduleStateStore>();
         return builder;
     }

--- a/src/FlowOrchestrator.PostgreSQL/PostgreSqlFlowOrchestratorMigrator.cs
+++ b/src/FlowOrchestrator.PostgreSQL/PostgreSqlFlowOrchestratorMigrator.cs
@@ -153,6 +153,20 @@ public sealed class PostgreSqlFlowOrchestratorMigrator : IHostedService
             PRIMARY KEY (run_id, step_key)
         );
 
+        CREATE TABLE IF NOT EXISTS flow_signal_waiters (
+            run_id        UUID         NOT NULL,
+            step_key      VARCHAR(256) NOT NULL,
+            signal_name   VARCHAR(256) NOT NULL,
+            created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+            expires_at    TIMESTAMPTZ  NULL,
+            delivered_at  TIMESTAMPTZ  NULL,
+            payload_json  TEXT         NULL,
+            PRIMARY KEY (run_id, step_key)
+        );
+
+        CREATE INDEX IF NOT EXISTS ix_flow_signal_waiters_run_id_signal_name
+            ON flow_signal_waiters (run_id, signal_name);
+
         CREATE TABLE IF NOT EXISTS flow_schedule_states (
             job_id         VARCHAR(256) NOT NULL PRIMARY KEY,
             flow_id        UUID         NOT NULL,

--- a/src/FlowOrchestrator.PostgreSQL/PostgreSqlFlowSignalStore.cs
+++ b/src/FlowOrchestrator.PostgreSQL/PostgreSqlFlowSignalStore.cs
@@ -1,0 +1,149 @@
+using Dapper;
+using FlowOrchestrator.Core.Storage;
+using Npgsql;
+
+namespace FlowOrchestrator.PostgreSQL;
+
+/// <summary>
+/// Dapper-based PostgreSQL implementation of <see cref="IFlowSignalStore"/>.
+/// Persists waiters in the <c>flow_signal_waiters</c> table created by <see cref="PostgreSqlFlowOrchestratorMigrator"/>.
+/// </summary>
+public sealed class PostgreSqlFlowSignalStore : IFlowSignalStore
+{
+    private readonly string _connectionString;
+
+    public PostgreSqlFlowSignalStore(string connectionString)
+    {
+        _connectionString = connectionString;
+    }
+
+    public async ValueTask RegisterWaiterAsync(
+        Guid runId,
+        string stepKey,
+        string signalName,
+        DateTimeOffset? expiresAt,
+        CancellationToken ct = default)
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.ExecuteAsync(
+            new CommandDefinition(
+                """
+                INSERT INTO flow_signal_waiters (run_id, step_key, signal_name, created_at, expires_at)
+                VALUES (@RunId, @StepKey, @SignalName, NOW(), @ExpiresAt)
+                ON CONFLICT (run_id, step_key) DO UPDATE
+                SET signal_name = EXCLUDED.signal_name,
+                    expires_at  = EXCLUDED.expires_at;
+                """,
+                new
+                {
+                    RunId = runId,
+                    StepKey = stepKey,
+                    SignalName = signalName,
+                    ExpiresAt = expiresAt
+                },
+                cancellationToken: ct)).ConfigureAwait(false);
+    }
+
+    public async ValueTask<SignalDeliveryResult> DeliverSignalAsync(
+        Guid runId,
+        string signalName,
+        string payloadJson,
+        CancellationToken ct = default)
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+
+        // Atomic conditional update; RETURNING gives us the delivered row's identity. The CTE
+        // narrows to the single oldest waiter so concurrent deliveries can never race past each other.
+        var delivered = await conn.QueryFirstOrDefaultAsync<DeliveryRow>(
+            new CommandDefinition(
+                """
+                WITH target AS (
+                    SELECT run_id, step_key
+                    FROM flow_signal_waiters
+                    WHERE run_id = @RunId
+                      AND signal_name = @SignalName
+                      AND delivered_at IS NULL
+                    ORDER BY created_at
+                    LIMIT 1
+                    FOR UPDATE SKIP LOCKED
+                )
+                UPDATE flow_signal_waiters w
+                SET delivered_at = NOW(),
+                    payload_json = @PayloadJson
+                FROM target
+                WHERE w.run_id = target.run_id AND w.step_key = target.step_key
+                RETURNING w.step_key AS StepKey, w.delivered_at AS DeliveredAt;
+                """,
+                new
+                {
+                    RunId = runId,
+                    SignalName = signalName,
+                    PayloadJson = payloadJson
+                },
+                cancellationToken: ct)).ConfigureAwait(false);
+
+        if (delivered is { StepKey: { } key, DeliveredAt: { } deliveredAt })
+        {
+            return new SignalDeliveryResult(SignalDeliveryStatus.Delivered, key, deliveredAt);
+        }
+
+        // No update happened — distinguish missing waiter from already-delivered waiter.
+        var existing = await conn.QueryFirstOrDefaultAsync<DeliveryRow>(
+            new CommandDefinition(
+                """
+                SELECT step_key AS StepKey, delivered_at AS DeliveredAt
+                FROM flow_signal_waiters
+                WHERE run_id = @RunId AND signal_name = @SignalName
+                ORDER BY created_at
+                LIMIT 1;
+                """,
+                new { RunId = runId, SignalName = signalName },
+                cancellationToken: ct)).ConfigureAwait(false);
+
+        if (existing is { DeliveredAt: { } prior })
+        {
+            return new SignalDeliveryResult(SignalDeliveryStatus.AlreadyDelivered, existing.StepKey, prior);
+        }
+
+        return new SignalDeliveryResult(SignalDeliveryStatus.NotFound, null, null);
+    }
+
+    public async ValueTask<FlowSignalWaiter?> GetWaiterAsync(
+        Guid runId,
+        string stepKey,
+        CancellationToken ct = default)
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        return await conn.QueryFirstOrDefaultAsync<FlowSignalWaiter>(
+            new CommandDefinition(
+                """
+                SELECT run_id     AS RunId,
+                       step_key   AS StepKey,
+                       signal_name AS SignalName,
+                       created_at  AS CreatedAt,
+                       expires_at  AS ExpiresAt,
+                       delivered_at AS DeliveredAt,
+                       payload_json AS PayloadJson
+                FROM flow_signal_waiters
+                WHERE run_id = @RunId AND step_key = @StepKey;
+                """,
+                new { RunId = runId, StepKey = stepKey },
+                cancellationToken: ct)).ConfigureAwait(false);
+    }
+
+    public async ValueTask RemoveWaiterAsync(Guid runId, string stepKey, CancellationToken ct = default)
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.ExecuteAsync(
+            new CommandDefinition(
+                "DELETE FROM flow_signal_waiters WHERE run_id = @RunId AND step_key = @StepKey;",
+                new { RunId = runId, StepKey = stepKey },
+                cancellationToken: ct)).ConfigureAwait(false);
+    }
+
+    private sealed class DeliveryRow
+    {
+        public string? StepKey { get; set; }
+        public DateTimeOffset? DeliveredAt { get; set; }
+    }
+}

--- a/src/FlowOrchestrator.PostgreSQL/PostgreSqlServiceCollectionExtensions.cs
+++ b/src/FlowOrchestrator.PostgreSQL/PostgreSqlServiceCollectionExtensions.cs
@@ -32,6 +32,8 @@ public static class PostgreSqlServiceCollectionExtensions
         builder.Services.AddSingleton<IOutputsRepository>(sp => sp.GetRequiredService<PostgreSqlOutputsRepository>());
         builder.Services.AddSingleton<IFlowEventReader>(sp => sp.GetRequiredService<PostgreSqlOutputsRepository>());
 
+        builder.Services.AddSingleton<IFlowSignalStore>(_ => new PostgreSqlFlowSignalStore(connectionString));
+
         builder.Services.AddSingleton<IFlowScheduleStateStore>(_ => new PostgreSqlFlowScheduleStateStore(connectionString));
         builder.Services.AddHostedService(sp =>
             new PostgreSqlFlowOrchestratorMigrator(connectionString, sp.GetRequiredService<ILogger<PostgreSqlFlowOrchestratorMigrator>>()));
@@ -59,6 +61,8 @@ public static class PostgreSqlServiceCollectionExtensions
         services.AddSingleton<PostgreSqlOutputsRepository>(_ => new PostgreSqlOutputsRepository(connectionString));
         services.AddSingleton<IOutputsRepository>(sp => sp.GetRequiredService<PostgreSqlOutputsRepository>());
         services.AddSingleton<IFlowEventReader>(sp => sp.GetRequiredService<PostgreSqlOutputsRepository>());
+
+        services.AddSingleton<IFlowSignalStore>(_ => new PostgreSqlFlowSignalStore(connectionString));
 
         services.AddSingleton<IFlowScheduleStateStore>(_ => new PostgreSqlFlowScheduleStateStore(connectionString));
         services.AddHostedService(sp =>

--- a/src/FlowOrchestrator.SqlServer/FlowOrchestratorSqlMigrator.cs
+++ b/src/FlowOrchestrator.SqlServer/FlowOrchestratorSqlMigrator.cs
@@ -220,6 +220,23 @@ public sealed class FlowOrchestratorSqlMigrator : IHostedService
             );
         END
 
+        IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'FlowSignalWaiters')
+        BEGIN
+            CREATE TABLE [FlowSignalWaiters] (
+                [RunId]       UNIQUEIDENTIFIER NOT NULL,
+                [StepKey]     NVARCHAR(256)    NOT NULL,
+                [SignalName]  NVARCHAR(256)    NOT NULL,
+                [CreatedAt]   DATETIMEOFFSET   NOT NULL DEFAULT SYSDATETIMEOFFSET(),
+                [ExpiresAt]   DATETIMEOFFSET   NULL,
+                [DeliveredAt] DATETIMEOFFSET   NULL,
+                [PayloadJson] NVARCHAR(MAX)    NULL,
+                CONSTRAINT PK_FlowSignalWaiters PRIMARY KEY ([RunId], [StepKey])
+            );
+
+            CREATE INDEX IX_FlowSignalWaiters_RunId_SignalName
+                ON [FlowSignalWaiters] ([RunId], [SignalName]);
+        END
+
         IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'FlowScheduleStates')
         BEGIN
             CREATE TABLE [FlowScheduleStates] (

--- a/src/FlowOrchestrator.SqlServer/SqlFlowSignalStore.cs
+++ b/src/FlowOrchestrator.SqlServer/SqlFlowSignalStore.cs
@@ -1,0 +1,141 @@
+using Dapper;
+using FlowOrchestrator.Core.Storage;
+using Microsoft.Data.SqlClient;
+
+namespace FlowOrchestrator.SqlServer;
+
+/// <summary>
+/// Dapper-based SQL Server implementation of <see cref="IFlowSignalStore"/>.
+/// Persists waiters in the <c>FlowSignalWaiters</c> table created by <see cref="FlowOrchestratorSqlMigrator"/>.
+/// </summary>
+internal sealed class SqlFlowSignalStore : IFlowSignalStore
+{
+    private readonly string _connectionString;
+
+    public SqlFlowSignalStore(string connectionString)
+    {
+        _connectionString = connectionString;
+    }
+
+    public async ValueTask RegisterWaiterAsync(
+        Guid runId,
+        string stepKey,
+        string signalName,
+        DateTimeOffset? expiresAt,
+        CancellationToken ct = default)
+    {
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.ExecuteAsync(
+            new CommandDefinition(
+                """
+                MERGE [FlowSignalWaiters] AS target
+                USING (SELECT @RunId AS RunId, @StepKey AS StepKey) AS source
+                ON target.RunId = source.RunId AND target.StepKey = source.StepKey
+                WHEN MATCHED THEN
+                    UPDATE SET SignalName = @SignalName, ExpiresAt = @ExpiresAt
+                WHEN NOT MATCHED THEN
+                    INSERT (RunId, StepKey, SignalName, CreatedAt, ExpiresAt)
+                    VALUES (@RunId, @StepKey, @SignalName, SYSDATETIMEOFFSET(), @ExpiresAt);
+                """,
+                new
+                {
+                    RunId = runId,
+                    StepKey = stepKey,
+                    SignalName = signalName,
+                    ExpiresAt = expiresAt
+                },
+                cancellationToken: ct)).ConfigureAwait(false);
+    }
+
+    public async ValueTask<SignalDeliveryResult> DeliverSignalAsync(
+        Guid runId,
+        string signalName,
+        string payloadJson,
+        CancellationToken ct = default)
+    {
+        await using var conn = new SqlConnection(_connectionString);
+
+        // Atomic: only update the row if no payload has been delivered yet.
+        // Returns 1 row when delivered, 0 rows when (a) no waiter matches or (b) already delivered.
+        var rows = await conn.QueryAsync<DeliveryRow>(
+            new CommandDefinition(
+                """
+                ;WITH target AS (
+                    SELECT TOP (1) *
+                    FROM [FlowSignalWaiters]
+                    WHERE RunId = @RunId AND SignalName = @SignalName
+                    ORDER BY CreatedAt
+                )
+                UPDATE target
+                SET DeliveredAt = SYSDATETIMEOFFSET(),
+                    PayloadJson = @PayloadJson
+                OUTPUT inserted.StepKey, inserted.DeliveredAt
+                WHERE target.DeliveredAt IS NULL;
+                """,
+                new
+                {
+                    RunId = runId,
+                    SignalName = signalName,
+                    PayloadJson = payloadJson
+                },
+                cancellationToken: ct)).ConfigureAwait(false);
+
+        var delivered = rows.FirstOrDefault();
+        if (delivered is { StepKey: { } stepKey, DeliveredAt: { } deliveredAt })
+        {
+            return new SignalDeliveryResult(SignalDeliveryStatus.Delivered, stepKey, deliveredAt);
+        }
+
+        // No update happened — figure out whether the waiter is missing or already delivered.
+        var existing = await conn.QueryFirstOrDefaultAsync<DeliveryRow>(
+            new CommandDefinition(
+                """
+                SELECT TOP (1) StepKey, DeliveredAt
+                FROM [FlowSignalWaiters]
+                WHERE RunId = @RunId AND SignalName = @SignalName
+                ORDER BY CreatedAt;
+                """,
+                new { RunId = runId, SignalName = signalName },
+                cancellationToken: ct)).ConfigureAwait(false);
+
+        if (existing is { DeliveredAt: { } prior })
+        {
+            return new SignalDeliveryResult(SignalDeliveryStatus.AlreadyDelivered, existing.StepKey, prior);
+        }
+
+        return new SignalDeliveryResult(SignalDeliveryStatus.NotFound, null, null);
+    }
+
+    public async ValueTask<FlowSignalWaiter?> GetWaiterAsync(
+        Guid runId,
+        string stepKey,
+        CancellationToken ct = default)
+    {
+        await using var conn = new SqlConnection(_connectionString);
+        return await conn.QueryFirstOrDefaultAsync<FlowSignalWaiter>(
+            new CommandDefinition(
+                """
+                SELECT RunId, StepKey, SignalName, CreatedAt, ExpiresAt, DeliveredAt, PayloadJson
+                FROM [FlowSignalWaiters]
+                WHERE RunId = @RunId AND StepKey = @StepKey;
+                """,
+                new { RunId = runId, StepKey = stepKey },
+                cancellationToken: ct)).ConfigureAwait(false);
+    }
+
+    public async ValueTask RemoveWaiterAsync(Guid runId, string stepKey, CancellationToken ct = default)
+    {
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.ExecuteAsync(
+            new CommandDefinition(
+                "DELETE FROM [FlowSignalWaiters] WHERE RunId = @RunId AND StepKey = @StepKey;",
+                new { RunId = runId, StepKey = stepKey },
+                cancellationToken: ct)).ConfigureAwait(false);
+    }
+
+    private sealed class DeliveryRow
+    {
+        public string? StepKey { get; set; }
+        public DateTimeOffset? DeliveredAt { get; set; }
+    }
+}

--- a/src/FlowOrchestrator.SqlServer/SqlServerServiceCollectionExtensions.cs
+++ b/src/FlowOrchestrator.SqlServer/SqlServerServiceCollectionExtensions.cs
@@ -32,6 +32,8 @@ public static class SqlServerServiceCollectionExtensions
         builder.Services.AddSingleton<IOutputsRepository>(sp => sp.GetRequiredService<SqlOutputsRepository>());
         builder.Services.AddSingleton<IFlowEventReader>(sp => sp.GetRequiredService<SqlOutputsRepository>());
 
+        builder.Services.AddSingleton<IFlowSignalStore>(_ => new SqlFlowSignalStore(connectionString));
+
         builder.Services.AddSingleton<IFlowScheduleStateStore>(_ => new SqlFlowScheduleStateStore(connectionString));
         builder.Services.AddHostedService(sp =>
             new FlowOrchestratorSqlMigrator(connectionString, sp.GetRequiredService<ILogger<FlowOrchestratorSqlMigrator>>()));
@@ -59,6 +61,8 @@ public static class SqlServerServiceCollectionExtensions
         services.AddSingleton<SqlOutputsRepository>(_ => new SqlOutputsRepository(connectionString));
         services.AddSingleton<IOutputsRepository>(sp => sp.GetRequiredService<SqlOutputsRepository>());
         services.AddSingleton<IFlowEventReader>(sp => sp.GetRequiredService<SqlOutputsRepository>());
+
+        services.AddSingleton<IFlowSignalStore>(_ => new SqlFlowSignalStore(connectionString));
 
         services.AddSingleton<IFlowScheduleStateStore>(_ => new SqlFlowScheduleStateStore(connectionString));
         services.AddHostedService(sp =>

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/DashboardTestServer.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/DashboardTestServer.cs
@@ -29,6 +29,9 @@ public sealed class DashboardTestServer : IDisposable
     /// <summary>Mock engine used to verify trigger and retry calls from dashboard endpoints.</summary>
     public IFlowOrchestrator FlowOrchestrator { get; } = Substitute.For<IFlowOrchestrator>();
 
+    /// <summary>Mock signal dispatcher used to verify signal endpoint behaviour.</summary>
+    public IFlowSignalDispatcher SignalDispatcher { get; } = Substitute.For<IFlowSignalDispatcher>();
+
     public IRecurringTriggerSync TriggerSync { get; } = Substitute.For<IRecurringTriggerSync>();
     public IRecurringTriggerDispatcher TriggerDispatcher { get; } = Substitute.For<IRecurringTriggerDispatcher>();
     public IRecurringTriggerInspector TriggerInspector { get; } = Substitute.For<IRecurringTriggerInspector>();
@@ -64,6 +67,7 @@ public sealed class DashboardTestServer : IDisposable
         builder.Services.AddSingleton(EventReader);
         builder.Services.AddSingleton(ScheduleStateStore);
         builder.Services.AddSingleton(FlowOrchestrator);
+        builder.Services.AddSingleton(SignalDispatcher);
         builder.Services.AddSingleton(TriggerSync);
         builder.Services.AddSingleton(TriggerDispatcher);
         builder.Services.AddSingleton(TriggerInspector);

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/SignalEndpointTests.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/SignalEndpointTests.cs
@@ -1,0 +1,136 @@
+using System.Net;
+using System.Text;
+using FlowOrchestrator.Core.Storage;
+
+namespace FlowOrchestrator.Dashboard.Tests;
+
+/// <summary>
+/// Integration coverage for <c>POST /flows/api/runs/{runId}/signals/{signalName}</c>:
+/// status code matrix (404 missing run, 404 no waiter, 409 already delivered, 400 bad JSON, 200 delivered)
+/// plus the run-status precondition.
+/// </summary>
+public sealed class SignalEndpointTests : IDisposable
+{
+    private readonly DashboardTestServer _server = new();
+    private readonly HttpClient _client;
+
+    public SignalEndpointTests() => _client = _server.CreateClient();
+
+    public void Dispose() => _server.Dispose();
+
+    [Fact]
+    public async Task POST_signal_returns_404_when_run_missing()
+    {
+        // Arrange
+        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
+
+        // Act
+        var response = await _client.PostAsync(
+            $"/flows/api/runs/{Guid.NewGuid()}/signals/approval",
+            new StringContent("{}", Encoding.UTF8, "application/json"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task POST_signal_returns_400_when_run_not_running()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        _server.FlowRunStore.GetRunDetailAsync(runId)
+            .Returns(new FlowRunRecord { Id = runId, FlowId = Guid.NewGuid(), Status = "Succeeded" });
+
+        // Act
+        var response = await _client.PostAsync(
+            $"/flows/api/runs/{runId}/signals/approval",
+            new StringContent("{}", Encoding.UTF8, "application/json"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task POST_signal_returns_400_for_invalid_json_body()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        _server.FlowRunStore.GetRunDetailAsync(runId)
+            .Returns(new FlowRunRecord { Id = runId, FlowId = Guid.NewGuid(), Status = "Running" });
+
+        // Act
+        var response = await _client.PostAsync(
+            $"/flows/api/runs/{runId}/signals/approval",
+            new StringContent("{not-json", Encoding.UTF8, "application/json"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task POST_signal_returns_404_when_no_matching_waiter()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        _server.FlowRunStore.GetRunDetailAsync(runId)
+            .Returns(new FlowRunRecord { Id = runId, FlowId = Guid.NewGuid(), Status = "Running" });
+        _server.SignalDispatcher
+            .DispatchAsync(runId, "approval", Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<SignalDeliveryResult>(
+                new SignalDeliveryResult(SignalDeliveryStatus.NotFound, null, null)));
+
+        // Act
+        var response = await _client.PostAsync(
+            $"/flows/api/runs/{runId}/signals/approval",
+            new StringContent("{}", Encoding.UTF8, "application/json"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task POST_signal_returns_409_when_already_delivered()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        _server.FlowRunStore.GetRunDetailAsync(runId)
+            .Returns(new FlowRunRecord { Id = runId, FlowId = Guid.NewGuid(), Status = "Running" });
+        _server.SignalDispatcher
+            .DispatchAsync(runId, "approval", Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<SignalDeliveryResult>(
+                new SignalDeliveryResult(SignalDeliveryStatus.AlreadyDelivered, "wait_step", DateTimeOffset.UtcNow)));
+
+        // Act
+        var response = await _client.PostAsync(
+            $"/flows/api/runs/{runId}/signals/approval",
+            new StringContent("{}", Encoding.UTF8, "application/json"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task POST_signal_returns_200_with_step_key_when_delivered()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        _server.FlowRunStore.GetRunDetailAsync(runId)
+            .Returns(new FlowRunRecord { Id = runId, FlowId = Guid.NewGuid(), Status = "Running" });
+        var deliveredAt = DateTimeOffset.UtcNow;
+        _server.SignalDispatcher
+            .DispatchAsync(runId, "approval", Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<SignalDeliveryResult>(
+                new SignalDeliveryResult(SignalDeliveryStatus.Delivered, "wait_for_approval", deliveredAt)));
+
+        // Act
+        var response = await _client.PostAsync(
+            $"/flows/api/runs/{runId}/signals/approval",
+            new StringContent("""{"approved":true}""", Encoding.UTF8, "application/json"));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("\"delivered\":true", body);
+        Assert.Contains("wait_for_approval", body);
+    }
+}

--- a/tests/integration/FlowOrchestrator.PostgreSQL.IntegrationTests/PostgreSqlFlowSignalStoreTests.cs
+++ b/tests/integration/FlowOrchestrator.PostgreSQL.IntegrationTests/PostgreSqlFlowSignalStoreTests.cs
@@ -1,0 +1,114 @@
+using FlowOrchestrator.Core.Storage;
+
+namespace FlowOrchestrator.PostgreSQL.Tests;
+
+public sealed class PostgreSqlFlowSignalStoreTests : IClassFixture<PostgreSqlFixture>
+{
+    private readonly PostgreSqlFlowSignalStore _store;
+
+    public PostgreSqlFlowSignalStoreTests(PostgreSqlFixture fixture)
+    {
+        _store = new PostgreSqlFlowSignalStore(fixture.ConnectionString);
+    }
+
+    [Fact]
+    public async Task RegisterWaiter_then_GetWaiter_round_trip()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        var expiresAt = DateTimeOffset.UtcNow.AddMinutes(5);
+
+        // Act
+        await _store.RegisterWaiterAsync(runId, "step1", "approval", expiresAt);
+        var waiter = await _store.GetWaiterAsync(runId, "step1");
+
+        // Assert
+        Assert.NotNull(waiter);
+        Assert.Equal(runId, waiter!.RunId);
+        Assert.Equal("step1", waiter.StepKey);
+        Assert.Equal("approval", waiter.SignalName);
+        Assert.NotNull(waiter.ExpiresAt);
+        Assert.Null(waiter.DeliveredAt);
+    }
+
+    [Fact]
+    public async Task RegisterWaiter_idempotent_on_duplicate_key()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        await _store.RegisterWaiterAsync(runId, "step1", "old-signal", null);
+
+        // Act
+        await _store.RegisterWaiterAsync(runId, "step1", "new-signal", DateTimeOffset.UtcNow.AddHours(1));
+        var waiter = await _store.GetWaiterAsync(runId, "step1");
+
+        // Assert
+        Assert.NotNull(waiter);
+        Assert.Equal("new-signal", waiter!.SignalName);
+        Assert.NotNull(waiter.ExpiresAt);
+    }
+
+    [Fact]
+    public async Task DeliverSignal_sets_payload_and_returns_Delivered()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        await _store.RegisterWaiterAsync(runId, "step_x", "approve", null);
+
+        // Act
+        var result = await _store.DeliverSignalAsync(runId, "approve", """{"approved":true}""");
+        var waiter = await _store.GetWaiterAsync(runId, "step_x");
+
+        // Assert
+        Assert.Equal(SignalDeliveryStatus.Delivered, result.Status);
+        Assert.Equal("step_x", result.StepKey);
+        Assert.NotNull(result.DeliveredAt);
+        Assert.Equal("""{"approved":true}""", waiter!.PayloadJson);
+        Assert.NotNull(waiter.DeliveredAt);
+    }
+
+    [Fact]
+    public async Task DeliverSignal_second_call_returns_AlreadyDelivered()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        await _store.RegisterWaiterAsync(runId, "step_y", "approve", null);
+        await _store.DeliverSignalAsync(runId, "approve", "{}");
+
+        // Act
+        var second = await _store.DeliverSignalAsync(runId, "approve", "{}");
+
+        // Assert
+        Assert.Equal(SignalDeliveryStatus.AlreadyDelivered, second.Status);
+        Assert.Equal("step_y", second.StepKey);
+    }
+
+    [Fact]
+    public async Task DeliverSignal_no_waiter_returns_NotFound()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+
+        // Act
+        var result = await _store.DeliverSignalAsync(runId, "ghost", "{}");
+
+        // Assert
+        Assert.Equal(SignalDeliveryStatus.NotFound, result.Status);
+        Assert.Null(result.StepKey);
+    }
+
+    [Fact]
+    public async Task RemoveWaiter_drops_row()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        await _store.RegisterWaiterAsync(runId, "step_z", "ping", null);
+
+        // Act
+        await _store.RemoveWaiterAsync(runId, "step_z");
+        var waiter = await _store.GetWaiterAsync(runId, "step_z");
+
+        // Assert
+        Assert.Null(waiter);
+    }
+}

--- a/tests/integration/FlowOrchestrator.SqlServer.IntegrationTests/SqlFlowSignalStoreTests.cs
+++ b/tests/integration/FlowOrchestrator.SqlServer.IntegrationTests/SqlFlowSignalStoreTests.cs
@@ -1,0 +1,115 @@
+using FlowOrchestrator.Core.Storage;
+
+namespace FlowOrchestrator.SqlServer.Tests;
+
+public sealed class SqlFlowSignalStoreTests : IClassFixture<SqlServerFixture>
+{
+    private readonly SqlFlowSignalStore _store;
+
+    public SqlFlowSignalStoreTests(SqlServerFixture fixture)
+    {
+        _store = new SqlFlowSignalStore(fixture.ConnectionString);
+    }
+
+    [Fact]
+    public async Task RegisterWaiter_then_GetWaiter_round_trip()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        var expiresAt = DateTimeOffset.UtcNow.AddMinutes(5);
+
+        // Act
+        await _store.RegisterWaiterAsync(runId, "step1", "approval", expiresAt);
+        var waiter = await _store.GetWaiterAsync(runId, "step1");
+
+        // Assert
+        Assert.NotNull(waiter);
+        Assert.Equal(runId, waiter!.RunId);
+        Assert.Equal("step1", waiter.StepKey);
+        Assert.Equal("approval", waiter.SignalName);
+        Assert.NotNull(waiter.ExpiresAt);
+        Assert.Null(waiter.DeliveredAt);
+        Assert.Null(waiter.PayloadJson);
+    }
+
+    [Fact]
+    public async Task RegisterWaiter_idempotent_on_duplicate_key()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        await _store.RegisterWaiterAsync(runId, "step1", "old-signal", null);
+
+        // Act
+        await _store.RegisterWaiterAsync(runId, "step1", "new-signal", DateTimeOffset.UtcNow.AddHours(1));
+        var waiter = await _store.GetWaiterAsync(runId, "step1");
+
+        // Assert
+        Assert.NotNull(waiter);
+        Assert.Equal("new-signal", waiter!.SignalName);
+        Assert.NotNull(waiter.ExpiresAt);
+    }
+
+    [Fact]
+    public async Task DeliverSignal_sets_payload_and_returns_Delivered()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        await _store.RegisterWaiterAsync(runId, "step_x", "approve", null);
+
+        // Act
+        var result = await _store.DeliverSignalAsync(runId, "approve", """{"approved":true}""");
+        var waiter = await _store.GetWaiterAsync(runId, "step_x");
+
+        // Assert
+        Assert.Equal(SignalDeliveryStatus.Delivered, result.Status);
+        Assert.Equal("step_x", result.StepKey);
+        Assert.NotNull(result.DeliveredAt);
+        Assert.Equal("""{"approved":true}""", waiter!.PayloadJson);
+        Assert.NotNull(waiter.DeliveredAt);
+    }
+
+    [Fact]
+    public async Task DeliverSignal_second_call_returns_AlreadyDelivered()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        await _store.RegisterWaiterAsync(runId, "step_y", "approve", null);
+        await _store.DeliverSignalAsync(runId, "approve", "{}");
+
+        // Act
+        var second = await _store.DeliverSignalAsync(runId, "approve", "{}");
+
+        // Assert
+        Assert.Equal(SignalDeliveryStatus.AlreadyDelivered, second.Status);
+        Assert.Equal("step_y", second.StepKey);
+    }
+
+    [Fact]
+    public async Task DeliverSignal_no_waiter_returns_NotFound()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+
+        // Act
+        var result = await _store.DeliverSignalAsync(runId, "ghost", "{}");
+
+        // Assert
+        Assert.Equal(SignalDeliveryStatus.NotFound, result.Status);
+        Assert.Null(result.StepKey);
+    }
+
+    [Fact]
+    public async Task RemoveWaiter_drops_row()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        await _store.RegisterWaiterAsync(runId, "step_z", "ping", null);
+
+        // Act
+        await _store.RemoveWaiterAsync(runId, "step_z");
+        var waiter = await _store.GetWaiterAsync(runId, "step_z");
+
+        // Assert
+        Assert.Null(waiter);
+    }
+}

--- a/tests/integration/FlowOrchestrator.Testing.IntegrationTests/Fixtures/WaitForSignalFlows.cs
+++ b/tests/integration/FlowOrchestrator.Testing.IntegrationTests/Fixtures/WaitForSignalFlows.cs
@@ -1,0 +1,103 @@
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Execution;
+
+namespace FlowOrchestrator.Testing.Tests.Fixtures;
+
+/// <summary>
+/// Two-step flow used by the WaitForSignal happy-path test:
+/// <c>wait_for_approval</c> (WaitForSignal) → <c>finalize</c> (Echo).
+/// </summary>
+public sealed class WaitForSignalFlow : IFlowDefinition
+{
+    public Guid Id { get; } = new("aaaa1111-aaaa-1111-aaaa-111111111111");
+    public string Version => "1.0";
+
+    public FlowManifest Manifest { get; set; } = new()
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            ["wait_for_approval"] = new StepMetadata
+            {
+                Type = "WaitForSignal",
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["signalName"] = "approval"
+                }
+            },
+            ["finalize"] = new StepMetadata
+            {
+                Type = "Echo",
+                RunAfter = new RunAfterCollection { ["wait_for_approval"] = [StepStatus.Succeeded] },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["label"] = "@steps('wait_for_approval').output.approver"
+                }
+            }
+        }
+    };
+}
+
+/// <summary>
+/// Two parallel WaitForSignal steps with different signal names. Used to verify that delivering
+/// signal "alpha" only resumes the matching waiter.
+/// </summary>
+public sealed class WaitForSignalParallelFlow : IFlowDefinition
+{
+    public Guid Id { get; } = new("aaaa2222-aaaa-2222-aaaa-222222222222");
+    public string Version => "1.0";
+
+    public FlowManifest Manifest { get; set; } = new()
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            ["wait_alpha"] = new StepMetadata
+            {
+                Type = "WaitForSignal",
+                Inputs = new Dictionary<string, object?> { ["signalName"] = "alpha" }
+            },
+            ["wait_beta"] = new StepMetadata
+            {
+                Type = "WaitForSignal",
+                Inputs = new Dictionary<string, object?> { ["signalName"] = "beta" }
+            }
+        }
+    };
+}
+
+/// <summary>
+/// Single WaitForSignal step with a short timeout configured. Used by the timeout test —
+/// no signal arrives so the step transitions to Failed.
+/// </summary>
+public sealed class WaitForSignalTimeoutFlow : IFlowDefinition
+{
+    public Guid Id { get; } = new("aaaa3333-aaaa-3333-aaaa-333333333333");
+    public string Version => "1.0";
+
+    public FlowManifest Manifest { get; set; } = new()
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            ["wait"] = new StepMetadata
+            {
+                Type = "WaitForSignal",
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["signalName"] = "approval",
+                    ["timeoutSeconds"] = 1
+                }
+            }
+        }
+    };
+}

--- a/tests/integration/FlowOrchestrator.Testing.IntegrationTests/WaitForSignalTests.cs
+++ b/tests/integration/FlowOrchestrator.Testing.IntegrationTests/WaitForSignalTests.cs
@@ -1,0 +1,292 @@
+using System.Text.Json;
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Storage;
+using FlowOrchestrator.Testing.Tests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FlowOrchestrator.Testing.Tests;
+
+/// <summary>
+/// End-to-end tests for the built-in <c>WaitForSignal</c> step type, covering the happy path,
+/// timeout, indefinite-wait, multi-waiter, cancellation, duplicate delivery, missing-run/missing-waiter
+/// 404s, and downstream payload propagation. All scenarios run against the in-memory storage and
+/// runtime via <see cref="FlowTestHost"/>.
+/// </summary>
+public sealed class WaitForSignalTests
+{
+    private static readonly TimeSpan TerminalTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan WaiterPollTimeout = TimeSpan.FromSeconds(15);
+
+    [Fact]
+    public async Task HappyPath_SignalArrives_StepSucceeds_DownstreamConsumesPayload()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<WaitForSignalFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithFastPolling()
+            .BuildAsync();
+
+        var runId = await StartRunAsync(host);
+        var signals = host.Services.GetRequiredService<IFlowSignalDispatcher>();
+
+        await WaitForWaiterAsync(host, runId, "wait_for_approval");
+
+        // Act
+        var delivery = await signals.DispatchAsync(
+            runId, "approval", JsonSerializer.Serialize(new { approver = "alice", approved = true }));
+
+        var result = await host.WaitForRunAsync(runId, TerminalTimeout);
+
+        // Assert
+        Assert.Equal(SignalDeliveryStatus.Delivered, delivery.Status);
+        Assert.Equal("wait_for_approval", delivery.StepKey);
+        Assert.False(result.TimedOut);
+        Assert.Equal(RunStatus.Succeeded, result.Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["wait_for_approval"].Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["finalize"].Status);
+        Assert.Equal("alice", result.Steps["finalize"].Output.GetProperty("Echoed").GetString());
+    }
+
+    [Fact]
+    public async Task MultipleWaiters_OnlyMatchingSignalResumes_OtherStillPending()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<WaitForSignalParallelFlow>()
+            .WithFastPolling()
+            .BuildAsync();
+
+        var runId = await StartRunAsync(host);
+        var signals = host.Services.GetRequiredService<IFlowSignalDispatcher>();
+        var runStore = host.Services.GetRequiredService<IFlowRunStore>();
+
+        await WaitForWaiterAsync(host, runId, "wait_alpha");
+        await WaitForWaiterAsync(host, runId, "wait_beta");
+
+        // Act
+        var delivery = await signals.DispatchAsync(runId, "alpha", "{\"who\":\"alpha-caller\"}");
+        await WaitForStepStatusAsync(runStore, runId, "wait_alpha", StepStatus.Succeeded);
+
+        var run = await runStore.GetRunDetailAsync(runId);
+        var alpha = run!.Steps!.First(s => s.StepKey == "wait_alpha");
+        var beta = run.Steps!.First(s => s.StepKey == "wait_beta");
+
+        // Assert
+        Assert.Equal(SignalDeliveryStatus.Delivered, delivery.Status);
+        Assert.Equal("Succeeded", alpha.Status);
+        Assert.Equal("Pending", beta.Status);
+
+        // Cleanup: deliver beta so the run can complete and the host shuts down cleanly.
+        await signals.DispatchAsync(runId, "beta", "{}");
+        await host.WaitForRunAsync(runId, TerminalTimeout);
+    }
+
+    [Fact]
+    public async Task Timeout_NoSignal_StepFailsWithDescriptiveReason()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<WaitForSignalTimeoutFlow>()
+            .WithFastPolling()
+            .BuildAsync();
+
+        // Act
+        var result = await host.TriggerAsync(timeout: TimeSpan.FromSeconds(15));
+
+        // Assert
+        Assert.False(result.TimedOut);
+        Assert.Equal(StepStatus.Failed, result.Steps["wait"].Status);
+        Assert.Contains(
+            "Signal 'approval' not received",
+            result.Steps["wait"].FailureReason ?? string.Empty,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task NoTimeout_StepRemainsPending_UntilSignalDelivered()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<WaitForSignalFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithFastPolling()
+            .BuildAsync();
+
+        var runId = await StartRunAsync(host);
+        var signals = host.Services.GetRequiredService<IFlowSignalDispatcher>();
+        var runStore = host.Services.GetRequiredService<IFlowRunStore>();
+
+        await WaitForWaiterAsync(host, runId, "wait_for_approval");
+
+        // Act — observe Pending status persists across multiple polling reschedules.
+        await Task.Delay(TimeSpan.FromMilliseconds(750));
+        var midRun = await runStore.GetRunDetailAsync(runId);
+        Assert.NotNull(midRun);
+        var midStep = midRun!.Steps?.FirstOrDefault(s => s.StepKey == "wait_for_approval");
+        Assert.Equal(StepStatus.Pending.ToString(), midStep!.Status);
+
+        await signals.DispatchAsync(runId, "approval", "{\"approver\":\"bob\"}");
+        var final = await host.WaitForRunAsync(runId, TerminalTimeout);
+
+        // Assert
+        Assert.Equal(RunStatus.Succeeded, final.Status);
+    }
+
+    [Fact]
+    public async Task DuplicateSignal_SecondDelivery_ReturnsAlreadyDelivered()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<WaitForSignalFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithFastPolling()
+            .BuildAsync();
+
+        var runId = await StartRunAsync(host);
+        var signals = host.Services.GetRequiredService<IFlowSignalDispatcher>();
+        await WaitForWaiterAsync(host, runId, "wait_for_approval");
+
+        // Act
+        var first = await signals.DispatchAsync(runId, "approval", "{\"approver\":\"first\"}");
+        var second = await signals.DispatchAsync(runId, "approval", "{\"approver\":\"second\"}");
+
+        // Assert
+        Assert.Equal(SignalDeliveryStatus.Delivered, first.Status);
+        Assert.Equal(SignalDeliveryStatus.AlreadyDelivered, second.Status);
+
+        // Cleanup: let the run finish before disposing the host.
+        await host.WaitForRunAsync(runId, TerminalTimeout);
+    }
+
+    [Fact]
+    public async Task SignalForUnknownRun_ReturnsNotFound()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<WaitForSignalFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithFastPolling()
+            .BuildAsync();
+        var signals = host.Services.GetRequiredService<IFlowSignalDispatcher>();
+
+        // Act
+        var result = await signals.DispatchAsync(Guid.NewGuid(), "approval", "{}");
+
+        // Assert
+        Assert.Equal(SignalDeliveryStatus.NotFound, result.Status);
+    }
+
+    [Fact]
+    public async Task SignalForExistingRun_NoMatchingWaiter_ReturnsNotFound()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<WaitForSignalFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithFastPolling()
+            .BuildAsync();
+
+        var runId = await StartRunAsync(host);
+        var signals = host.Services.GetRequiredService<IFlowSignalDispatcher>();
+        await WaitForWaiterAsync(host, runId, "wait_for_approval");
+
+        // Act
+        var result = await signals.DispatchAsync(runId, "this-signal-does-not-exist", "{}");
+
+        // Assert
+        Assert.Equal(SignalDeliveryStatus.NotFound, result.Status);
+
+        // Cleanup
+        await signals.DispatchAsync(runId, "approval", "{\"approver\":\"cleanup\"}");
+        await host.WaitForRunAsync(runId, TerminalTimeout);
+    }
+
+    [Fact]
+    public async Task RunCancelled_WhileWaiting_StepSkipped_RunCancelled()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<WaitForSignalFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithFastPolling()
+            .BuildAsync();
+
+        var runId = await StartRunAsync(host);
+        var control = host.Services.GetRequiredService<IFlowRunControlStore>();
+        await WaitForWaiterAsync(host, runId, "wait_for_approval");
+
+        // Act
+        await control.RequestCancelAsync(runId, "user cancelled");
+        var result = await host.WaitForRunAsync(runId, TerminalTimeout);
+
+        // Assert — engine marks the active step Skipped (with the run-status reason) and the run Cancelled.
+        Assert.Equal(RunStatus.Cancelled, result.Status);
+        Assert.Equal(StepStatus.Skipped, result.Steps["wait_for_approval"].Status);
+    }
+
+    [Fact]
+    public async Task DownstreamStep_ReceivesSignalPayloadField()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<WaitForSignalFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithFastPolling()
+            .BuildAsync();
+
+        var runId = await StartRunAsync(host);
+        var signals = host.Services.GetRequiredService<IFlowSignalDispatcher>();
+        await WaitForWaiterAsync(host, runId, "wait_for_approval");
+
+        // Act
+        await signals.DispatchAsync(
+            runId, "approval", JsonSerializer.Serialize(new { approver = "carol", approved = true }));
+        var result = await host.WaitForRunAsync(runId, TerminalTimeout);
+
+        // Assert
+        Assert.Equal(RunStatus.Succeeded, result.Status);
+        Assert.Equal("carol", result.Steps["finalize"].Output.GetProperty("Echoed").GetString());
+    }
+
+    private static async Task<Guid> StartRunAsync<TFlow>(FlowTestHost<TFlow> host)
+        where TFlow : class, IFlowDefinition, new()
+    {
+        using var scope = host.Services.CreateScope();
+        var orchestrator = scope.ServiceProvider.GetRequiredService<IFlowOrchestrator>();
+        var flow = scope.ServiceProvider.GetServices<IFlowDefinition>().OfType<TFlow>().First();
+
+        var ctx = new TriggerContext
+        {
+            Flow = flow,
+            Trigger = new Trigger("manual", "Manual", null),
+            RunId = Guid.Empty
+        };
+        await orchestrator.TriggerAsync(ctx);
+        return ctx.RunId;
+    }
+
+    private static async Task WaitForStepStatusAsync(IFlowRunStore runStore, Guid runId, string stepKey, StepStatus expected)
+    {
+        var deadline = DateTimeOffset.UtcNow + WaiterPollTimeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var run = await runStore.GetRunDetailAsync(runId);
+            var step = run?.Steps?.FirstOrDefault(s => s.StepKey == stepKey);
+            if (step is not null && step.Status == expected.ToString())
+            {
+                return;
+            }
+            await Task.Delay(50);
+        }
+        throw new InvalidOperationException(
+            $"Timed out waiting for step '{stepKey}' to reach status {expected} (run={runId}).");
+    }
+
+    private static async Task WaitForWaiterAsync<TFlow>(FlowTestHost<TFlow> host, Guid runId, string stepKey)
+        where TFlow : class, IFlowDefinition, new()
+    {
+        var store = host.Services.GetRequiredService<IFlowSignalStore>();
+        var deadline = DateTimeOffset.UtcNow + WaiterPollTimeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            var waiter = await store.GetWaiterAsync(runId, stepKey);
+            if (waiter is not null) return;
+            await Task.Delay(25);
+        }
+        throw new InvalidOperationException(
+            $"Timed out waiting for waiter (run={runId}, step={stepKey}) to be registered.");
+    }
+}


### PR DESCRIPTION
## Summary

Implements [Plan 07](.claude/plans/07-wait-for-signal.md) — built-in `WaitForSignal` step type that parks a flow until an external HTTP signal is delivered. Unlocks the **approval workflow** category (manager sign-off, content moderation, manual QA gates) without forcing users to fake it via long-polling steps.

- New `WaitForSignal` handler + `IFlowSignalStore` abstraction with InMemory / SQL Server / PostgreSQL implementations (idempotent migration on existing DBs).
- New `POST /flows/api/runs/{runId}/signals/{signalName}` endpoint with full `200 / 400 / 404 / 409` status matrix; **Send Signal** button on parked steps in the dashboard run-detail page.
- Sample `ApprovalWorkflowFlow` and full article at [docs/articles/wait-for-signal.md](docs/articles/wait-for-signal.md).
- Version bump 1.17.0 → **1.18.0**.

## Test plan

- [x] `dotnet build` → 0 errors, 0 warnings
- [x] `dotnet test FlowOrchestrator.UnitTests.slnf` → 213 tests passing × 3 TFMs
- [x] `dotnet test FlowOrchestrator.IntegrationTests.slnf` → all suites passing × 3 TFMs (includes 9 new `WaitForSignalTests`, 6 each `SqlFlowSignalStoreTests` / `PostgreSqlFlowSignalStoreTests`, 6 new `SignalEndpointTests`)
- [x] Manual smoke: trigger `ApprovalWorkflowFlow` from dashboard → click **Send Signal** with `{"approver":"alice","approved":true}` → run completes; downstream `notify_approver` logs `"alice"`.
- [x] Migrators idempotent on existing DB: integration tests run schema migrations against fresh containers and re-runs cleanly.

## Security note

A focused security review on the diff found **no new HIGH/MEDIUM vulnerabilities**. All Dapper queries are parameterized, payload rendering goes through the existing `esc()` / `prettyJson` HTML-escape pipeline, the new endpoint inherits the same BasicAuth filter as other dashboard mutation endpoints, and `JsonDocument.Parse` is used for body validation (no polymorphic deserialization).

The signal endpoint shares the same auth model as `/cancel`, `/retry`, `/rerun`, and `/trigger` (BasicAuth-only by default). Production deployments should layer real auth middleware in front of the dashboard — covered in the article's **Security** section. To expose signal delivery to external customers (vs internal admins), front it with your own authenticated API that calls `IFlowSignalDispatcher.DispatchAsync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)