### PR TITLE
feat: v1.19.0 — production observability, health checks, production docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,91 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.19.0] - 2026-05-01
+
+### Added
+
+- **Production-grade observability across logs, traces, and metrics.** Three-phase
+  upgrade in this release:
+  - **Phase 1 — Foundations + P0 correctness.** A new `FlowOrchestrator.Core.Observability`
+    namespace gathers `FlowOrchestratorTelemetry` (moved from `Core.Execution`),
+    `FlowOrchestratorInstrumentationExtensions` (moved from `FlowOrchestrator.Hangfire`,
+    Hangfire keeps a deprecated `[Obsolete]` shim for one release), `LogEvents` event-ID
+    constants, an `EngineLogScope` helper, and an `ActivityExtensions.RecordError` helper
+    that follows the OTel exception semantic convention. Every public engine entry point
+    now opens a `BeginScope({RunId, FlowId, StepKey, Attempt})` so nested log lines —
+    including logs emitted by user-written step handlers — are correlation-ready. Every
+    failed step / failed trigger now marks its activity with `ActivityStatusCode.Error`
+    and records the exception, so APMs treat the span as red instead of silently green.
+  - **Phase 2 — Trace continuity across runtime boundaries (Hangfire AND InMemory).**
+    A new `TraceContextHangfireFilter` (`IClientFilter` + `IServerFilter`) captures
+    `Activity.Current.Context` on enqueue, persists the W3C `traceparent` /
+    `tracestate` as Hangfire job parameters, and restores them in a wrapping
+    `flow.runtime.execute` activity when the worker dequeues. Symmetrically, the
+    InMemory runtime captures the same context on `InMemoryStepDispatcher` enqueue
+    (stored on `InMemoryStepEnvelope.ParentTraceContext`) and the channel runner
+    opens an equivalent `flow.runtime.execute` wrapper before invoking
+    `RunStepAsync`. Inbound webhook (`POST /flows/api/webhook/...`) and signal
+    (`POST /flows/api/runs/{runId}/signals/{name}`) endpoints in the Dashboard
+    read the same headers via the new `InboundTraceContext` helper and start their
+    entry-point activity as a child. The upshot: a single `traceId` connects the
+    original caller, the run, the runtime job, and every step span — for both
+    runtimes — no more forests of disconnected root spans. `FlowOrchestratorTelemetry.SharedActivitySource`
+    is now public so external runtime adapters can emit through the same source.
+  - **Phase 3 — Full span coverage, all metrics wired, source-gen logging, E2E test.** Three
+    new spans: `flow.step.retry` (per `RetryStepAsync`), `flow.step.when` (per `When`-clause
+    evaluation, tagged with resolved expression + result), `flow.step.poll` (per iteration
+    in `PollableStepHandler`, tagged with attempt number and condition match). Five new
+    instruments fully wired: counter `flow_step_retries`, counter `flow_step_skipped`
+    (with `reason` tag — `when_false` / `prerequisites_unmet`), counter
+    `flow_step_poll_attempts`, histogram `flow_signal_wait_ms` (from waiter registration
+    to signal delivery, recorded by `FlowSignalDispatcher`), histogram `flow_cron_lag_ms`
+    (scheduled-fire-time vs actual-dispatch, recorded by both Hangfire and InMemory
+    recurring dispatchers, tagged with `runtime`). Engine hot-path `ILogger` calls converted
+    to source-generated `[LoggerMessage]` partial methods (`EngineLog.cs`) for zero-allocation,
+    AOT-friendly logging. New E2E integration test
+    `TraceContextPropagationTests` spins up a real `BackgroundJobServer` over Hangfire
+    in-memory storage and asserts the parent `TraceId` survives enqueue → dequeue.
+- **`AddFlowOrchestratorHealthChecks()` extension** on `IHealthChecksBuilder`.
+  Registers a storage-reachability probe (`flow-orchestrator-storage`) backed by
+  `IFlowStore.GetAllAsync()` so a load balancer or container orchestrator can drop
+  traffic when the database is unreachable. Probe budget defaults to 5 s and is
+  configurable; the resolved `IFlowStore` is fetched from DI on every probe so
+  SQL Server, PostgreSQL, and in-memory all work without re-registration.
+- **Documentation: *Observability*** ([docs/articles/observability.md](docs/articles/observability.md))
+  rewritten with the full per-span / per-metric / per-tag table, a "Distributed tracing
+  across the runtime" diagram, sampling guidance, and a logger-scope / EventIds section.
+- **Documentation: *Versioning Flows in Production*** ([docs/articles/versioning.md](docs/articles/versioning.md)).
+  Five-section guide covering the three-layer mental model (Id / Version / manifest),
+  safe changes, caution changes that require a drain, breaking changes with
+  migration recipes, a pre-deploy checklist, and a worked `OrderFulfillmentFlow`
+  v1.0 → v1.1 → v2.0 evolution.
+- **Documentation: *Production Deployment Checklist*** ([docs/articles/production-checklist.md](docs/articles/production-checklist.md)).
+  Six-section checklist covering storage and persistence (the twelve tables
+  written by `FlowOrchestratorSqlMigrator`), multi-instance deployment under the
+  *Dispatch many, Execute once* invariant, monitoring (logs / OTel spans / metrics
+  / suggested alerts / health-check endpoint), secrets and PII, capacity planning
+  with retention guidance, and the upgrade path.
+- README: new **Production?** top-level section and two doc-table rows linking
+  to the new pages.
+
+### Changed
+
+- `FlowOrchestratorTelemetry` moved from the `FlowOrchestrator.Core.Execution` namespace
+  to `FlowOrchestrator.Core.Observability`. Add `using FlowOrchestrator.Core.Observability;`
+  to existing call sites; binary compatibility is unaffected because the type is normally
+  resolved from DI.
+- `AddFlowOrchestratorInstrumentation` moved from `FlowOrchestrator.Hangfire` to
+  `FlowOrchestrator.Core.Observability`. The Hangfire namespace still exposes a forwarding
+  `[Obsolete]` shim that emits a CS0618 warning at the call site. Existing user code
+  continues to compile; update the namespace at your convenience.
+
+### Internal
+
+- `OpenTelemetry.Api` (~30 KB API-only package) added as a direct dependency of
+  `FlowOrchestrator.Core` to let the OTel registration helpers ship in the same assembly
+  that already emits the activities. The full SDK is still opt-in.
+
 ## [1.18.0] - 2026-05-01
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <RepositoryUrl>https://github.com/hoangsnowy/FlowOrchestrator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/hoangsnowy/FlowOrchestrator</PackageProjectUrl>
-    <VersionPrefix>1.18.0</VersionPrefix>
+    <VersionPrefix>1.19.0</VersionPrefix>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,6 +40,8 @@
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
@@ -51,6 +53,8 @@
   <!-- Observability — keep all OpenTelemetry packages on the same release line. -->
   <ItemGroup>
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FlowOrchestrator
 
-**The DAG layer Hangfire is missing. No new infrastructure.**
+**Code-first DAG orchestration for .NET. Runs on Hangfire — or in-process with zero infrastructure.**
 
 [![NuGet](https://img.shields.io/nuget/v/FlowOrchestrator.Core)](https://www.nuget.org/packages/FlowOrchestrator.Core)
 [![Downloads](https://img.shields.io/nuget/dt/FlowOrchestrator.Core)](https://www.nuget.org/packages/FlowOrchestrator.Core)
@@ -15,14 +15,19 @@
 
 ---
 
+> **What's new in v1.19** — `AddFlowOrchestratorHealthChecks()` for storage reachability probes, plus two new docs: [Versioning Flows in Production](https://hoangsnowy.github.io/FlowOrchestrator/articles/versioning.html) and [Production Deployment Checklist](https://hoangsnowy.github.io/FlowOrchestrator/articles/production-checklist.html). v1.18 shipped [`WaitForSignal`](https://hoangsnowy.github.io/FlowOrchestrator/articles/wait-for-signal.html) for human-in-loop workflows; v1.17 shipped [`When` conditions](https://hoangsnowy.github.io/FlowOrchestrator/articles/conditional-execution.html) on `RunAfter`. Full [CHANGELOG](CHANGELOG.md).
+
+---
+
 ## When to choose FlowOrchestrator
 
 ✅ **Choose FlowOrchestrator if:**
-- You already use Hangfire and want multi-step DAGs without leaving it
+- You want multi-step DAGs in .NET without standing up a separate workflow server
 - Your team writes C# and wants flows defined as plain code, not JSON or a designer
-- You need a built-in dashboard with Timeline, DAG, and Gantt views
-- You want polling, fan-out, and cron in one library with one storage backend
-- You want zero new infrastructure — just SQL Server or PostgreSQL you already have
+- You need conditional branching (`When`), polling, fan-out (`ForEach`), human-in-loop (`WaitForSignal`), and cron in one library
+- You want a built-in dashboard with Timeline, DAG, and Gantt views
+- You want flows that are unit-testable in-process (`FlowTestHost`) and renderable as Mermaid diagrams in a PR
+- You already use Hangfire — or you want zero infrastructure at all (in-process runtime works without Hangfire or a database)
 
 ❌ **Choose something else if:**
 - You need multi-language workflows (Python + Go + .NET) → **[Temporal](https://temporal.io)**
@@ -50,11 +55,11 @@
 | Separate server / sidecar required | ✗ | ✗ | Optional | ✓ Required | ✓ Sidecar |
 | Storage you already have | SQL Server, PG, Redis | SQL Server, PG | SQL Server, PG, MongoDB | Cassandra, MySQL, PG | State store of choice |
 | Deterministic replay | ✗ | ✗ | ✗ | ✓ | ✓ |
-| External signals / human-in-loop | ✗ | Roadmap | ✓ | ✓ | ✓ |
+| External signals / human-in-loop | ✗ | ✓ `WaitForSignal` | ✓ | ✓ | ✓ |
 | Operational complexity | Low | Low | Low–Medium | High | Medium |
 | Learning curve (.NET dev) | Low | Low | Medium | Medium–High | Medium |
 
-> *FlowOrchestrator deliberately ships fewer features than Temporal or Dapr Workflows. It does not replay. It does not run a separate server. It is for teams that want DAG orchestration inside their existing Hangfire app, not a new platform.*
+> *FlowOrchestrator deliberately ships fewer features than Temporal or Dapr Workflows. It does not replay. It does not run a separate server. It is for teams that want DAG orchestration inside their existing ASP.NET Core app — alongside Hangfire if they have it, or fully in-process if they do not.*
 
 *Comparison verified 2026-04-30 against Elsa v3, Temporal .NET SDK v1, Dapr .NET SDK v1. [PRs welcome](https://github.com/hoangsnowy/FlowOrchestrator/pulls) to keep it current.*
 
@@ -141,18 +146,44 @@ public sealed class OrderFlow : IFlowDefinition
 
 ---
 
+## Pick a runtime
+
+FlowOrchestrator separates **storage** (where flow definitions and run history live) from the **runtime adapter** (which dispatches and executes steps).
+
+| | Hangfire runtime | InMemory runtime |
+|---|---|---|
+| Step dispatcher | `IBackgroundJobClient` | `Channel<T>` inside the host process |
+| Cron triggers | `IRecurringJobManager` (multi-instance safe) | `PeriodicTimer` (single-instance only) |
+| Survives process restart | ✓ (jobs in Hangfire storage) | ✗ (in-memory queue) |
+| Multi-instance horizontal scale | ✓ | ✗ |
+| Extra infrastructure | Hangfire + SQL Server / PostgreSQL | None |
+| Best for | Production workloads | Local dev, integration tests, single-node side projects |
+
+Storage is independent — InMemory storage works only for dev / tests, while SQL Server and PostgreSQL are production-ready under either runtime.
+
+---
+
 ## Install
 
 ```bash
 dotnet add package FlowOrchestrator.Core
-dotnet add package FlowOrchestrator.Hangfire
-dotnet add package FlowOrchestrator.SqlServer     # or FlowOrchestrator.PostgreSQL / FlowOrchestrator.InMemory
-dotnet add package FlowOrchestrator.Dashboard     # optional — REST API + SPA dashboard
+
+# Runtime adapter — pick one
+dotnet add package FlowOrchestrator.Hangfire     # Hangfire-backed (production default)
+dotnet add package FlowOrchestrator.InMemory     # In-process Channel<T> (dev / testing / single-node)
+
+# Storage backend — pick one
+dotnet add package FlowOrchestrator.SqlServer    # or FlowOrchestrator.PostgreSQL
+                                                  # FlowOrchestrator.InMemory ships its own storage too
+
+# Optional
+dotnet add package FlowOrchestrator.Dashboard    # REST API + SPA dashboard
+dotnet add package FlowOrchestrator.Testing      # FlowTestHost — in-process integration test helper
 ```
 
 ---
 
-## Quick Start (SQL Server + Hangfire)
+## Quick Start — SQL Server + Hangfire
 
 ```csharp
 // Program.cs
@@ -203,7 +234,29 @@ public sealed class OrderFulfillmentFlow : IFlowDefinition
 
 Open `http://localhost:5000/flows` — trigger the flow, watch steps execute in the DAG view, retry any failure.
 
-For InMemory (no Hangfire, no database) and PostgreSQL variants, see **[📖 Getting Started](https://hoangsnowy.github.io/FlowOrchestrator/articles/getting-started.html)**.
+## Quick Start — InMemory (zero infrastructure)
+
+For local development, prototypes, and single-node side projects — no Hangfire, no database:
+
+```csharp
+// Program.cs
+builder.Services.AddFlowOrchestrator(options =>
+{
+    options.UseInMemory();           // storage in-process
+    options.UseInMemoryRuntime();    // Channel<T> dispatcher + PeriodicTimer cron
+    options.AddFlow<OrderFulfillmentFlow>();
+});
+
+builder.Services.AddStepHandler<FetchOrdersStep>("FetchOrders");
+builder.Services.AddStepHandler<SubmitToWmsStep>("SubmitToWms");
+builder.Services.AddFlowDashboard(builder.Configuration);
+
+app.MapFlowDashboard("/flows");
+```
+
+All run data is lost on restart — see [Storage Backends](https://hoangsnowy.github.io/FlowOrchestrator/articles/storage.html#in-memory) for the full picture, and [Production Checklist](https://hoangsnowy.github.io/FlowOrchestrator/articles/production-checklist.html) for why this combo is unsuitable for production.
+
+For PostgreSQL, see **[📖 Getting Started](https://hoangsnowy.github.io/FlowOrchestrator/articles/getting-started.html)**.
 
 ---
 
@@ -224,6 +277,17 @@ For InMemory (no Hangfire, no database) and PostgreSQL variants, see **[📖 Get
 | Architecture | [architecture](https://hoangsnowy.github.io/FlowOrchestrator/articles/architecture.html) |
 | Observability | [observability](https://hoangsnowy.github.io/FlowOrchestrator/articles/observability.html) |
 | Mermaid export | [mermaid-export](https://hoangsnowy.github.io/FlowOrchestrator/articles/mermaid-export.html) |
+| Conditional execution (`When`) | [conditional-execution](https://hoangsnowy.github.io/FlowOrchestrator/articles/conditional-execution.html) |
+| Human-in-loop (`WaitForSignal`) | [wait-for-signal](https://hoangsnowy.github.io/FlowOrchestrator/articles/wait-for-signal.html) |
+| Testing flows (`FlowTestHost`) | [testing](https://hoangsnowy.github.io/FlowOrchestrator/articles/testing.html) |
+| Versioning flows in production | [versioning](https://hoangsnowy.github.io/FlowOrchestrator/articles/versioning.html) |
+| Production deployment checklist | [production-checklist](https://hoangsnowy.github.io/FlowOrchestrator/articles/production-checklist.html) |
+
+---
+
+## Production?
+
+Before changing any deployed flow, read **[Versioning Flows](https://hoangsnowy.github.io/FlowOrchestrator/articles/versioning.html)** — it explains which manifest changes are safe and which need a maintenance window. Before go-live, walk through the **[Production Checklist](https://hoangsnowy.github.io/FlowOrchestrator/articles/production-checklist.html)** for storage, multi-instance, monitoring, secrets, capacity, and upgrade guidance. Wire `AddFlowOrchestratorHealthChecks()` into `/health` so your load balancer can drop traffic when the flow store is unreachable.
 
 ---
 
@@ -268,6 +332,7 @@ sample app exposes `--export-mermaid <flowId>` for CI integrations.
 | `FlowOrchestrator.SqlServer` | `net8.0` · `net9.0` · `net10.0` |
 | `FlowOrchestrator.PostgreSQL` | `net8.0` · `net9.0` · `net10.0` |
 | `FlowOrchestrator.Dashboard` | `net8.0` · `net9.0` · `net10.0` |
+| `FlowOrchestrator.Testing` | `net8.0` · `net9.0` · `net10.0` |
 
 ---
 

--- a/docs/articles/core-concepts.md
+++ b/docs/articles/core-concepts.md
@@ -84,8 +84,8 @@ new StepMetadata
 
 | Field | Purpose |
 |---|---|
-| `Type` | Name used to look up the `IStepHandler` registered with `AddStepHandler<T>("Name")` |
-| `RunAfter` | Zero or more step keys → required statuses. Empty = entry step (runs immediately after trigger). |
+| `Type` | Name used to look up the `IStepHandler` registered with `AddStepHandler<T>("Name")`. Built-in step types include `ForEach` (see [ForEach Loops](foreach.md)) and `WaitForSignal` (see [WaitForSignal](wait-for-signal.md)). |
+| `RunAfter` | Zero or more step keys → required statuses, optionally combined with a `When` boolean expression. Empty = entry step (runs immediately after trigger). See [Conditional Execution](conditional-execution.md) for the full syntax. |
 | `Inputs` | Key-value pairs passed to the handler. Values may be literals or `@` expressions — see [Expressions](expressions.md). |
 
 ### LoopStepMetadata
@@ -133,6 +133,8 @@ RunAfter = null  // or omit entirely
 
 When multiple predecessors are listed, **all** must reach one of their declared statuses before the step becomes ready (AND-join semantics). This enables fan-in after parallel branches.
 
+`RunAfterCondition` also supports a `When` boolean expression evaluated against trigger payload and upstream step outputs. A step whose `When` evaluates to `false` is recorded as `Skipped` and the dashboard surfaces the evaluation trace under the **Why skipped** panel. See [Conditional Execution](conditional-execution.md).
+
 ---
 
 ## Step Statuses
@@ -143,7 +145,7 @@ When multiple predecessors are listed, **all** must reach one of their declared 
 | `Running` | The runtime adapter is executing this step |
 | `Succeeded` | Handler returned without error |
 | `Failed` | Handler threw an exception, or returned `StepStatus.Failed` |
-| `Skipped` | All paths to this step ended in statuses not listed in its `RunAfter`. The dashboard displays this as **Blocked**. |
+| `Skipped` | The step did not run. Either every path to it ended in statuses not listed in its `RunAfter`, or its `When` condition evaluated to `false` (see [Conditional Execution](conditional-execution.md)). The dashboard displays this as **Blocked**. |
 
 ---
 

--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -179,6 +179,20 @@ app.UseHangfireDashboard("/hangfire");  // Hangfire's own dashboard (optional)
 app.MapFlowDashboard("/flows");          // FlowOrchestrator dashboard + REST API
 ```
 
+## Add a Health Check (optional but recommended)
+
+For production, expose a `/health` endpoint that probes flow-store reachability so a load balancer can drop traffic when the database is unavailable:
+
+```csharp
+builder.Services
+    .AddHealthChecks()
+    .AddFlowOrchestratorHealthChecks();   // probes IFlowStore reachability
+
+app.MapHealthChecks("/health");
+```
+
+The check resolves whichever `IFlowStore` you registered (SQL Server, PostgreSQL, or in-memory). Probe budget defaults to 5 seconds and is configurable. See [Production Checklist](production-checklist.md#3-monitoring) for the full operational story.
+
 ## Run the App
 
 ```bash
@@ -214,3 +228,6 @@ GET /flows/api/runs/3fa85f64-5717-4562-b3fc-2c963f66afa6
 - [Step Handlers](step-handlers.md) — write more complex handlers with typed outputs
 - [Triggers](triggers.md) — cron schedules, webhooks, and idempotency
 - [Polling Steps](polling.md) — wait for external systems without blocking threads
+
+> [!TIP]
+> When you are ready for production, read **[Versioning Flows](versioning.md)** before changing any deployed flow, and walk through the **[Production Checklist](production-checklist.md)** before go-live.

--- a/docs/articles/observability.md
+++ b/docs/articles/observability.md
@@ -238,6 +238,9 @@ The check resolves whichever `IFlowStore` you registered (SQL Server, PostgreSQL
 
 When running under Aspire, `OTEL_EXPORTER_OTLP_ENDPOINT` is injected automatically. Spans and metrics appear in the Aspire Dashboard with no extra configuration beyond `AddFlowOrchestratorInstrumentation()`.
 
+> [!IMPORTANT]
+> **For the engine's structured logs to show up in Aspire's Logs tab** (with `RunId` / `StepKey` / `EventId` as searchable attributes), wire up `builder.Logging.AddOpenTelemetry(...)` with `IncludeScopes = true` and `AddOtlpExporter()` — see the [OpenTelemetry Logs](#opentelemetry-logs-auto-trace-correlation) example above. OTel's tracing and metrics pipelines do *not* automatically wire the logging pipeline; without this snippet the Logs tab will be empty even though traces and metrics flow through.
+
 ---
 
 ## Run Control State

--- a/docs/articles/observability.md
+++ b/docs/articles/observability.md
@@ -4,7 +4,7 @@ FlowOrchestrator exposes run events, OpenTelemetry traces/metrics, and a retenti
 
 ## Run Events
 
-When event persistence is enabled, FlowOrchestrator writes structured `FlowEvent` records for every state transition: run started, step queued, step started, step completed/failed, run completed.
+When event persistence is enabled, FlowOrchestrator writes structured `FlowEvent` records for every state transition: run started, step queued, step started, step completed/failed, run completed. Built-in step types — including `WaitForSignal` (`step.pending` while waiting, `step.completed` once the signal lands) and `ForEach` (per child-iteration events) — emit through the same channel as user-written handlers.
 
 ```csharp
 options.Observability.EnableEventPersistence = true;
@@ -35,6 +35,8 @@ options.Observability.EnableOpenTelemetry = true;
 Wire up the instrumentation in your OTel pipeline:
 
 ```csharp
+using FlowOrchestrator.Core.Observability;
+
 builder.Services.AddOpenTelemetry()
     .ConfigureResource(r => r.AddService("MyApp"))
     .WithTracing(t => t
@@ -47,20 +49,190 @@ builder.Services.AddOpenTelemetry()
         .AddOtlpExporter());
 ```
 
-`AddFlowOrchestratorInstrumentation()` is an extension method on both `TracerProviderBuilder` and `MeterProviderBuilder`. It subscribes to the `FlowOrchestrator` activity source and meter.
+`AddFlowOrchestratorInstrumentation()` is an extension method on both `TracerProviderBuilder` and `MeterProviderBuilder`. It subscribes to the `FlowOrchestrator` activity source and meter, and now lives in `FlowOrchestrator.Core.Observability` (moved from `FlowOrchestrator.Hangfire` in v1.19). The Hangfire namespace still exposes `[Obsolete]` shims for one release so existing code keeps compiling.
 
 ### What is emitted
 
-**Traces:**
-- `flow.trigger` span — covers `TriggerAsync` from trigger receipt to first step dispatch via `IStepDispatcher`
-- `flow.step` span — covers the full execution of each step, including expression resolution and handler dispatch
-- `flow.step.poll` span — each individual poll attempt for polling steps
+**Traces (every span is on the `FlowOrchestrator` activity source):**
 
-**Metrics:**
-- `floworch.runs.started` — counter, tagged with `flow_id`, `trigger_type`
-- `floworch.runs.completed` — counter, tagged with `flow_id`, `status` (`succeeded`/`failed`/`cancelled`/`timed_out`)
-- `floworch.steps.duration` — histogram (milliseconds), tagged with `flow_id`, `step_type`
-- `floworch.steps.poll_attempts` — histogram, tagged with `flow_id`, `step_key`
+| Span | Kind | When | Notable tags |
+|---|---|---|---|
+| `flow.trigger` | Internal | One per `TriggerAsync` call | `flow.id`, `run.id`, `trigger.key`, `trigger.type`, `duplicate` (set when idempotency dedupe fires) |
+| `flow.step` | Internal | One per `RunStepAsync` call | `flow.id`, `run.id`, `step.key`, `step.type` |
+| `flow.step.retry` | Internal | One per `RetryStepAsync` call | `flow.id`, `run.id`, `step.key` |
+| `flow.step.when` | Internal | When a step's `When` clause is evaluated | `flow.id`, `run.id`, `step.key`, `flow.when.expression`, `flow.when.resolved`, `flow.when.result` |
+| `flow.step.poll` | Internal | One per polling iteration in `PollableStepHandler` | `flow.id`, `run.id`, `step.key`, `flow.poll.attempt`, `flow.poll.condition_met` |
+| `flow.runtime.execute` | Consumer | Wraps each Hangfire job. Restores the parent `traceparent` captured at enqueue, so step spans become children of the original caller. | `messaging.system=hangfire`, `messaging.message.id` |
+| `flow.webhook.receive` | Server | One per inbound webhook hit, parented onto the caller's `traceparent` header | `flow.webhook.slug_or_id` |
+| `flow.signal.deliver` | Server | One per inbound signal HTTP call, parented onto the caller's `traceparent` | `flow.run_id`, `flow.signal_name` |
+
+Failures set `Status = Error` on the activity and add an `exception` event with the standard
+OTel tags (`exception.type`, `exception.message`, `exception.stacktrace`). APMs treat the span as
+red without any extra configuration.
+
+**Metrics (every instrument is on the `FlowOrchestrator` meter):**
+
+| Metric | Type | Unit | Tags |
+|---|---|---|---|
+| `flow_runs_started` | counter | runs | `flow_id`, `trigger_key` |
+| `flow_runs_completed` | counter | runs | `status` |
+| `flow_steps_completed` | counter | steps | `flow_id`, `status` |
+| `flow_step_duration_ms` | histogram | ms | `flow_id`, `step_key`, `status` |
+| `flow_step_queue_delay_ms` | histogram | ms | `flow_id`, `step_key` |
+| `flow_step_retries` | counter | retries | `flow_id`, `step_key` |
+| `flow_step_skipped` | counter | steps | `flow_id`, `step_key`, `reason` (`when_false` / `prerequisites_unmet`) |
+| `flow_step_poll_attempts` | counter | attempts | `flow_id`, `step_key` |
+| `flow_signal_wait_ms` | histogram | ms | `flow_id`, `step_key`, `signal_name` — recorded by `FlowSignalDispatcher` on delivery |
+| `flow_cron_lag_ms` | histogram | ms | `flow_id`, `trigger_key`, `runtime` (`hangfire` / `in_memory`) — gap between scheduled fire and actual dispatch |
+
+### Distributed tracing across the runtime
+
+A single `traceId` connects everything from the inbound HTTP request to the last step's exit:
+
+```
+caller traceparent
+   └── flow.webhook.receive          (Dashboard, Server)
+         └── flow.trigger             (engine)
+               └── flow.runtime.execute  (Hangfire, Consumer)
+                     └── flow.step       (engine, per dispatched step)
+                           └── flow.step.poll  (handler, per poll attempt)
+```
+
+The `flow.runtime.execute` wrapper is opened by `TraceContextHangfireFilter` (registered automatically when `options.UseHangfire()` is set). It captures `Activity.Current.Context` on enqueue, persists the W3C identifiers as Hangfire job parameters, and restores them as the parent context when the worker picks the job up. Inbound webhook and signal endpoints in the Dashboard read the `traceparent` / `tracestate` headers via `InboundTraceContext` and start their entry-point activity as a child of the parsed context.
+
+Without this plumbing, a Hangfire-backed run would appear as a forest of disconnected root spans — one per step. With it, an APM shows a single connected tree from the original caller down to every step.
+
+### Sampling
+
+OTel sampling for traces should be configured at the SDK, not at FlowOrchestrator. For low-volume systems start with `AlwaysOnSampler`; for high-volume production prefer parent-based sampling so trace continuity is preserved across the runtime boundary:
+
+```csharp
+.WithTracing(t => t
+    .SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(0.05))) // 5% root sampling
+    .AddFlowOrchestratorInstrumentation()
+    .AddOtlpExporter());
+```
+
+Metrics are aggregated, not sampled — leave the default cardinality limits in place and only override if you see exporter overflow warnings.
+
+### Logger scopes and EventIds
+
+The engine wraps every public entry point (`TriggerAsync`, `RunStepAsync`, `RetryStepAsync`) in `_logger.BeginScope(...)` carrying `RunId`, `FlowId`, `StepKey`, and `Attempt` (when applicable). Every nested log line — including logs from your own step handlers — carries those properties automatically. Logging providers that honour scopes (Serilog, NLog, OpenTelemetry Logs, Application Insights, Datadog, …) surface them as searchable fields. Engine hot-path log calls go through source-generated `[LoggerMessage]` partial methods (`EngineLog.cs`) for zero-allocation, AOT-friendly emission. See [Logging integrations](#logging-integrations) below for concrete provider wireup.
+
+Stable `EventId` constants are defined in `FlowOrchestrator.Core.Observability.LogEvents` so production users can filter or alert on a specific log event without parsing the message template:
+
+```csharp
+LogEvents.RunStarted        = 1000
+LogEvents.RunCompleted      = 1001
+LogEvents.StepStarted       = 2000
+LogEvents.StepCompleted     = 2001
+LogEvents.StepFailed        = 2002
+LogEvents.StepSkipped       = 2003
+LogEvents.WhenEvaluationFailed = 2005
+LogEvents.DispatchEnqueued  = 3000
+// …see the source for the full list.
+```
+
+### Logging integrations
+
+The library is logging-framework-agnostic — it only uses `Microsoft.Extensions.Logging.ILogger<T>`. Plug in any provider that honours `ILogger.BeginScope` and you get the engine's correlation properties (`RunId`, `FlowId`, `StepKey`, `Attempt`) on every nested log line, including logs emitted by your own step handlers.
+
+#### Microsoft.Extensions.Logging (Console)
+
+Built into the framework. Scopes are off by default — opt in via the formatter options:
+
+```csharp
+builder.Logging.AddJsonConsole(o => o.IncludeScopes = true);
+// or
+builder.Logging.AddSimpleConsole(o => o.IncludeScopes = true);
+```
+
+Output:
+
+```json
+{ "Timestamp":"…", "EventId":2002, "LogLevel":"Error",
+  "Category":"FlowOrchestrator.Core.Execution.FlowOrchestratorEngine",
+  "Message":"Step execution failed for submit_to_wms",
+  "Scopes":[{"RunId":"3fa85f64-…","FlowId":"a1b2c3d4-…","StepKey":"submit_to_wms"}] }
+```
+
+#### Serilog
+
+```bash
+dotnet add package Serilog.AspNetCore
+dotnet add package Serilog.Sinks.Seq      # or Console / File / Datadog / Splunk / …
+```
+
+```csharp
+builder.Host.UseSerilog((ctx, cfg) => cfg
+    .ReadFrom.Configuration(ctx.Configuration)
+    .Enrich.FromLogContext()                        // <-- required so scope props become structured fields
+    .Enrich.WithProperty("Service", "OrderHub")
+    .WriteTo.Seq("http://seq:5341"));
+```
+
+Query in Seq / any structured sink:
+
+```
+EventId.Id = 2002 and StepKey = 'submit_to_wms'
+```
+
+#### NLog
+
+```bash
+dotnet add package NLog.Web.AspNetCore
+```
+
+```csharp
+builder.Host.UseNLog();
+```
+
+`nlog.config` — use `${scopeproperty}` to render scope keys:
+
+```xml
+<targets>
+  <target xsi:type="Console" name="console"
+          layout="${longdate} ${level} ${event-properties:item=EventId_Id} run=${scopeproperty:item=RunId} step=${scopeproperty:item=StepKey} - ${message} ${exception:format=tostring}" />
+</targets>
+```
+
+#### OpenTelemetry Logs (auto trace correlation)
+
+When you already use OTel for traces, exporting logs through the same pipeline gives automatic `TraceId` / `SpanId` correlation in every log line — clicking a log in your APM jumps straight to the trace:
+
+```csharp
+using FlowOrchestrator.Core.Observability;
+
+builder.Logging.AddOpenTelemetry(o =>
+{
+    o.IncludeFormattedMessage = true;
+    o.IncludeScopes = true;                         // <-- emits RunId/FlowId/StepKey as log attributes
+    o.ParseStateValues = true;
+    o.AddOtlpExporter();
+});
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(t => t.AddFlowOrchestratorInstrumentation().AddOtlpExporter())
+    .WithMetrics(m => m.AddFlowOrchestratorInstrumentation().AddOtlpExporter());
+```
+
+#### Application Insights / Datadog / Splunk / Seq / Loki
+
+All honour `BeginScope` — scope properties surface as `customDimensions` (App Insights), structured tags (Datadog/Splunk/Loki), or top-level fields (Seq) automatically. No FlowOrchestrator-specific configuration required beyond enabling scopes on the provider.
+
+> [!TIP]
+> If your scope properties are missing in the sink output, the provider almost certainly has scopes disabled by default. Search its docs for `IncludeScopes` (Microsoft.Extensions.Logging.Console, OpenTelemetry), `Enrich.FromLogContext` (Serilog), or `${scopeproperty}` (NLog).
+
+### Health checks
+
+Wire the bundled storage probe so a load balancer can drop traffic when the flow store is unreachable:
+
+```csharp
+builder.Services.AddHealthChecks().AddFlowOrchestratorHealthChecks();
+app.MapHealthChecks("/health");
+```
+
+The check resolves whichever `IFlowStore` you registered (SQL Server, PostgreSQL, in-memory). Probe budget defaults to 5 s and is configurable. See [Production Checklist](production-checklist.md#3-monitoring) for the full operational story.
 
 ### Running with .NET Aspire
 

--- a/docs/articles/production-checklist.md
+++ b/docs/articles/production-checklist.md
@@ -1,0 +1,239 @@
+# Production Deployment Checklist
+
+A pragmatic checklist for shipping FlowOrchestrator to production. Walk through every
+section before go-live; bookmark this page for the first incident review.
+
+For *changing* a flow once it is in production, see [Versioning Flows](versioning.md).
+
+---
+
+## 1. Storage and Persistence
+
+FlowOrchestrator writes to twelve tables. The auto-migrator
+(`FlowOrchestratorSqlMigrator`) creates them idempotently on startup.
+
+| Table | Holds |
+|---|---|
+| `FlowDefinitions` | One row per registered flow (id, name, version, manifest JSON). |
+| `FlowRuns` | One row per `TriggerAsync` invocation (status, trigger data, timestamps). |
+| `FlowSteps` | One row per step instance per run (status, inputs, output). |
+| `FlowStepAttempts` | Per-attempt history for retried steps (attempt number, error, durations). |
+| `FlowOutputs` | Step outputs keyed by `(RunId, StepKey)`. |
+| `FlowStepDispatches` | Idempotent dispatch ledger — supports the *Dispatch many, Execute once* invariant. |
+| `FlowStepClaims` | Exclusive execution claim per step (the "Execute once" half). |
+| `FlowRunControls` | Cancellation, idempotency key, run timeout. |
+| `FlowIdempotencyKeys` | Idempotency dedupe at trigger time. |
+| `FlowEvents` | State-transition audit log (when event persistence is enabled). |
+| `FlowSignalWaiters` | Parked `WaitForSignal` steps. |
+| `FlowScheduleStates` | Recurring-trigger sync state. |
+
+> [!WARNING]
+> **`UseInMemory()` is not for production.** All run data is stored in-process and
+> lost on restart. The runtime is supported only for development and tests; the
+> manifest's [Getting Started](getting-started.md#in-memory-dev--testing) page
+> already calls this out, but it bears repeating here.
+
+### SQL Server
+
+- Use a **case-insensitive** collation (the default `SQL_Latin1_General_CP1_CI_AS` is fine). Step keys are matched as-is and a CS collation will surprise developers.
+- Indexes are created by the auto-migrator. If you sharpen them, do it under a separate review — the engine relies on them for the dispatch-ledger fast path.
+- Enable point-in-time recovery (PITR) — every table is part of the operational record and a 24 h gap is hard to reconstruct.
+
+### PostgreSQL
+
+- Tune `max_connections` against the Hangfire worker count (default 20) plus dashboard / API traffic.
+- Leave autovacuum on. The dispatch ledger is hot under high throughput; bloat shows up as `EXPLAIN` plans falling off index scans.
+- Logical replication or `pg_basebackup` for backups — both work, just have a tested restore drill.
+
+### Backup recipe
+
+Full backup + transaction-log / WAL replay covers every table above. Step inputs and outputs are persisted in `FlowOutputs`, so restoring is restoring **state**, not just configuration.
+
+---
+
+## 2. Multi-Instance Deployment
+
+FlowOrchestrator's core invariant — **Dispatch many, Execute once** — is what makes
+horizontal scale safe.
+
+- `IFlowRunStore.TryRecordDispatchAsync` is an idempotent INSERT into `FlowStepDispatches`. Multiple workers may try; only one row lands. Backed by `SqlFlowRunStore` ([source](https://github.com/hoangsnowy/FlowOrchestrator/blob/main/src/FlowOrchestrator.SqlServer/SqlFlowRunStore.cs)).
+- `TryClaimStepAsync` (the claim guard) ensures only one runtime instance executes a given step attempt; the others exit silently.
+- **Cron triggers** under the Hangfire runtime use `IRecurringJobManager`, which fires each schedule on exactly one server. No extra coordination is needed.
+
+> [!WARNING]
+> **InMemory runtime + multi-instance is not supported.** The dispatcher is a `Channel<T>` inside one process — instance B has no way to observe a job that instance A enqueued. Always combine `UseInMemoryRuntime()` with a single instance.
+
+### Blue-green deployment
+
+1. Pause every cron trigger (dashboard → trigger pause toggle).
+2. Wait for `GET /flows/api/runs/active` to drain to `[]`.
+3. Cut over traffic to the new version.
+4. Resume cron triggers.
+
+The dispatch ledger means an interrupted run will be re-driven by `FlowRunRecoveryHostedService` on the new instance — no manual replay step required.
+
+---
+
+## 3. Monitoring
+
+### Logs
+
+Every log line emitted by the engine includes the `RunId` and step key (when
+applicable). Forward the following correlation fields if your aggregator strips
+unknown ones:
+
+- `RunId` (Guid)
+- `FlowId` (Guid)
+- `StepKey` (string)
+- `Attempt` (int)
+
+### OpenTelemetry traces and metrics
+
+Enable via `options.Observability.EnableOpenTelemetry = true` and wire up via
+`AddFlowOrchestratorInstrumentation()` — see [Observability](observability.md#opentelemetry).
+
+| Span | Covers |
+|---|---|
+| `flow.trigger` | `TriggerAsync` from receipt to first step dispatch. |
+| `flow.step` | One step end-to-end (expression resolution + handler). |
+| `flow.step.poll` | One poll attempt of a `PollableStepHandler<T>`. |
+
+| Metric | Type | Tags |
+|---|---|---|
+| `floworch.runs.started` | counter | `flow_id`, `trigger_type` |
+| `floworch.runs.completed` | counter | `flow_id`, `status` |
+| `floworch.steps.duration` | histogram (ms) | `flow_id`, `step_type` |
+| `floworch.steps.poll_attempts` | histogram | `flow_id`, `step_key` |
+
+### Suggested alerts
+
+- **Stuck runs.** `count(active_runs WHERE status='Running' AND age > 1h) > 0` — usually a missing handler or external dependency timeout.
+- **Failed-run rate.** `rate(floworch.runs.completed{status="failed"}[5m]) > 1` — tune to your volume.
+- **Cron lag.** `now() - last_recurring_fire > 2 × schedule_interval` — Hangfire server unhealthy or paused inadvertently.
+- **Queue depth.** Hangfire's own `enqueued` counter; FlowOrchestrator inherits it.
+
+### Health-check endpoint
+
+Wire up the bundled health check so the load balancer can drop traffic when storage is unreachable:
+
+```csharp
+builder.Services
+    .AddHealthChecks()
+    .AddFlowOrchestratorHealthChecks();   // probes IFlowStore reachability
+
+var app = builder.Build();
+app.MapHealthChecks("/health");
+```
+
+The check resolves `IFlowStore` from DI on every probe, so SQL Server, PostgreSQL,
+and in-memory all work without re-registration. The probe budget defaults to 5
+seconds and is configurable:
+
+```csharp
+.AddFlowOrchestratorHealthChecks(timeout: TimeSpan.FromSeconds(2));
+```
+
+Verify it:
+
+```bash
+curl -f https://app.example.com/health
+# Healthy
+```
+
+```http
+GET /health HTTP/1.1
+
+HTTP/1.1 200 OK
+Content-Type: text/plain
+
+Healthy
+```
+
+The response degrades to `503 Service Unavailable` with body `Unhealthy` when the
+flow store throws or the probe budget elapses — point your load balancer at it.
+
+---
+
+## 4. Secrets and Credentials
+
+- **Connection strings.** Never in source. Use environment variables, `appsettings.{Environment}.json` outside of `main`, or a managed secret store.
+- **Webhook secrets.** Each webhook trigger carries a `webhookSecret` input. Rotate it like any shared secret; supply a new value in the manifest and pause-resume the trigger so the routing table refreshes.
+- **Dashboard Basic Auth.** The dashboard ships with optional Basic Auth — sufficient for an internal-only surface behind a VPN. **Insufficient for any production fronting the public internet** — put a real auth proxy (OIDC, Azure AD, Cloudflare Access) in front.
+- **PII in step inputs/outputs.** Step inputs and outputs are persisted in `FlowSteps` and `FlowOutputs` and are visible in the dashboard's run detail view. **Treat them as logs.** If you need to ingest PII, redact before the step boundary and pass an opaque token instead.
+
+---
+
+## 5. Capacity Planning
+
+### Storage cost per run
+
+A single run typically writes:
+
+- 1 row in `FlowRuns`
+- *N* rows in `FlowSteps` (one per step)
+- *N* rows in `FlowOutputs` (one per step that produced output)
+- *M* rows in `FlowStepAttempts` (one per attempt — usually 1, more with retries)
+- *K* rows in `FlowEvents` (when event persistence is on; ~5 per step)
+
+For a 5-step flow with retries off and event persistence on, that is ~30 rows per run. At one million runs per month, expect tens of GB per year before retention.
+
+### Retention
+
+Turn it on:
+
+```csharp
+options.Retention.Enabled = true;
+options.Retention.DataTtl = TimeSpan.FromDays(30);
+options.Retention.SweepInterval = TimeSpan.FromHours(1);
+```
+
+Pick `DataTtl` against your audit requirements, not your storage budget — storage is cheap and a forensics request always wants a longer window than you set.
+
+### Hangfire worker tuning
+
+The default `WorkerCount = Environment.ProcessorCount * 5` is fine for most
+FlowOrchestrator workloads (steps are typically I/O-bound). Increase only if
+metrics show queue depth growing while CPU stays low. For background-CPU-bound
+steps, lower it to avoid thrashing.
+
+---
+
+## 6. Upgrade Path
+
+### Within a major version (1.x → 1.y)
+
+`FlowOrchestratorSqlMigrator` runs on every startup and applies pending DDL idempotently. Releases note any table or column additions; rolling deploys are safe.
+
+### Across major versions (1.x → 2.x)
+
+A major bump may rename or split tables. The release notes include the migration
+path; run it in a non-production environment first and verify with a smoke run
+(see below).
+
+### Disabling the auto-migrator
+
+If your operations team owns DDL changes:
+
+```csharp
+options.UseSqlServer(connectionString, autoMigrate: false);
+```
+
+…then run the migration script (published in each release) under your own
+deployment pipeline.
+
+### Smoke-run verification
+
+After any deploy:
+
+1. Trigger a manual run of a no-op flow (the simplest one in your manifest).
+2. Assert the run reaches `Status = Succeeded` within the SLA you expect.
+3. Hit `/health` and check the response is `Healthy`.
+
+If any of those fail, roll back before letting business traffic resume.
+
+---
+
+> [!TIP]
+> Running FlowOrchestrator in production? Tell us about your deployment in the
+> [GitHub Discussions](https://github.com/hoangsnowy/FlowOrchestrator/discussions)
+> — patterns and pain points feed directly into the roadmap.

--- a/docs/articles/storage.md
+++ b/docs/articles/storage.md
@@ -37,10 +37,13 @@ builder.Services.AddFlowOrchestrator(options =>
 | `FlowSteps` | One row per step per run: status, attempt count |
 | `FlowStepAttempts` | Detailed per-attempt records (start, end, error) |
 | `FlowOutputs` | Step inputs and outputs serialized as JSON |
-| `FlowTriggerData` | Persisted trigger headers and body |
-| `FlowScheduleState` | Cron override storage (when `PersistOverrides = true`) |
-| `FlowRunControl` | Timeout, cancellation, idempotency key records |
+| `FlowStepDispatches` | Idempotent dispatch ledger — supports the *Dispatch many, Execute once* invariant |
+| `FlowStepClaims` | Exclusive execution claim per step (the *Execute once* half) |
+| `FlowRunControls` | Cancellation, timeout, and idempotency key records |
+| `FlowIdempotencyKeys` | Trigger-time idempotency dedupe |
 | `FlowEvents` | Event stream records (when `EnableEventPersistence = true`) |
+| `FlowSignalWaiters` | Parked `WaitForSignal` step state (see [WaitForSignal](wait-for-signal.md)) |
+| `FlowScheduleStates` | Cron override storage (when `Scheduler.PersistOverrides = true`) |
 
 **Connection string format:**
 
@@ -147,6 +150,7 @@ For full feature parity (schedule overrides, run control, event stream, retentio
 | `IFlowRunControlStore` | Cancel, timeout, and idempotency key state. The engine checks this on every `TriggerAsync` to deduplicate runs and on every `RunStepAsync` to honour cancellation. |
 | `IFlowEventReader` | Run event stream (`GET /flows/api/runs/{runId}/events`) |
 | `IFlowRetentionStore` | Background retention sweep (deletes old run data) |
+| `IFlowSignalStore` | Parked `WaitForSignal` waiter state. Required if you want to use the [`WaitForSignal`](wait-for-signal.md) built-in step on a custom backend. |
 | `IFlowRunRuntimeStore` | Step claim/dispatch ledger per run. Implements `TryRecordDispatchAsync` (idempotent INSERT — prevents duplicate dispatch) and `TryClaimStepAsync` (claim exclusion — ensures a step is executed by at most one worker). Required for production use with any multi-worker runtime. |
 
 Register these the same way — directly on `options.Services`.

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -45,3 +45,9 @@
 
 - name: Configuration Reference
   href: configuration.md
+
+- name: Versioning Flows
+  href: versioning.md
+
+- name: Production Checklist
+  href: production-checklist.md

--- a/docs/articles/versioning.md
+++ b/docs/articles/versioning.md
@@ -1,0 +1,172 @@
+# Versioning Flows in Production
+
+Once a flow has run in production, its definition is no longer a free-form artifact —
+every change must be reasoned about against in-flight runs, the run history, and the
+recurring-job state stored by the runtime. This page is the rule-set for changing a
+deployed flow safely.
+
+## The Mental Model — Three Layers of Version
+
+FlowOrchestrator separates *identity*, *display*, and *shape*:
+
+| Layer | Type | Mutability | Effect of changing |
+|---|---|---|---|
+| **Flow `Id`** | `Guid` | **Immutable** — never change after first deploy. | All historical runs, recurring jobs, dispatch ledger entries, and webhook routes are keyed by `Id`. Changing it orphans every existing record and creates a new flow. |
+| **Flow `Version` string** | `string` | Free-form display label. | Cosmetic only. Bump it whenever you ship a meaningful change so the dashboard and run history make the timeline legible. |
+| **Manifest shape** | `FlowManifest` | Mutable, but each change has consequences. | The actual graph — triggers, steps, `RunAfter`, `When`, `Inputs`. The rest of this page is about which manifest changes are safe and which need a maintenance window. |
+
+> [!IMPORTANT]
+> The `Id` is stored in the database and used to route Hangfire jobs and webhook callbacks across all runtimes. **Never change it** — see [Getting Started](getting-started.md#define-your-first-flow).
+
+---
+
+## Safe Changes — Deploy at Any Time
+
+These changes do not touch in-flight runs. No drain, no maintenance window.
+
+- **Adding a brand-new step that no existing step depends on.** New runs pick it up; old runs do not retroactively gain it.
+- **Adding a new trigger** (manual, cron, webhook). Existing triggers are unaffected.
+- **Changing step `Inputs` values.** Inputs are resolved at step-execution time, so the change applies to any step that has not yet started. Topology is unchanged.
+- **Changing the handler implementation.** Handlers are registered at runtime via `AddStepHandler<T>("StepType")` — they are not part of the persisted manifest.
+- **Bumping the `Version` string.**
+
+---
+
+## Caution Changes — Drain First
+
+These changes are safe only if no runs are in flight, because they can change the readiness rules for steps that have already started.
+
+| Change | Failure mode if not drained | Recommendation |
+|---|---|---|
+| Inserting a step in the *middle* of an existing path | An in-flight run that already passed the upstream step will **not** retroactively run the new step. The run continues with the old graph it was planned against. | Pause cron, wait for `Active Runs == 0` on the dashboard, deploy. |
+| Changing `RunAfter` dependencies on an existing step | A step that is already queued on the runtime may dispatch under the old plan and produce results inconsistent with the new edge set. | As above — drain. |
+| Adding a new `When` condition to an existing step | A run that already passed the upstream gate will continue under the old condition, so two runs of "the same flow" can take divergent branches depending on when they were triggered. | Drain, or use a new step with the condition rather than modifying the existing one. |
+| Changing a step's `Type` to point at a different handler | Re-runs of historical runs will use the new handler, which may not understand the old persisted inputs. | Drain. If you also need to re-run history, snapshot the manifest before the change so you can read back what each run was planned against. |
+
+The drain procedure (mirrors the *Production Checklist*):
+
+1. In the dashboard, pause every cron trigger for the flow.
+2. Wait for `GET /flows/api/runs/active` to return `[]` for that flow.
+3. Deploy the change.
+4. Resume the cron triggers.
+
+---
+
+## Breaking Changes — Migrate Explicitly
+
+These changes break run history readability or violate the `Id`-immutability rule. Do not do them silently — the recipes below preserve the audit trail.
+
+### Removing a step that has historical runs
+
+Do **not** delete the step from the manifest. Run history still references the step by key in `FlowSteps` rows, and dropping it makes the dashboard's run-detail view print "unknown step" for every past run.
+
+**Recipe:** keep the step in the manifest but mark its `Type` as a no-op handler or set `Disabled = true` so the planner skips it for new runs while history continues to render correctly.
+
+### Renaming a step key
+
+A step key (`"submit_to_wms"`) is part of the persisted run record. Renaming it makes every historical row unreadable.
+
+**Recipe — alias and skip:**
+
+1. Add the new key (`"submit_to_wms_v2"`) alongside the old one with the desired downstream wiring.
+2. Mark the old key as `Disabled` (or guard it with `When = "false"`) so new runs skip it.
+3. Leave the old key in the manifest until the retention window has expired (default 30 days; see [Observability](observability.md#data-retention)) — by then no live run history references it and you can finally delete it.
+
+### Changing the flow `Id`
+
+Don't. The `Id` is the join key for every row in `FlowRuns`, `FlowSteps`, `FlowOutputs`, `FlowStepDispatches`, `FlowStepClaims`, `FlowRunControls`, `FlowIdempotencyKeys`, and the recurring-job state. Changing it creates a brand-new flow with no history.
+
+If you genuinely need a clean break (e.g. the original `Id` was generated by `Guid.NewGuid()` and is now unstable across environments) the only safe move is:
+
+1. Define a new flow class with a new fixed `Id`.
+2. Leave the old flow registered with `Disabled = true` so the dashboard can still surface its history.
+3. Cut over triggers (cron, webhook routes) to the new flow.
+
+---
+
+## Pre-Deploy Checklist
+
+Before merging a flow change to production, walk through:
+
+- [ ] Run the full test suite using [`FlowTestHost`](testing.md). New step or `When`? Add a test for it.
+- [ ] Open the dashboard and confirm the **Active Runs** count for this flow is what you expect — drain if the change is in the *Caution* category above.
+- [ ] If the change touches storage (new step → new rows in `FlowOutputs`; new trigger → new recurring-job state), run the migration in a non-production environment first. The auto-migrator (`FlowOrchestratorSqlMigrator`) is idempotent, but verify before trusting it.
+- [ ] If the cron schedule changed, **pause and resume** the trigger from the dashboard rather than relying on the auto-update path — Hangfire's `RecurringJob` honours the new expression on the next sync.
+- [ ] Tag the release with a semantic version and bump the flow's `Version` string so the timeline view tells the story.
+
+---
+
+## Worked Example — `OrderFulfillmentFlow` Evolution
+
+The sample at [`samples/FlowOrchestrator.SampleApp/Flows/OrderFulfillmentFlow.cs`](https://github.com/hoangsnowy/FlowOrchestrator/blob/main/samples/FlowOrchestrator.SampleApp/Flows/OrderFulfillmentFlow.cs) is a useful walking example because it has the three patterns most flows have: a query, a polling external call, and a save.
+
+### v1.0 — Initial shape
+
+```csharp
+Steps =
+{
+    ["fetch_orders"]  = new StepMetadata { Type = "QueryDatabase",   /* … */ },
+    ["submit_to_wms"] = new StepMetadata { Type = "CallExternalApi",
+        RunAfter = { ["fetch_orders"] = [StepStatus.Succeeded] }, /* … */ },
+    ["save_result"]   = new StepMetadata { Type = "SaveResult",
+        RunAfter = { ["submit_to_wms"] = [StepStatus.Succeeded] }, /* … */ },
+}
+```
+
+### v1.1 — Safe: append a notification step
+
+We want to ping a Slack channel after every successful run. The new step has no
+dependents, so it is a *safe* change — deploy any time.
+
+```csharp
+Steps =
+{
+    ["fetch_orders"]  = /* unchanged */,
+    ["submit_to_wms"] = /* unchanged */,
+    ["save_result"]   = /* unchanged */,
+
+    // New — appended after save_result, no existing step depends on it
+    ["notify_warehouse"] = new StepMetadata { Type = "NotifySlack",
+        RunAfter = { ["save_result"] = [StepStatus.Succeeded] },
+        Inputs = { ["channel"] = "#warehouse" } },
+}
+```
+
+Bump `Version` to `"1.1"`. Done.
+
+### v2.0 — Caution: insert a validator in the middle
+
+We've decided every order must be validated before submission. The new step
+`validate_order` sits *between* `fetch_orders` and `submit_to_wms`.
+
+```csharp
+Steps =
+{
+    ["fetch_orders"]  = /* unchanged */,
+
+    // NEW step inserted into the existing path
+    ["validate_order"] = new StepMetadata { Type = "ValidateOrder",
+        RunAfter = { ["fetch_orders"] = [StepStatus.Succeeded] } },
+
+    // CHANGED — submit_to_wms now waits on validate_order, not fetch_orders
+    ["submit_to_wms"] = new StepMetadata { Type = "CallExternalApi",
+        RunAfter = { ["validate_order"] = [StepStatus.Succeeded] }, /* … */ },
+
+    ["save_result"]   = /* unchanged */,
+    ["notify_warehouse"] = /* unchanged */,
+}
+```
+
+This is a *caution* change — both an inserted step and a modified `RunAfter`. An
+in-flight run that already passed `fetch_orders` will continue under the v1.1
+graph; it will *not* retroactively run `validate_order`. To avoid that ambiguity:
+
+1. Pause cron + webhook for `OrderFulfillmentFlow`.
+2. Wait for `GET /flows/api/runs/active?flowId=…` → `[]`.
+3. Deploy.
+4. Bump `Version` to `"2.0"`.
+5. Resume the triggers.
+
+If you cannot drain (e.g. the flow is webhook-driven and webhooks cannot be paused),
+the safer alternative is to ship as a new flow with a new `Id` and route new
+webhooks there — leaving v1.1 to drain naturally.

--- a/samples/FlowOrchestrator.SampleApp/FlowOrchestrator.SampleApp.csproj
+++ b/samples/FlowOrchestrator.SampleApp/FlowOrchestrator.SampleApp.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Hangfire.InMemory" />
     <PackageReference Include="Dapper" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />

--- a/samples/FlowOrchestrator.SampleApp/Program.cs
+++ b/samples/FlowOrchestrator.SampleApp/Program.cs
@@ -1,4 +1,5 @@
 using FlowOrchestrator.Core.Configuration;
+using FlowOrchestrator.Core.HealthChecks;
 using FlowOrchestrator.Dashboard;
 using FlowOrchestrator.Hangfire;
 using FlowOrchestrator.InMemory;
@@ -191,18 +192,34 @@ builder.Services.AddHttpClient("ExternalApi", client =>
 // When running under Aspire, OTEL_EXPORTER_OTLP_ENDPOINT is injected automatically
 // and spans/metrics appear in the Aspire Dashboard. Standalone, set the env var to
 // point at any OTLP-compatible backend (Jaeger, Grafana, etc.).
+// OTel: console exporter prints spans/metrics to stdout for local development; OTLP exporter
+// forwards to whatever backend OTEL_EXPORTER_OTLP_ENDPOINT points at (Aspire Dashboard, Jaeger,
+// Tempo, …). Both can run concurrently — production typically keeps only the OTLP exporter.
+var enableConsoleExporter = builder.Configuration.GetValue("OBSERVABILITY_CONSOLE", true);
+
 builder.Services.AddOpenTelemetry()
     .ConfigureResource(r => r.AddService("FlowOrchestrator.SampleApp"))
-    .WithTracing(t => t
-        .AddFlowOrchestratorInstrumentation()
-        .AddAspNetCoreInstrumentation()
-        .AddOtlpExporter())
-    .WithMetrics(m => m
-        .AddFlowOrchestratorInstrumentation()
-        .AddAspNetCoreInstrumentation()
-        .AddOtlpExporter());
+    .WithTracing(t =>
+    {
+        t.AddFlowOrchestratorInstrumentation()
+         .AddAspNetCoreInstrumentation()
+         .AddOtlpExporter();
+        if (enableConsoleExporter) t.AddConsoleExporter();
+    })
+    .WithMetrics(m =>
+    {
+        m.AddFlowOrchestratorInstrumentation()
+         .AddAspNetCoreInstrumentation()
+         .AddOtlpExporter();
+        if (enableConsoleExporter) m.AddConsoleExporter();
+    });
 
 builder.Services.AddFlowDashboard(builder.Configuration);
+
+// Storage-reachability probe so a load balancer can drop traffic when the flow store is down.
+builder.Services
+    .AddHealthChecks()
+    .AddFlowOrchestratorHealthChecks();
 
 var app = builder.Build();
 
@@ -210,6 +227,7 @@ app.UseStaticFiles();
 if (useHangfireRuntime)
     app.UseHangfireDashboard("/hangfire");
 app.MapFlowDashboard("/flows");
+app.MapHealthChecks("/health");
 
 app.MapGet("/", () =>
     $"OrderHub [runtime={runtime}, storage={storageBackend}] is running. Visit /flows for the dashboard.");

--- a/samples/FlowOrchestrator.SampleApp/Program.cs
+++ b/samples/FlowOrchestrator.SampleApp/Program.cs
@@ -10,6 +10,7 @@ using FlowOrchestrator.SampleApp.Flows;
 using FlowOrchestrator.SampleApp.Steps;
 using Hangfire;
 using Hangfire.SqlServer;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Trace;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -213,6 +214,19 @@ builder.Services.AddOpenTelemetry()
          .AddOtlpExporter();
         if (enableConsoleExporter) m.AddConsoleExporter();
     });
+
+// OTel structured-logging exporter: ships every ILogger call as an OTLP log record so the
+// engine's BeginScope correlation (RunId / FlowId / StepKey / Attempt) and stable EventIds
+// land in Aspire Dashboard's Logs tab — alongside the matching trace. Without this, logs
+// only go to stdout via the default ConsoleLogger and the OTLP backend sees zero log records.
+builder.Logging.AddOpenTelemetry(o =>
+{
+    o.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("FlowOrchestrator.SampleApp"));
+    o.IncludeFormattedMessage = true;
+    o.IncludeScopes = true;            // CRITICAL: surfaces BeginScope props as log attributes
+    o.ParseStateValues = true;          // Treat structured-template values as structured attrs
+    o.AddOtlpExporter();
+});
 
 builder.Services.AddFlowDashboard(builder.Configuration);
 

--- a/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Configuration;
 using FlowOrchestrator.Core.Expressions;
+using FlowOrchestrator.Core.Observability;
 using FlowOrchestrator.Core.Storage;
 using Microsoft.Extensions.Logging;
 
@@ -75,8 +76,7 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
 
         if (_runtimeStore is null)
         {
-            _logger.LogDebug(
-                "No IFlowRunRuntimeStore registered. Running in legacy sequential mode — parallel graph evaluation and step-claim deduplication are disabled.");
+            EngineLog.LegacySequentialMode(_logger);
         }
     }
 
@@ -123,6 +123,10 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
         triggerContext.TriggerData = triggerContext.Trigger.Data;
         triggerContext.TriggerHeaders = triggerContext.Trigger.Headers;
         _contextAccessor.CurrentContext = triggerContext;
+
+        // BeginScope ensures every nested log line in this run carries RunId/FlowId,
+        // including logs emitted by user-written step handlers further down the stack.
+        using var _scope = EngineLogScope.Begin(_logger, triggerContext.RunId, triggerContext.Flow.Id);
 
         activity?.SetTag("flow.id", triggerContext.Flow.Id.ToString());
         activity?.SetTag("run.id", triggerContext.RunId.ToString());
@@ -177,7 +181,7 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to track flow run start.");
+                EngineLog.RunStartTrackingFailed(_logger, ex);
             }
 
             if (_runControlStore is not null)
@@ -245,6 +249,13 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
 
             return new { runId = triggerContext.RunId, duplicate = false };
         }
+        catch (Exception ex)
+        {
+            // Mark the trigger activity as failed before propagating. Without this, APM tools
+            // see a span that simply ended with no error indicator and never raise an alert.
+            activity.RecordError(ex);
+            throw;
+        }
         finally
         {
             _contextAccessor.CurrentContext = null;
@@ -278,6 +289,8 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
 
         await EnsureTriggerDataAsync(ctx).ConfigureAwait(false);
         _contextAccessor.CurrentContext = ctx;
+
+        using var _scope = EngineLogScope.Begin(_logger, ctx.RunId, flow.Id, step.Key);
 
         activity?.SetTag("flow.id", flow.Id.ToString());
         activity?.SetTag("run.id", ctx.RunId.ToString());
@@ -313,13 +326,14 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to track step start.");
+                EngineLog.StepStartTrackingFailed(_logger, ex);
             }
 
             await RecordEventAsync(ctx, flow, step, "step.started", $"Step '{step.Key}' started.").ConfigureAwait(false);
 
             var stepExecutionStart = Stopwatch.GetTimestamp();
             IStepResult result;
+            Exception? handlerException = null;
             try
             {
                 result = await _stepExecutor.ExecuteAsync(ctx, flow, step).ConfigureAwait(false);
@@ -327,7 +341,8 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Step execution failed for {StepKey}", step.Key);
+                handlerException = ex;
+                EngineLog.StepExecutionFailed(_logger, ex, step.Key);
                 result = new StepResult
                 {
                     Key = step.Key,
@@ -335,6 +350,20 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
                     FailedReason = ex.ToString(),
                     ReThrow = false
                 };
+            }
+
+            // Mark the step activity as Error so APMs treat the span as a failure even when
+            // the handler exception is swallowed and translated into a Failed StepResult.
+            if (result.Status == StepStatus.Failed)
+            {
+                if (handlerException is not null)
+                {
+                    activity.RecordError(handlerException);
+                }
+                else
+                {
+                    activity?.SetStatus(ActivityStatusCode.Error, result.FailedReason);
+                }
             }
 
             try
@@ -345,7 +374,7 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to track step completion.");
+                EngineLog.StepCompletionTrackingFailed(_logger, ex);
             }
 
             var stepExecutionMs = Stopwatch.GetElapsedTime(stepExecutionStart).TotalMilliseconds;
@@ -374,6 +403,16 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
 
             if (result.Status == StepStatus.Pending)
             {
+                // A step returning Pending means a poll iteration completed without satisfying the
+                // condition — count it so operators can see how aggressive a flow's polling is.
+                if (_observabilityOptions.EnableOpenTelemetry)
+                {
+                    _telemetry.StepPollAttemptsCounter.Add(
+                        1,
+                        new KeyValuePair<string, object?>("flow_id", flow.Id.ToString()),
+                        new KeyValuePair<string, object?>("step_key", step.Key));
+                }
+
                 var controlAfterPending = await ResolveTerminationStatusAsync(ctx.RunId).ConfigureAwait(false);
                 if (controlAfterPending is not null)
                 {
@@ -435,6 +474,13 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
 
             return result.Result;
         }
+        catch (Exception ex)
+        {
+            // Engine-level failure outside the handler (storage, dispatch, continuation). The
+            // inner catch already recorded handler exceptions; this guards everything else.
+            activity.RecordError(ex);
+            throw;
+        }
         finally
         {
             _contextAccessor.CurrentContext = null;
@@ -444,6 +490,25 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
     /// <inheritdoc/>
     public async ValueTask<object?> RetryStepAsync(Guid flowId, Guid runId, string stepKey, CancellationToken ct = default)
     {
+        using var _scope = EngineLogScope.Begin(_logger, runId, flowId, stepKey);
+
+        // Span the retry dispatch separately from the eventual flow.step that runs the
+        // re-executed handler. Tags help operators correlate retry storms with run state.
+        using var activity = _observabilityOptions.EnableOpenTelemetry
+            ? _telemetry.ActivitySource.StartActivity("flow.step.retry", ActivityKind.Internal)
+            : null;
+        activity?.SetTag("flow.id", flowId.ToString());
+        activity?.SetTag("run.id", runId.ToString());
+        activity?.SetTag("step.key", stepKey);
+
+        if (_observabilityOptions.EnableOpenTelemetry)
+        {
+            _telemetry.StepRetriesCounter.Add(
+                1,
+                new KeyValuePair<string, object?>("flow_id", flowId.ToString()),
+                new KeyValuePair<string, object?>("step_key", stepKey));
+        }
+
         var flows = await _flowRepository.GetAllFlowsAsync().ConfigureAwait(false);
         var flow = flows.FirstOrDefault(f => f.Id == flowId)
             ?? throw new InvalidOperationException($"Flow {flowId} not found.");
@@ -503,6 +568,15 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
                 blockedStepKey,
                 metadata?.Type ?? "Unknown",
                 "Prerequisite status did not satisfy runAfter conditions.").ConfigureAwait(false);
+
+            if (_observabilityOptions.EnableOpenTelemetry)
+            {
+                _telemetry.StepSkippedCounter.Add(
+                    1,
+                    new KeyValuePair<string, object?>("flow_id", flow.Id.ToString()),
+                    new KeyValuePair<string, object?>("step_key", blockedStepKey),
+                    new KeyValuePair<string, object?>("reason", "prerequisites_unmet"));
+            }
 
             await RecordEventAsync(
                 ctx,
@@ -670,7 +744,7 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to annotate dispatch for step {StepKey}.", step.Key);
+                EngineLog.DispatchAnnotateFailed(_logger, ex, step.Key);
             }
         }
 
@@ -697,6 +771,13 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
             return false;
         }
 
+        using var whenActivity = _observabilityOptions.EnableOpenTelemetry
+            ? _telemetry.ActivitySource.StartActivity("flow.step.when", ActivityKind.Internal)
+            : null;
+        whenActivity?.SetTag("flow.id", flow.Id.ToString());
+        whenActivity?.SetTag("run.id", ctx.RunId.ToString());
+        whenActivity?.SetTag("step.key", stepKey);
+
         WhenEvaluationTrace? trace;
         try
         {
@@ -704,7 +785,9 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
         }
         catch (FlowExpressionException ex)
         {
-            _logger.LogError(ex, "When-clause evaluation failed for step {StepKey}; treating as failure.", stepKey);
+            EngineLog.WhenEvaluationFailed(_logger, ex, stepKey);
+            // Surface to the parent flow.step activity (if any) so APMs see a failure event.
+            Activity.Current.RecordError(ex);
             // A malformed expression is an authoring error. Skip with a synthetic trace
             // so the dashboard surfaces the problem to the user.
             trace = new WhenEvaluationTrace
@@ -734,6 +817,18 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
         var reason = $"When clause '{trace.Expression}' evaluated to false ({trace.Resolved}).";
         await _runtimeStore.RecordSkippedStepAsync(ctx.RunId, stepKey, metadata.Type, reason, traceJson).ConfigureAwait(false);
 
+        whenActivity?.SetTag("flow.when.expression", trace.Expression);
+        whenActivity?.SetTag("flow.when.resolved", trace.Resolved);
+        whenActivity?.SetTag("flow.when.result", false);
+        if (_observabilityOptions.EnableOpenTelemetry)
+        {
+            _telemetry.StepSkippedCounter.Add(
+                1,
+                new KeyValuePair<string, object?>("flow_id", flow.Id.ToString()),
+                new KeyValuePair<string, object?>("step_key", stepKey),
+                new KeyValuePair<string, object?>("reason", "when_false"));
+        }
+
         await RecordEventAsync(
             ctx,
             flow,
@@ -759,7 +854,7 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to mark step {StepKey} as skipped due to terminal run status.", step.Key);
+            EngineLog.StepSkipTrackingFailed(_logger, ex, step.Key);
         }
     }
 
@@ -921,7 +1016,7 @@ public sealed class FlowOrchestratorEngine : IFlowOrchestrator
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to record flow event {EventType}.", type);
+            EngineLog.EventPersistenceFailed(_logger, ex, type);
         }
     }
 

--- a/src/FlowOrchestrator.Core/Execution/FlowSignalDispatcher.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowSignalDispatcher.cs
@@ -1,4 +1,5 @@
 using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Observability;
 using FlowOrchestrator.Core.Storage;
 
 namespace FlowOrchestrator.Core.Execution;
@@ -35,20 +36,23 @@ public sealed class FlowSignalDispatcher : IFlowSignalDispatcher
     private readonly IFlowRepository _flowRepository;
     private readonly IStepDispatcher _dispatcher;
     private readonly IOutputsRepository _outputsRepository;
+    private readonly FlowOrchestratorTelemetry? _telemetry;
 
-    /// <summary>Initialises the dispatcher with its dependencies.</summary>
+    /// <summary>Initialises the dispatcher with its dependencies. <paramref name="telemetry"/> is optional — when omitted, signal-wait metrics are not emitted.</summary>
     public FlowSignalDispatcher(
         IFlowSignalStore signalStore,
         IFlowRunStore runStore,
         IFlowRepository flowRepository,
         IStepDispatcher dispatcher,
-        IOutputsRepository outputsRepository)
+        IOutputsRepository outputsRepository,
+        FlowOrchestratorTelemetry? telemetry = null)
     {
         _signalStore = signalStore;
         _runStore = runStore;
         _flowRepository = flowRepository;
         _dispatcher = dispatcher;
         _outputsRepository = outputsRepository;
+        _telemetry = telemetry;
     }
 
     /// <inheritdoc/>
@@ -73,6 +77,23 @@ public sealed class FlowSignalDispatcher : IFlowSignalDispatcher
         if (run is null)
         {
             return new SignalDeliveryResult(SignalDeliveryStatus.NotFound, null, null);
+        }
+
+        // Record the parked-step wait time: from waiter registration to signal delivery.
+        // GetWaiterAsync returns the persisted row including CreatedAt; DeliveredAt is set
+        // by DeliverSignalAsync above. Skip silently if telemetry was not registered.
+        if (_telemetry is not null && result.DeliveredAt is { } deliveredAt)
+        {
+            var waiter = await _signalStore.GetWaiterAsync(runId, result.StepKey, ct).ConfigureAwait(false);
+            if (waiter is not null)
+            {
+                var waitMs = Math.Max(0, (deliveredAt - waiter.CreatedAt).TotalMilliseconds);
+                _telemetry.SignalWaitMs.Record(
+                    waitMs,
+                    new KeyValuePair<string, object?>("flow_id", run.FlowId.ToString()),
+                    new KeyValuePair<string, object?>("step_key", result.StepKey),
+                    new KeyValuePair<string, object?>("signal_name", signalName));
+            }
         }
 
         var flows = await _flowRepository.GetAllFlowsAsync().ConfigureAwait(false);

--- a/src/FlowOrchestrator.Core/Execution/PollableStepHandler.cs
+++ b/src/FlowOrchestrator.Core/Execution/PollableStepHandler.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Observability;
 
 namespace FlowOrchestrator.Core.Execution;
 
@@ -28,7 +30,29 @@ public abstract class PollableStepHandler<TInput> : IStepHandler<TInput>
         IExecutionContext ctx, IFlowDefinition flow, IStepInstance<TInput> step)
     {
         var input = step.Inputs;
-        var (result, parsedAsJson) = await FetchAsync(ctx, flow, step).ConfigureAwait(false);
+
+        // Open a span around each individual poll attempt so APMs show the polling history as a
+        // sequence of child spans of the parent flow.step. The current attempt number is read
+        // before IncrementPollAttempt so it reflects "the attempt about to happen".
+        using var activity = FlowOrchestratorTelemetry.SharedActivitySource.StartActivity(
+            "flow.step.poll",
+            ActivityKind.Internal);
+        activity?.SetTag("flow.id", flow.Id.ToString());
+        activity?.SetTag("run.id", ctx.RunId.ToString());
+        activity?.SetTag("step.key", step.Key);
+        activity?.SetTag("flow.poll.attempt", (input.PollAttempt ?? 0) + 1);
+
+        (JsonElement result, bool parsedAsJson) fetched;
+        try
+        {
+            fetched = await FetchAsync(ctx, flow, step).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            activity.RecordError(ex);
+            throw;
+        }
+        var (result, parsedAsJson) = fetched;
 
         if (!input.PollEnabled)
         {
@@ -56,9 +80,11 @@ public abstract class PollableStepHandler<TInput> : IStepHandler<TInput>
         if (currentAttempt >= minAttempts
             && PollConditionEvaluator.IsMatched(result, input.PollConditionPath, input.PollConditionEquals))
         {
+            activity?.SetTag("flow.poll.condition_met", true);
             ResetPollState(input);
             return new StepResult<JsonElement> { Key = step.Key, Value = result };
         }
+        activity?.SetTag("flow.poll.condition_met", false);
 
         var elapsed = DateTimeOffset.UtcNow - pollStartedAt;
         if (elapsed >= TimeSpan.FromSeconds(timeoutSeconds))

--- a/src/FlowOrchestrator.Core/FlowOrchestrator.Core.csproj
+++ b/src/FlowOrchestrator.Core/FlowOrchestrator.Core.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="System.Text.Json" />
@@ -22,6 +23,12 @@
          IEnumerable auto-detection regardless of Hangfire's contract caching /
          settings init order. All internal serialisation still uses STJ end-to-end. -->
     <PackageReference Include="Newtonsoft.Json" />
+    <!-- Observability: OpenTelemetry.Api is the API-only ~30 KB package that defines
+         TracerProviderBuilder / MeterProviderBuilder. The Activity / Meter primitives
+         themselves come from System.Diagnostics in the BCL. The full OpenTelemetry SDK
+         is opt-in (the user adds it when they call .AddOpenTelemetry()), so library
+         consumers who do not enable telemetry pay essentially nothing at runtime. -->
+    <PackageReference Include="OpenTelemetry.Api" />
   </ItemGroup>
 
 </Project>

--- a/src/FlowOrchestrator.Core/HealthChecks/FlowOrchestratorHealthCheckExtensions.cs
+++ b/src/FlowOrchestrator.Core/HealthChecks/FlowOrchestratorHealthCheckExtensions.cs
@@ -1,0 +1,47 @@
+using FlowOrchestrator.Core.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace FlowOrchestrator.Core.HealthChecks;
+
+/// <summary>
+/// <see cref="IHealthChecksBuilder"/> extensions that register FlowOrchestrator health checks.
+/// </summary>
+public static class FlowOrchestratorHealthCheckExtensions
+{
+    /// <summary>Default registration name used by <see cref="AddFlowOrchestratorHealthChecks"/>.</summary>
+    public const string DefaultName = "flow-orchestrator-storage";
+
+    /// <summary>
+    /// Registers a health check that probes <see cref="IFlowStore"/> reachability.
+    /// </summary>
+    /// <param name="builder">The health-check builder, typically obtained from <c>services.AddHealthChecks()</c>.</param>
+    /// <param name="name">Registration name. Defaults to <see cref="DefaultName"/>.</param>
+    /// <param name="failureStatus">Status reported when the probe fails. Defaults to <see cref="HealthStatus.Unhealthy"/>.</param>
+    /// <param name="tags">Optional tags. Defaults to <c>["flow-orchestrator", "storage"]</c>.</param>
+    /// <param name="timeout">
+    /// Probe budget. Defaults to 5 seconds. On expiry the check reports <paramref name="failureStatus"/>.
+    /// </param>
+    /// <returns>The same <paramref name="builder"/> for chaining.</returns>
+    /// <remarks>
+    /// The check resolves <see cref="IFlowStore"/> from DI on every probe so the registered
+    /// store implementation (SQL Server / PostgreSQL / in-memory) is honoured without re-registration.
+    /// </remarks>
+    public static IHealthChecksBuilder AddFlowOrchestratorHealthChecks(
+        this IHealthChecksBuilder builder,
+        string name = DefaultName,
+        HealthStatus? failureStatus = null,
+        IEnumerable<string>? tags = null,
+        TimeSpan? timeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.Add(new HealthCheckRegistration(
+            name,
+            sp => new FlowStoreHealthCheck(
+                sp.GetRequiredService<IFlowStore>(),
+                timeout),
+            failureStatus,
+            tags ?? new[] { "flow-orchestrator", "storage" }));
+    }
+}

--- a/src/FlowOrchestrator.Core/HealthChecks/FlowStoreHealthCheck.cs
+++ b/src/FlowOrchestrator.Core/HealthChecks/FlowStoreHealthCheck.cs
@@ -1,0 +1,63 @@
+using FlowOrchestrator.Core.Storage;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace FlowOrchestrator.Core.HealthChecks;
+
+/// <summary>
+/// Health check that probes <see cref="IFlowStore"/> reachability so a load balancer
+/// or container orchestrator can refuse traffic when the storage backend is unavailable.
+/// </summary>
+/// <remarks>
+/// The probe issues the cheapest read on every backend
+/// (<see cref="IFlowStore.GetAllAsync"/>) and is wrapped in a configurable timeout so
+/// a hung connection pool never blocks `/health` for longer than the budget.
+/// Returns <see cref="HealthStatus.Healthy"/> with a <c>flow_count</c> data entry on success,
+/// <see cref="HealthStatus.Unhealthy"/> on timeout or any thrown exception.
+/// </remarks>
+public sealed class FlowStoreHealthCheck : IHealthCheck
+{
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly IFlowStore _store;
+    private readonly TimeSpan _timeout;
+
+    /// <summary>Creates a new health check bound to the given <paramref name="store"/>.</summary>
+    /// <param name="store">The flow definition store to probe.</param>
+    /// <param name="timeout">
+    /// Probe budget; defaults to 5 seconds when <see langword="null"/>.
+    /// On expiry the check returns <see cref="HealthStatus.Unhealthy"/>.
+    /// </param>
+    public FlowStoreHealthCheck(IFlowStore store, TimeSpan? timeout = null)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _timeout = timeout ?? DefaultTimeout;
+    }
+
+    /// <inheritdoc />
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(_timeout);
+
+        try
+        {
+            var flows = await _store.GetAllAsync().WaitAsync(cts.Token).ConfigureAwait(false);
+            var data = new Dictionary<string, object>
+            {
+                ["flow_count"] = flows.Count,
+            };
+            return HealthCheckResult.Healthy("Flow store is reachable.", data);
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            return HealthCheckResult.Unhealthy(
+                $"Flow store probe timed out after {_timeout.TotalMilliseconds:N0} ms.");
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy("Flow store is unreachable.", ex);
+        }
+    }
+}

--- a/src/FlowOrchestrator.Core/Observability/ActivityExtensions.cs
+++ b/src/FlowOrchestrator.Core/Observability/ActivityExtensions.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics;
+
+namespace FlowOrchestrator.Core.Observability;
+
+/// <summary>
+/// Helpers for the System.Diagnostics activity API used by the engine.
+/// </summary>
+/// <remarks>
+/// Implemented manually rather than depending on the <c>OpenTelemetry.Api</c>
+/// <c>Activity.RecordException</c> extension so <c>FlowOrchestrator.Core</c> stays free of any
+/// OpenTelemetry runtime dependency. The event shape (event name <c>"exception"</c> with
+/// <c>exception.type</c>, <c>exception.message</c>, <c>exception.stacktrace</c> tags) matches the
+/// OpenTelemetry semantic convention so APMs treat it identically.
+/// </remarks>
+public static class ActivityExtensions
+{
+    /// <summary>
+    /// Records <paramref name="ex"/> on the activity following the OpenTelemetry exception
+    /// semantic convention and marks the activity status as <see cref="ActivityStatusCode.Error"/>.
+    /// Safe to call with a <see langword="null"/> activity.
+    /// </summary>
+    /// <param name="activity">The current activity, or <see langword="null"/> when tracing is disabled.</param>
+    /// <param name="ex">The exception to record.</param>
+    public static void RecordError(this Activity? activity, Exception ex)
+    {
+        if (activity is null || ex is null)
+        {
+            return;
+        }
+
+        activity.SetStatus(ActivityStatusCode.Error, ex.Message);
+        activity.AddEvent(new ActivityEvent(
+            "exception",
+            timestamp: default,
+            tags: new ActivityTagsCollection
+            {
+                ["exception.type"] = ex.GetType().FullName,
+                ["exception.message"] = ex.Message,
+                ["exception.stacktrace"] = ex.ToString(),
+            }));
+    }
+}

--- a/src/FlowOrchestrator.Core/Observability/EngineLog.cs
+++ b/src/FlowOrchestrator.Core/Observability/EngineLog.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Logging;
+
+namespace FlowOrchestrator.Core.Observability;
+
+/// <summary>
+/// Source-generated <see cref="LoggerMessage"/> methods for every <see cref="ILogger"/> call
+/// emitted by <c>FlowOrchestratorEngine</c>. Generates allocation-free, AOT-friendly delegates
+/// at build time and gives every call site a stable <see cref="EventId"/>.
+/// </summary>
+/// <remarks>
+/// Event IDs are kept in numeric sync with <see cref="LogEvents"/> so consumers can choose either
+/// API surface — programmatic filtering by <c>EventId.Id</c> on the structured-log sink, or the
+/// strongly-typed methods here at the call site. Keep both files in lock-step when adding new
+/// events: bump the numeric ID, add the <see cref="LogEvents"/> constant, and add the matching
+/// <see cref="LoggerMessageAttribute"/> partial method below.
+/// </remarks>
+internal static partial class EngineLog
+{
+    [LoggerMessage(EventId = 1003, Level = LogLevel.Warning, Message = "Failed to track flow run start.")]
+    public static partial void RunStartTrackingFailed(ILogger logger, Exception ex);
+
+    [LoggerMessage(EventId = 2002, Level = LogLevel.Error, Message = "Step execution failed for {StepKey}")]
+    public static partial void StepExecutionFailed(ILogger logger, Exception ex, string stepKey);
+
+    [LoggerMessage(EventId = 2005, Level = LogLevel.Error, Message = "When-clause evaluation failed for step {StepKey}; treating as failure.")]
+    public static partial void WhenEvaluationFailed(ILogger logger, Exception ex, string stepKey);
+
+    [LoggerMessage(EventId = 2006, Level = LogLevel.Warning, Message = "Failed to track step start.")]
+    public static partial void StepStartTrackingFailed(ILogger logger, Exception ex);
+
+    [LoggerMessage(EventId = 2007, Level = LogLevel.Warning, Message = "Failed to track step completion.")]
+    public static partial void StepCompletionTrackingFailed(ILogger logger, Exception ex);
+
+    [LoggerMessage(EventId = 2008, Level = LogLevel.Warning, Message = "Failed to mark step {StepKey} as skipped due to terminal run status.")]
+    public static partial void StepSkipTrackingFailed(ILogger logger, Exception ex, string stepKey);
+
+    [LoggerMessage(EventId = 3001, Level = LogLevel.Warning, Message = "Failed to annotate dispatch for step {StepKey}.")]
+    public static partial void DispatchAnnotateFailed(ILogger logger, Exception ex, string stepKey);
+
+    [LoggerMessage(EventId = 3002, Level = LogLevel.Warning, Message = "Failed to record flow event {EventType}.")]
+    public static partial void EventPersistenceFailed(ILogger logger, Exception ex, string eventType);
+
+    [LoggerMessage(EventId = 9000, Level = LogLevel.Debug, Message = "No IFlowRunRuntimeStore registered. Running in legacy sequential mode — parallel graph evaluation and step-claim deduplication are disabled.")]
+    public static partial void LegacySequentialMode(ILogger logger);
+}

--- a/src/FlowOrchestrator.Core/Observability/EngineLogScope.cs
+++ b/src/FlowOrchestrator.Core/Observability/EngineLogScope.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.Logging;
+
+namespace FlowOrchestrator.Core.Observability;
+
+/// <summary>
+/// Helper for opening an <see cref="ILogger.BeginScope{TState}(TState)"/> populated with the
+/// engine's standard correlation properties (<c>RunId</c>, <c>FlowId</c>, <c>StepKey</c>, <c>Attempt</c>).
+/// </summary>
+/// <remarks>
+/// Every public engine entry point should wrap its body in <c>using var _ = EngineLogScope.Begin(...)</c>
+/// so every nested log line — including logs emitted by user-written step handlers — automatically
+/// carries the run-level correlation. Logging providers that honour scopes (Serilog, NLog, OpenTelemetry
+/// Logs, Application Insights) surface these as searchable properties.
+/// </remarks>
+public static class EngineLogScope
+{
+    /// <summary>
+    /// Begins a logger scope tagged with the run-level correlation IDs.
+    /// </summary>
+    /// <param name="logger">The logger to attach the scope to. Returns <see langword="null"/> when null.</param>
+    /// <param name="runId">The current run identifier.</param>
+    /// <param name="flowId">The flow identifier owning the run.</param>
+    /// <param name="stepKey">Optional step key — set when scoped to a single step's execution.</param>
+    /// <param name="attempt">Optional attempt number — set on retry execution paths.</param>
+    /// <returns>An <see cref="IDisposable"/> that closes the scope, or <see langword="null"/> if the logger is null.</returns>
+    public static IDisposable? Begin(
+        ILogger? logger,
+        Guid runId,
+        Guid flowId,
+        string? stepKey = null,
+        int? attempt = null)
+    {
+        if (logger is null)
+        {
+            return null;
+        }
+
+        var state = new Dictionary<string, object?>(capacity: 4)
+        {
+            ["RunId"] = runId,
+            ["FlowId"] = flowId,
+        };
+        if (!string.IsNullOrEmpty(stepKey))
+        {
+            state["StepKey"] = stepKey;
+        }
+        if (attempt.HasValue)
+        {
+            state["Attempt"] = attempt.Value;
+        }
+
+        return logger.BeginScope(state);
+    }
+}

--- a/src/FlowOrchestrator.Core/Observability/FlowOrchestratorInstrumentationExtensions.cs
+++ b/src/FlowOrchestrator.Core/Observability/FlowOrchestratorInstrumentationExtensions.cs
@@ -1,0 +1,39 @@
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace FlowOrchestrator.Core.Observability;
+
+/// <summary>
+/// Extension methods for wiring <see cref="FlowOrchestratorTelemetry"/> into an OpenTelemetry pipeline.
+/// </summary>
+/// <remarks>
+/// Moved from <c>FlowOrchestrator.Hangfire</c> to <c>FlowOrchestrator.Core.Observability</c> in v1.19.
+/// The Hangfire project still exposes a deprecated forwarder for one release; new code should reference
+/// the Core namespace directly so OTel registration does not depend on the Hangfire package.
+/// </remarks>
+public static class FlowOrchestratorInstrumentationExtensions
+{
+    /// <summary>
+    /// Registers the FlowOrchestrator <see cref="System.Diagnostics.ActivitySource"/> so that
+    /// flow and step execution spans are captured by the tracing pipeline.
+    /// </summary>
+    /// <param name="builder">The <see cref="TracerProviderBuilder"/> to configure.</param>
+    /// <returns>The same builder for chaining.</returns>
+    public static TracerProviderBuilder AddFlowOrchestratorInstrumentation(
+        this TracerProviderBuilder builder)
+    {
+        return builder.AddSource(FlowOrchestratorTelemetry.SourceName);
+    }
+
+    /// <summary>
+    /// Registers the FlowOrchestrator <see cref="System.Diagnostics.Metrics.Meter"/> so that
+    /// run/step counters and duration histograms are captured by the metrics pipeline.
+    /// </summary>
+    /// <param name="builder">The <see cref="MeterProviderBuilder"/> to configure.</param>
+    /// <returns>The same builder for chaining.</returns>
+    public static MeterProviderBuilder AddFlowOrchestratorInstrumentation(
+        this MeterProviderBuilder builder)
+    {
+        return builder.AddMeter(FlowOrchestratorTelemetry.SourceName);
+    }
+}

--- a/src/FlowOrchestrator.Core/Observability/FlowOrchestratorTelemetry.cs
+++ b/src/FlowOrchestrator.Core/Observability/FlowOrchestratorTelemetry.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 
-namespace FlowOrchestrator.Core.Execution;
+namespace FlowOrchestrator.Core.Observability;
 
 /// <summary>
 /// Singleton telemetry hub exposing the <c>FlowOrchestrator</c> <see cref="System.Diagnostics.ActivitySource"/>
@@ -9,10 +9,26 @@ namespace FlowOrchestrator.Core.Execution;
 /// Wire up <c>AddOpenTelemetry()</c> and <c>AddFlowOrchestratorInstrumentation()</c> to export
 /// spans and counters to your observability backend.
 /// </summary>
+/// <remarks>
+/// Moved from <c>FlowOrchestrator.Core.Execution</c> in v1.19 so OpenTelemetry registration is
+/// independent of any specific runtime adapter (Hangfire, in-memory, queue). The activity source
+/// and meter names are unchanged — all existing OTel pipelines continue to work without changes.
+/// </remarks>
 public sealed class FlowOrchestratorTelemetry : IDisposable
 {
     /// <summary>Name shared by both the <see cref="ActivitySource"/> and the <see cref="Meter"/>.</summary>
     public const string SourceName = "FlowOrchestrator";
+
+    /// <summary>
+    /// Library-wide static activity source. Used from contexts where DI is not available
+    /// (e.g. <see cref="FlowOrchestrator.Core.Execution.PollableStepHandler{T}"/> base class
+    /// and the InMemory runtime's channel runner). Listeners subscribed to
+    /// <see cref="SourceName"/> receive activities from this source and from the per-instance
+    /// <see cref="ActivitySource"/> identically — multiple
+    /// <see cref="System.Diagnostics.ActivitySource"/> instances with the same name is the
+    /// supported way to emit from many compilation units without round-tripping through DI.
+    /// </summary>
+    public static readonly ActivitySource SharedActivitySource = new(SourceName);
 
     /// <summary>OpenTelemetry activity source for distributed tracing of flow and step executions.</summary>
     public ActivitySource ActivitySource { get; } = new(SourceName);
@@ -35,6 +51,21 @@ public sealed class FlowOrchestratorTelemetry : IDisposable
     /// <summary>Records the delay between step enqueue time and actual execution start in milliseconds.</summary>
     public Histogram<double> QueueDelayMs { get; }
 
+    /// <summary>Incremented every time a failed step is dispatched for retry.</summary>
+    public Counter<long> StepRetriesCounter { get; }
+
+    /// <summary>Incremented every time a step is skipped (false <c>When</c> clause or unmet <c>RunAfter</c>).</summary>
+    public Counter<long> StepSkippedCounter { get; }
+
+    /// <summary>Incremented for each polling attempt of a <c>PollableStepHandler</c>.</summary>
+    public Counter<long> StepPollAttemptsCounter { get; }
+
+    /// <summary>Records the wall-clock time a <c>WaitForSignal</c> step spent parked, in milliseconds.</summary>
+    public Histogram<double> SignalWaitMs { get; }
+
+    /// <summary>Records the gap between a cron trigger's scheduled fire time and its actual dispatch time, in milliseconds.</summary>
+    public Histogram<double> CronLagMs { get; }
+
     /// <summary>Initialises all counters and histograms against the shared <see cref="Meter"/>.</summary>
     public FlowOrchestratorTelemetry()
     {
@@ -43,6 +74,11 @@ public sealed class FlowOrchestratorTelemetry : IDisposable
         StepCompletedCounter = Meter.CreateCounter<long>("flow_steps_completed");
         StepDurationMs = Meter.CreateHistogram<double>("flow_step_duration_ms");
         QueueDelayMs = Meter.CreateHistogram<double>("flow_step_queue_delay_ms");
+        StepRetriesCounter = Meter.CreateCounter<long>("flow_step_retries");
+        StepSkippedCounter = Meter.CreateCounter<long>("flow_step_skipped");
+        StepPollAttemptsCounter = Meter.CreateCounter<long>("flow_step_poll_attempts");
+        SignalWaitMs = Meter.CreateHistogram<double>("flow_signal_wait_ms");
+        CronLagMs = Meter.CreateHistogram<double>("flow_cron_lag_ms");
     }
 
     /// <summary>Disposes the <see cref="ActivitySource"/> and <see cref="Meter"/>.</summary>

--- a/src/FlowOrchestrator.Core/Observability/InboundTraceContext.cs
+++ b/src/FlowOrchestrator.Core/Observability/InboundTraceContext.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics;
+
+namespace FlowOrchestrator.Core.Observability;
+
+/// <summary>
+/// Helpers for extracting an <see cref="ActivityContext"/> from W3C trace-context headers on an
+/// inbound HTTP request.
+/// </summary>
+/// <remarks>
+/// The Dashboard's webhook and signal endpoints call <see cref="TryParse"/> with the values of the
+/// inbound <c>traceparent</c> / <c>tracestate</c> headers and, on success, start the entry-point
+/// activity as a child of the parent context. This stitches the run's spans onto the caller's
+/// distributed trace even when the consuming app has not enabled
+/// <c>AddAspNetCoreInstrumentation()</c>. The helper lives in Core so it is reusable from any
+/// runtime adapter that exposes its own ingress points.
+/// </remarks>
+public static class InboundTraceContext
+{
+    /// <summary>The standard W3C header name for the incoming trace identifier.</summary>
+    public const string TraceparentHeaderName = "traceparent";
+
+    /// <summary>The standard W3C header name for vendor-specific trace state.</summary>
+    public const string TracestateHeaderName = "tracestate";
+
+    /// <summary>
+    /// Attempts to parse an <see cref="ActivityContext"/> from the standard W3C headers.
+    /// </summary>
+    /// <param name="traceparent">Value of the <c>traceparent</c> header, or <see langword="null"/>.</param>
+    /// <param name="tracestate">Value of the <c>tracestate</c> header, or <see langword="null"/>.</param>
+    /// <param name="context">Receives the parsed context on success.</param>
+    /// <returns><see langword="true"/> when both <paramref name="traceparent"/> is present and parses successfully.</returns>
+    public static bool TryParse(string? traceparent, string? tracestate, out ActivityContext context)
+    {
+        if (string.IsNullOrEmpty(traceparent))
+        {
+            context = default;
+            return false;
+        }
+
+        return ActivityContext.TryParse(traceparent, tracestate, isRemote: true, out context);
+    }
+
+    /// <summary>
+    /// Starts an inbound activity, using the W3C headers as the parent context when present.
+    /// Falls back to a normal root activity when the headers are absent or invalid.
+    /// </summary>
+    /// <param name="source">The activity source to start the activity on.</param>
+    /// <param name="name">Activity name (e.g. <c>"flow.webhook.receive"</c>, <c>"flow.signal.deliver"</c>).</param>
+    /// <param name="kind">Activity kind. Defaults to <see cref="ActivityKind.Server"/> for HTTP ingress.</param>
+    /// <param name="traceparent">Inbound <c>traceparent</c> header value or <see langword="null"/>.</param>
+    /// <param name="tracestate">Inbound <c>tracestate</c> header value or <see langword="null"/>.</param>
+    /// <returns>The started activity, or <see langword="null"/> when no listener is subscribed.</returns>
+    public static Activity? StartActivity(
+        ActivitySource source,
+        string name,
+        ActivityKind kind,
+        string? traceparent,
+        string? tracestate)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        if (TryParse(traceparent, tracestate, out var parentContext))
+        {
+            return source.StartActivity(name, kind, parentContext);
+        }
+
+        return source.StartActivity(name, kind);
+    }
+}

--- a/src/FlowOrchestrator.Core/Observability/LogEvents.cs
+++ b/src/FlowOrchestrator.Core/Observability/LogEvents.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Logging;
+
+namespace FlowOrchestrator.Core.Observability;
+
+/// <summary>
+/// Stable <see cref="EventId"/> constants for the structured-logging story.
+/// </summary>
+/// <remarks>
+/// Production users can filter or alert on a specific event by ID without parsing message templates.
+/// IDs are grouped by domain — 1000 series for run lifecycle, 2000 series for step lifecycle,
+/// 3000 series for dispatch / runtime, 4000 series for storage / migration. Once published, an ID
+/// must keep its meaning across releases.
+/// </remarks>
+public static class LogEvents
+{
+    /// <summary>A new run started via <c>TriggerAsync</c>.</summary>
+    public static readonly EventId RunStarted = new(1000, nameof(RunStarted));
+
+    /// <summary>A run reached a terminal status.</summary>
+    public static readonly EventId RunCompleted = new(1001, nameof(RunCompleted));
+
+    /// <summary>A run failed and was not recovered.</summary>
+    public static readonly EventId RunFailed = new(1002, nameof(RunFailed));
+
+    /// <summary>A run start could not be persisted to the run store. Engine continues; log is informational.</summary>
+    public static readonly EventId RunStartTrackingFailed = new(1003, nameof(RunStartTrackingFailed));
+
+    /// <summary>A step transitioned to <c>Running</c>.</summary>
+    public static readonly EventId StepStarted = new(2000, nameof(StepStarted));
+
+    /// <summary>A step completed without error.</summary>
+    public static readonly EventId StepCompleted = new(2001, nameof(StepCompleted));
+
+    /// <summary>A step handler threw or returned a failed result.</summary>
+    public static readonly EventId StepFailed = new(2002, nameof(StepFailed));
+
+    /// <summary>A step was skipped because of a false <c>When</c> clause or unmet <c>RunAfter</c>.</summary>
+    public static readonly EventId StepSkipped = new(2003, nameof(StepSkipped));
+
+    /// <summary>A step returned <c>Pending</c> and was rescheduled (poll loop).</summary>
+    public static readonly EventId StepPending = new(2004, nameof(StepPending));
+
+    /// <summary>A <c>When</c>-clause expression failed to evaluate.</summary>
+    public static readonly EventId WhenEvaluationFailed = new(2005, nameof(WhenEvaluationFailed));
+
+    /// <summary>A step start could not be tracked. Engine continues; log is informational.</summary>
+    public static readonly EventId StepStartTrackingFailed = new(2006, nameof(StepStartTrackingFailed));
+
+    /// <summary>A step completion could not be tracked. Engine continues; log is informational.</summary>
+    public static readonly EventId StepCompletionTrackingFailed = new(2007, nameof(StepCompletionTrackingFailed));
+
+    /// <summary>A skipped-step record could not be persisted. Engine continues; log is informational.</summary>
+    public static readonly EventId StepSkipTrackingFailed = new(2008, nameof(StepSkipTrackingFailed));
+
+    /// <summary>A step was enqueued onto the runtime adapter (Hangfire, channel, queue).</summary>
+    public static readonly EventId DispatchEnqueued = new(3000, nameof(DispatchEnqueued));
+
+    /// <summary>A best-effort dispatch annotation failed. Engine continues; log is informational.</summary>
+    public static readonly EventId DispatchAnnotateFailed = new(3001, nameof(DispatchAnnotateFailed));
+
+    /// <summary>A flow event could not be persisted. Engine continues; log is informational.</summary>
+    public static readonly EventId EventPersistenceFailed = new(3002, nameof(EventPersistenceFailed));
+}

--- a/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
@@ -1,10 +1,12 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Diagnostics;
 using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Observability;
 using FlowOrchestrator.Core.Storage;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -202,8 +204,19 @@ public static class DashboardServiceCollectionExtensions
         // - idOrSlug = flow GUID: use first Webhook trigger (only Webhook has external URL)
         // - idOrSlug = slug: lookup flow by webhookSlug in Webhook trigger Inputs
         // - If trigger has webhookSecret in Inputs, require X-Webhook-Key header to match
-        endpoints.MapPost($"{basePath}/api/webhook/{{idOrSlug}}", async (HttpContext http, IFlowRepository repo, IFlowStore store, string idOrSlug, IFlowOrchestrator engine) =>
+        endpoints.MapPost($"{basePath}/api/webhook/{{idOrSlug}}", async (HttpContext http, IFlowRepository repo, IFlowStore store, string idOrSlug, IFlowOrchestrator engine, [Microsoft.AspNetCore.Mvc.FromServices] FlowOrchestratorTelemetry? telemetry) =>
         {
+            // Stitch the run onto the caller's distributed trace by reading the inbound W3C
+            // headers and starting our entry-point activity as a child of them. This works
+            // even when the host app has not enabled OpenTelemetry's AspNetCore instrumentation.
+            // telemetry is nullable so dashboards wired without observability still resolve.
+            using var ingressActivity = telemetry is null ? null : InboundTraceContext.StartActivity(
+                telemetry.ActivitySource,
+                "flow.webhook.receive",
+                ActivityKind.Server,
+                http.Request.Headers.TryGetValue(InboundTraceContext.TraceparentHeaderName, out var tp) ? tp.FirstOrDefault() : null,
+                http.Request.Headers.TryGetValue(InboundTraceContext.TracestateHeaderName, out var ts) ? ts.FirstOrDefault() : null);
+            ingressActivity?.SetTag("flow.webhook.slug_or_id", idOrSlug);
             var flows = (await repo.GetAllFlowsAsync()).ToList();
             Core.Abstractions.IFlowDefinition? flow = null;
             string? triggerKey = null;
@@ -512,8 +525,19 @@ public static class DashboardServiceCollectionExtensions
             await WriteJsonAsync(http.Response,new { success = true, message = $"Step '{stepKey}' retry enqueued." });
         });
 
-        group.MapPost("/api/runs/{runId:guid}/signals/{signalName}", async (HttpContext http, IFlowRunStore runStore, IFlowSignalDispatcher signals, Guid runId, string signalName) =>
+        group.MapPost("/api/runs/{runId:guid}/signals/{signalName}", async (HttpContext http, IFlowRunStore runStore, IFlowSignalDispatcher signals, Guid runId, string signalName, [Microsoft.AspNetCore.Mvc.FromServices] FlowOrchestratorTelemetry? telemetry) =>
         {
+            // Same inbound-traceparent extraction as the webhook endpoint — keeps signal delivery
+            // on the caller's trace so APMs can show "approval came in here, run continued there".
+            using var ingressActivity = telemetry is null ? null : InboundTraceContext.StartActivity(
+                telemetry.ActivitySource,
+                "flow.signal.deliver",
+                ActivityKind.Server,
+                http.Request.Headers.TryGetValue(InboundTraceContext.TraceparentHeaderName, out var tp) ? tp.FirstOrDefault() : null,
+                http.Request.Headers.TryGetValue(InboundTraceContext.TracestateHeaderName, out var ts) ? ts.FirstOrDefault() : null);
+            ingressActivity?.SetTag("flow.run_id", runId.ToString());
+            ingressActivity?.SetTag("flow.signal_name", signalName);
+
             if (string.IsNullOrWhiteSpace(signalName))
             {
                 http.Response.StatusCode = StatusCodes.Status400BadRequest;

--- a/src/FlowOrchestrator.Hangfire/FlowOrchestratorInstrumentationExtensions.cs
+++ b/src/FlowOrchestrator.Hangfire/FlowOrchestratorInstrumentationExtensions.cs
@@ -1,35 +1,38 @@
-using FlowOrchestrator.Core.Execution;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
+using CoreObservability = FlowOrchestrator.Core.Observability;
 
 namespace FlowOrchestrator.Hangfire;
 
 /// <summary>
-/// Extension methods for wiring <see cref="FlowOrchestratorTelemetry"/> into an OpenTelemetry pipeline.
+/// Backwards-compatibility forwarders for the OpenTelemetry registration helpers that moved to
+/// <see cref="CoreObservability.FlowOrchestratorInstrumentationExtensions"/> in v1.19.
 /// </summary>
+/// <remarks>
+/// Existing user code calling <c>using FlowOrchestrator.Hangfire;</c> followed by
+/// <c>tracer.AddFlowOrchestratorInstrumentation()</c> continues to compile, but the call site
+/// produces a CS0618 obsolete-warning pointing at the new location. Remove these forwarders in
+/// the next major release.
+/// </remarks>
+[Obsolete(
+    "Use FlowOrchestrator.Core.Observability.FlowOrchestratorInstrumentationExtensions instead. " +
+    "OTel registration is no longer Hangfire-specific.",
+    error: false)]
 public static class FlowOrchestratorInstrumentationExtensions
 {
-    /// <summary>
-    /// Registers the FlowOrchestrator <see cref="System.Diagnostics.ActivitySource"/> so that
-    /// flow and step execution spans are captured by the tracing pipeline.
-    /// </summary>
-    /// <param name="builder">The <see cref="TracerProviderBuilder"/> to configure.</param>
-    /// <returns>The same builder for chaining.</returns>
+    /// <summary>Forwards to <see cref="CoreObservability.FlowOrchestratorInstrumentationExtensions.AddFlowOrchestratorInstrumentation(TracerProviderBuilder)"/>.</summary>
+    [Obsolete(
+        "Use FlowOrchestrator.Core.Observability.FlowOrchestratorInstrumentationExtensions.AddFlowOrchestratorInstrumentation instead.",
+        error: false)]
     public static TracerProviderBuilder AddFlowOrchestratorInstrumentation(
         this TracerProviderBuilder builder)
-    {
-        return builder.AddSource(FlowOrchestratorTelemetry.SourceName);
-    }
+        => CoreObservability.FlowOrchestratorInstrumentationExtensions.AddFlowOrchestratorInstrumentation(builder);
 
-    /// <summary>
-    /// Registers the FlowOrchestrator <see cref="System.Diagnostics.Metrics.Meter"/> so that
-    /// run/step counters and duration histograms are captured by the metrics pipeline.
-    /// </summary>
-    /// <param name="builder">The <see cref="MeterProviderBuilder"/> to configure.</param>
-    /// <returns>The same builder for chaining.</returns>
+    /// <summary>Forwards to <see cref="CoreObservability.FlowOrchestratorInstrumentationExtensions.AddFlowOrchestratorInstrumentation(MeterProviderBuilder)"/>.</summary>
+    [Obsolete(
+        "Use FlowOrchestrator.Core.Observability.FlowOrchestratorInstrumentationExtensions.AddFlowOrchestratorInstrumentation instead.",
+        error: false)]
     public static MeterProviderBuilder AddFlowOrchestratorInstrumentation(
         this MeterProviderBuilder builder)
-    {
-        return builder.AddMeter(FlowOrchestratorTelemetry.SourceName);
-    }
+        => CoreObservability.FlowOrchestratorInstrumentationExtensions.AddFlowOrchestratorInstrumentation(builder);
 }

--- a/src/FlowOrchestrator.Hangfire/FlowOrchestratorServiceCollectionExtensions.cs
+++ b/src/FlowOrchestrator.Hangfire/FlowOrchestratorServiceCollectionExtensions.cs
@@ -2,7 +2,10 @@ using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Configuration;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Hosting;
+using FlowOrchestrator.Core.Observability;
 using FlowOrchestrator.Core.Storage;
+using FlowOrchestrator.Hangfire.Telemetry;
+using Hangfire;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -88,6 +91,15 @@ public static class FlowOrchestratorServiceCollectionExtensions
             services.AddTransient<IHangfireStepRunner, HangfireFlowOrchestrator>();
             // Newtonsoft uses RunAfterCondition's [JsonConverter] attribute automatically.
             // No global serializer settings to mutate — keeps Hangfire's defaults intact.
+
+            // W3C trace-context propagation across the enqueue / dequeue boundary. Idempotent —
+            // double-registration of AddFlowOrchestrator does not stack the filter. The
+            // GlobalJobFilters.Filters collection wraps each instance in a JobFilter, so we
+            // probe via .Instance rather than OfType<T>.
+            if (!GlobalJobFilters.Filters.Any(f => f.Instance is TraceContextHangfireFilter))
+            {
+                GlobalJobFilters.Filters.Add(new TraceContextHangfireFilter());
+            }
         }
 
         services.AddStepHandler<ForEachStepHandler>("ForEach");

--- a/src/FlowOrchestrator.Hangfire/HangfireFlowOrchestrator.cs
+++ b/src/FlowOrchestrator.Hangfire/HangfireFlowOrchestrator.cs
@@ -1,5 +1,6 @@
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Observability;
 using FlowOrchestrator.Core.Storage;
 using Hangfire.Server;
 
@@ -22,12 +23,17 @@ public sealed class HangfireFlowOrchestrator : IHangfireFlowTrigger, IHangfireSt
 {
     private readonly IFlowOrchestrator _engine;
     private readonly IFlowRepository _flowRepository;
+    private readonly FlowOrchestratorTelemetry? _telemetry;
 
-    /// <summary>Initialises the adapter with the core execution engine and the flow repository used to rehydrate definitions on the worker.</summary>
-    public HangfireFlowOrchestrator(IFlowOrchestrator engine, IFlowRepository flowRepository)
+    /// <summary>Initialises the adapter with the core execution engine, the flow repository used to rehydrate definitions on the worker, and an optional telemetry hub for cron-lag metrics.</summary>
+    public HangfireFlowOrchestrator(
+        IFlowOrchestrator engine,
+        IFlowRepository flowRepository,
+        FlowOrchestratorTelemetry? telemetry = null)
     {
         _engine = engine;
         _flowRepository = flowRepository;
+        _telemetry = telemetry;
     }
 
     /// <inheritdoc/>
@@ -39,7 +45,23 @@ public sealed class HangfireFlowOrchestrator : IHangfireFlowTrigger, IHangfireSt
 
     /// <inheritdoc/>
     public ValueTask<object?> TriggerByScheduleAsync(Guid flowId, string triggerKey, PerformContext? performContext = null)
-        => _engine.TriggerByScheduleAsync(flowId, triggerKey, performContext?.BackgroundJob?.Id);
+    {
+        // Cron lag = wall-clock between Hangfire enqueueing the job (when the recurring scheduler
+        // fired internally) and the worker picking it up. Hangfire does not expose the cron's
+        // exact scheduled tick time, but BackgroundJob.CreatedAt is the closest proxy and is
+        // what operators care about: "how far behind is the cron pipeline?".
+        if (_telemetry is not null && performContext?.BackgroundJob?.CreatedAt is { } createdAt)
+        {
+            var lagMs = Math.Max(0, (DateTime.UtcNow - createdAt).TotalMilliseconds);
+            _telemetry.CronLagMs.Record(
+                lagMs,
+                new KeyValuePair<string, object?>("flow_id", flowId.ToString()),
+                new KeyValuePair<string, object?>("trigger_key", triggerKey),
+                new KeyValuePair<string, object?>("runtime", "hangfire"));
+        }
+
+        return _engine.TriggerByScheduleAsync(flowId, triggerKey, performContext?.BackgroundJob?.Id);
+    }
 
     /// <inheritdoc/>
     public async ValueTask<object?> RunStepAsync(IExecutionContext ctx, Guid flowId, IStepInstance step, PerformContext? performContext = null)

--- a/src/FlowOrchestrator.Hangfire/Telemetry/TraceContextHangfireFilter.cs
+++ b/src/FlowOrchestrator.Hangfire/Telemetry/TraceContextHangfireFilter.cs
@@ -1,0 +1,115 @@
+using System.Diagnostics;
+using FlowOrchestrator.Core.Observability;
+using Hangfire.Client;
+using Hangfire.Common;
+using Hangfire.Server;
+
+namespace FlowOrchestrator.Hangfire.Telemetry;
+
+/// <summary>
+/// Hangfire client + server filter that propagates the W3C <c>traceparent</c> header across the
+/// enqueue / dequeue boundary, restoring distributed-trace continuity that Hangfire's
+/// argument serializer otherwise drops.
+/// </summary>
+/// <remarks>
+/// On enqueue (<see cref="IClientFilter.OnCreating"/>) we capture <see cref="Activity.Current"/>'s
+/// W3C identifiers and store them on Hangfire job parameters. On execute
+/// (<see cref="IServerFilter.OnPerforming"/>) we read those parameters back and open a wrapper
+/// activity (<c>flow.runtime.execute</c>) whose parent context is the captured one. Subsequent
+/// activities opened by the engine — <c>flow.trigger</c>, <c>flow.step</c> — automatically become
+/// children of the wrapper, so APMs see a single connected trace from the original caller through
+/// to every step's execution.
+/// </remarks>
+internal sealed class TraceContextHangfireFilter : JobFilterAttribute, IClientFilter, IServerFilter
+{
+    private const string TraceparentParam = "flow_traceparent";
+    private const string TracestateParam = "flow_tracestate";
+    private const string ItemsKey = "flow_runtime_activity";
+
+    private readonly ActivitySource _activitySource;
+
+    /// <summary>Creates a filter that propagates trace context using the shared FlowOrchestrator activity source.</summary>
+    public TraceContextHangfireFilter()
+        : this(new ActivitySource(FlowOrchestratorTelemetry.SourceName))
+    {
+    }
+
+    /// <summary>Creates a filter that propagates trace context using the supplied activity source. Used by tests.</summary>
+    public TraceContextHangfireFilter(ActivitySource activitySource)
+    {
+        _activitySource = activitySource ?? throw new ArgumentNullException(nameof(activitySource));
+    }
+
+    /// <inheritdoc />
+    public void OnCreating(CreatingContext filterContext)
+    {
+        var current = Activity.Current;
+        if (current is null || current.IdFormat != ActivityIdFormat.W3C)
+        {
+            return;
+        }
+
+        // Capture the W3C identifiers — these survive Hangfire's job-argument serialisation as
+        // simple strings, unlike ActivityContext which Hangfire would not know how to round-trip.
+        filterContext.SetJobParameter(TraceparentParam, current.Id);
+        if (!string.IsNullOrEmpty(current.TraceStateString))
+        {
+            filterContext.SetJobParameter(TracestateParam, current.TraceStateString);
+        }
+    }
+
+    /// <inheritdoc />
+    public void OnCreated(CreatedContext filterContext)
+    {
+        // No-op — the parameter was already set in OnCreating.
+    }
+
+    /// <inheritdoc />
+    public void OnPerforming(PerformingContext filterContext)
+    {
+        var traceparent = filterContext.GetJobParameter<string?>(TraceparentParam);
+        if (string.IsNullOrEmpty(traceparent))
+        {
+            return;
+        }
+
+        var tracestate = filterContext.GetJobParameter<string?>(TracestateParam);
+        if (!ActivityContext.TryParse(traceparent, tracestate, out var parentContext))
+        {
+            return;
+        }
+
+        // Open a wrapper that becomes the parent of every span the engine opens for this job.
+        // ActivityKind.Consumer matches the OTel messaging convention — this code consumed a
+        // job from the queue and is now executing it.
+        var activity = _activitySource.StartActivity(
+            "flow.runtime.execute",
+            ActivityKind.Consumer,
+            parentContext);
+
+        if (activity is not null)
+        {
+            activity.SetTag("messaging.system", "hangfire");
+            activity.SetTag("messaging.operation", "process");
+            activity.SetTag("messaging.message.id", filterContext.BackgroundJob.Id);
+            filterContext.Items[ItemsKey] = activity;
+        }
+    }
+
+    /// <inheritdoc />
+    public void OnPerformed(PerformedContext filterContext)
+    {
+        if (!filterContext.Items.TryGetValue(ItemsKey, out var raw) || raw is not Activity activity)
+        {
+            return;
+        }
+
+        if (filterContext.Exception is not null)
+        {
+            activity.RecordError(filterContext.Exception);
+        }
+
+        activity.Dispose();
+        filterContext.Items.Remove(ItemsKey);
+    }
+}

--- a/src/FlowOrchestrator.InMemory/InMemoryStepDispatcher.cs
+++ b/src/FlowOrchestrator.InMemory/InMemoryStepDispatcher.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Threading.Channels;
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
@@ -32,7 +33,8 @@ internal sealed class InMemoryStepDispatcher : IStepDispatcher
         CancellationToken ct = default)
     {
         var id = Guid.NewGuid().ToString("N");
-        await _writer.WriteAsync(new InMemoryStepEnvelope(context, flow, step, id), ct).ConfigureAwait(false);
+        var traceContext = CaptureCurrentTraceContext();
+        await _writer.WriteAsync(new InMemoryStepEnvelope(context, flow, step, id) { ParentTraceContext = traceContext }, ct).ConfigureAwait(false);
         return id;
     }
 
@@ -45,6 +47,7 @@ internal sealed class InMemoryStepDispatcher : IStepDispatcher
         CancellationToken ct = default)
     {
         var id = Guid.NewGuid().ToString("N");
+        var traceContext = CaptureCurrentTraceContext();
 
         // Fire-and-forget: wait for the delay then write to channel.
         // The outer ValueTask completes immediately; the step becomes visible to the runner
@@ -54,7 +57,7 @@ internal sealed class InMemoryStepDispatcher : IStepDispatcher
             try
             {
                 await Task.Delay(delay, ct).ConfigureAwait(false);
-                await _writer.WriteAsync(new InMemoryStepEnvelope(context, flow, step, id), ct)
+                await _writer.WriteAsync(new InMemoryStepEnvelope(context, flow, step, id) { ParentTraceContext = traceContext }, ct)
                              .ConfigureAwait(false);
             }
             catch (OperationCanceledException)
@@ -65,5 +68,16 @@ internal sealed class InMemoryStepDispatcher : IStepDispatcher
         }, ct);
 
         return new ValueTask<string?>(id);
+    }
+
+    /// <summary>
+    /// Captures <see cref="Activity.Current"/>'s context if it is W3C-formatted; the runner
+    /// uses it to re-parent the step's span and keep the distributed trace continuous across
+    /// the channel handover.
+    /// </summary>
+    private static ActivityContext? CaptureCurrentTraceContext()
+    {
+        var current = Activity.Current;
+        return current is { IdFormat: ActivityIdFormat.W3C } ? current.Context : null;
     }
 }

--- a/src/FlowOrchestrator.InMemory/InMemoryStepEnvelope.cs
+++ b/src/FlowOrchestrator.InMemory/InMemoryStepEnvelope.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
 
@@ -23,4 +24,14 @@ internal sealed record InMemoryStepEnvelope(
     IStepInstance Step,
 
     /// <summary>Opaque identifier returned to the caller as the "job id".</summary>
-    string EnvelopeId);
+    string EnvelopeId)
+{
+    /// <summary>
+    /// W3C trace context captured at dispatch time so the runner can re-establish it as the
+    /// parent of the step's span — preserving distributed-trace continuity across the
+    /// <see cref="System.Threading.Channels.Channel{T}"/> boundary, mirroring what
+    /// <c>TraceContextHangfireFilter</c> does for the Hangfire runtime. <see langword="null"/>
+    /// when no activity was current at dispatch time.
+    /// </summary>
+    public ActivityContext? ParentTraceContext { get; init; }
+}

--- a/src/FlowOrchestrator.InMemory/InMemoryStepRunnerHostedService.cs
+++ b/src/FlowOrchestrator.InMemory/InMemoryStepRunnerHostedService.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics;
 using System.Threading.Channels;
 using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Observability;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -48,6 +50,19 @@ internal sealed class InMemoryStepRunnerHostedService : BackgroundService
             // Run each step in a separate scope so scoped services (e.g. IExecutionContextAccessor) are isolated.
             _ = Task.Run(async () =>
             {
+                // Re-establish the parent trace context captured at dispatch time so the
+                // step's flow.step span becomes a child of the original caller's trace,
+                // not an orphan root. Mirrors TraceContextHangfireFilter for the InMemory runtime.
+                using var wrapperActivity = envelope.ParentTraceContext is { } parentCtx
+                    ? FlowOrchestratorTelemetry.SharedActivitySource.StartActivity(
+                        "flow.runtime.execute",
+                        ActivityKind.Consumer,
+                        parentCtx)
+                    : null;
+                wrapperActivity?.SetTag("messaging.system", "in_memory_channel");
+                wrapperActivity?.SetTag("messaging.operation", "process");
+                wrapperActivity?.SetTag("messaging.message.id", envelope.EnvelopeId);
+
                 try
                 {
                     await using var scope = _scopeFactory.CreateAsyncScope();

--- a/src/FlowOrchestrator.InMemory/PeriodicTimerRecurringTriggerDispatcher.cs
+++ b/src/FlowOrchestrator.InMemory/PeriodicTimerRecurringTriggerDispatcher.cs
@@ -3,6 +3,7 @@ using Cronos;
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Configuration;
 using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Observability;
 using FlowOrchestrator.Core.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -31,20 +32,22 @@ internal sealed class PeriodicTimerRecurringTriggerDispatcher
     private readonly FlowSchedulerOptions _schedulerOptions;
     private readonly ILogger<PeriodicTimerRecurringTriggerDispatcher> _logger;
     private readonly TimeProvider _timeProvider;
+    private readonly FlowOrchestratorTelemetry? _telemetry;
     private readonly ConcurrentDictionary<string, JobState> _jobs = new(StringComparer.Ordinal);
 
     private PeriodicTimer? _timer;
     private Task? _loop;
     private CancellationTokenSource? _cts;
 
-    /// <summary>Initialises the dispatcher with required services.</summary>
+    /// <summary>Initialises the dispatcher with required services. <paramref name="telemetry"/> is optional — when omitted, cron-lag metrics are not emitted.</summary>
     public PeriodicTimerRecurringTriggerDispatcher(
         IServiceProvider services,
         IFlowRepository repository,
         IFlowScheduleStateStore scheduleStateStore,
         FlowSchedulerOptions schedulerOptions,
         ILogger<PeriodicTimerRecurringTriggerDispatcher> logger,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        FlowOrchestratorTelemetry? telemetry = null)
     {
         _services = services;
         _repository = repository;
@@ -52,6 +55,7 @@ internal sealed class PeriodicTimerRecurringTriggerDispatcher
         _schedulerOptions = schedulerOptions;
         _logger = logger;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _telemetry = telemetry;
     }
 
     /// <inheritdoc/>
@@ -116,6 +120,20 @@ internal sealed class PeriodicTimerRecurringTriggerDispatcher
 
     private async Task FireAsync(string jobId, JobState state, CancellationToken ct)
     {
+        // Capture cron lag: how late we are versus the scheduled fire time. NextExecution is the
+        // schedule we're firing for; the loop guarantees it is <= now when FireAsync is called.
+        var scheduledAt = state.NextExecution;
+        var firedAt = _timeProvider.GetUtcNow();
+        if (_telemetry is not null)
+        {
+            var lagMs = Math.Max(0, (firedAt - scheduledAt).TotalMilliseconds);
+            _telemetry.CronLagMs.Record(
+                lagMs,
+                new KeyValuePair<string, object?>("flow_id", state.FlowId.ToString()),
+                new KeyValuePair<string, object?>("trigger_key", state.TriggerKey),
+                new KeyValuePair<string, object?>("runtime", "in_memory"));
+        }
+
         try
         {
             using var scope = _services.CreateScope();

--- a/tests/integration/FlowOrchestrator.Hangfire.IntegrationTests/FlowOrchestrator.Hangfire.IntegrationTests.csproj
+++ b/tests/integration/FlowOrchestrator.Hangfire.IntegrationTests/FlowOrchestrator.Hangfire.IntegrationTests.csproj
@@ -19,6 +19,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <!-- E2E trace propagation test needs a real (in-memory) Hangfire BackgroundJobServer. -->
+    <PackageReference Include="Hangfire.AspNetCore" />
+    <PackageReference Include="Hangfire.InMemory" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/integration/FlowOrchestrator.Hangfire.IntegrationTests/HangfireFlowOrchestratorTests.cs
+++ b/tests/integration/FlowOrchestrator.Hangfire.IntegrationTests/HangfireFlowOrchestratorTests.cs
@@ -1,6 +1,7 @@
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Configuration;
 using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Observability;
 using FlowOrchestrator.Core.Storage;
 using FlowOrchestrator.Hangfire;
 using Hangfire;

--- a/tests/integration/FlowOrchestrator.Hangfire.IntegrationTests/TraceContextPropagationTests.cs
+++ b/tests/integration/FlowOrchestrator.Hangfire.IntegrationTests/TraceContextPropagationTests.cs
@@ -1,0 +1,171 @@
+using System.Diagnostics;
+using FlowOrchestrator.Core.Observability;
+using FlowOrchestrator.Hangfire.Telemetry;
+using Hangfire;
+using Hangfire.InMemory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace FlowOrchestrator.Hangfire.Tests;
+
+/// <summary>Marker collection that serializes Hangfire global-filter tests; <see cref="GlobalJobFilters"/> is process-wide mutable state.</summary>
+[CollectionDefinition(nameof(HangfireIntegrationGlobalFiltersCollection), DisableParallelization = true)]
+public sealed class HangfireIntegrationGlobalFiltersCollection
+{
+}
+
+/// <summary>
+/// End-to-end test for the W3C trace-context propagation across the Hangfire enqueue/dequeue boundary.
+/// Spins up a real <see cref="BackgroundJobServer"/> over Hangfire.InMemory storage so the filter is
+/// exercised exactly as it would be in production.
+/// </summary>
+[Collection(nameof(HangfireIntegrationGlobalFiltersCollection))]
+public sealed class TraceContextPropagationTests : IDisposable
+{
+    private readonly ServiceProvider _provider;
+    private readonly BackgroundJobServer _server;
+
+    private readonly JobStorage _storage;
+
+    public TraceContextPropagationTests()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.AddDebug().SetMinimumLevel(LogLevel.Warning));
+        services.AddTransient<TestJob>();
+
+        // Mirror what AddFlowOrchestrator(...).UseHangfire() does for the trace filter — we test
+        // the filter directly here without dragging the whole engine into the integration surface.
+        if (!GlobalJobFilters.Filters.Any(f => f.Instance is TraceContextHangfireFilter))
+        {
+            GlobalJobFilters.Filters.Add(new TraceContextHangfireFilter());
+        }
+
+        _provider = services.BuildServiceProvider();
+
+        // Build the in-memory storage directly so the test does not race against the static
+        // JobStorage.Current setter that AddHangfire would otherwise mutate from a hosted-service.
+        _storage = new InMemoryStorage();
+        JobStorage.Current = _storage;
+
+        // Start a server with one worker so the test drains predictably.
+        _server = new BackgroundJobServer(
+            new BackgroundJobServerOptions
+            {
+                WorkerCount = 1,
+                ServerName = "trace-test-server",
+                Activator = new ServiceProviderJobActivator(_provider),
+            },
+            _storage);
+    }
+
+    public void Dispose()
+    {
+        _server.Dispose();
+        _provider.Dispose();
+        GlobalJobFilters.Filters
+            .Where(f => f.Instance is TraceContextHangfireFilter)
+            .Select(f => f.Instance)
+            .ToList()
+            .ForEach(GlobalJobFilters.Filters.Remove);
+    }
+
+    [Fact]
+    public async Task EnqueueAndExecute_RestoresParentTraceContextOnTheWorker()
+    {
+        // Arrange
+        var captured = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = src => src.Name == FlowOrchestratorTelemetry.SourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = captured.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var parentSource = new ActivitySource("FlowOrchestrator.Hangfire.Tests.Parent");
+        using var parentListener = new ActivityListener
+        {
+            ShouldListenTo = src => src.Name == "FlowOrchestrator.Hangfire.Tests.Parent",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(parentListener);
+
+        var client = new BackgroundJobClient(_storage);
+        TestJob.Reset();
+
+        string expectedTraceId;
+        using (var parent = parentSource.StartActivity("test.parent"))
+        {
+            Assert.NotNull(parent);
+            expectedTraceId = parent.TraceId.ToString();
+            client.Enqueue<TestJob>(j => j.Run());
+        }
+
+        // Act — wait for the worker to pick up + run + finish
+        var ran = await TestJob.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+        // Assert
+        Assert.True(ran, "TestJob did not run within 30s — Hangfire server may not have started.");
+        var wrapper = Assert.Single(captured, a => a.OperationName == "flow.runtime.execute");
+        Assert.Equal(expectedTraceId, wrapper.TraceId.ToString());
+        Assert.Equal("hangfire", wrapper.GetTagItem("messaging.system"));
+    }
+
+    [Fact]
+    public async Task EnqueueWithoutParentActivity_DoesNotOpenWrapperActivity()
+    {
+        // Arrange
+        var captured = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = src => src.Name == FlowOrchestratorTelemetry.SourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = captured.Add,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var client = new BackgroundJobClient(_storage);
+        TestJob.Reset();
+
+        // Act — no parent activity in scope; enqueue + drain
+        Assert.Null(Activity.Current);
+        client.Enqueue<TestJob>(j => j.Run());
+        var ran = await TestJob.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+        // Assert
+        Assert.True(ran);
+        Assert.DoesNotContain(captured, a => a.OperationName == "flow.runtime.execute");
+    }
+
+    /// <summary>Marker job that signals completion via a TaskCompletionSource so tests can await it deterministically.</summary>
+    public sealed class TestJob
+    {
+        private static TaskCompletionSource _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public static void Reset()
+        {
+            _tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public static Task<bool> WaitForCompletionAsync(TimeSpan timeout)
+        {
+            return Task.Run(async () =>
+            {
+                var winner = await Task.WhenAny(_tcs.Task, Task.Delay(timeout));
+                return winner == _tcs.Task;
+            });
+        }
+
+        public void Run()
+        {
+            _tcs.TrySetResult();
+        }
+    }
+
+    private sealed class ServiceProviderJobActivator : JobActivator
+    {
+        private readonly IServiceProvider _services;
+        public ServiceProviderJobActivator(IServiceProvider services) => _services = services;
+        public override object ActivateJob(Type jobType) => _services.GetRequiredService(jobType);
+    }
+}

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/FlowOrchestratorEngineInvariantTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/FlowOrchestratorEngineInvariantTests.cs
@@ -1,6 +1,7 @@
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Configuration;
 using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Observability;
 using FlowOrchestrator.Core.Storage;
 using FlowOrchestrator.InMemory;
 using Microsoft.Extensions.Logging;

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RunControlTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RunControlTests.cs
@@ -1,6 +1,7 @@
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Configuration;
 using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Observability;
 using FlowOrchestrator.Core.Storage;
 using FlowOrchestrator.InMemory;
 using Microsoft.Extensions.Logging;

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/FlowOrchestrator.Core.UnitTests.csproj
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/FlowOrchestrator.Core.UnitTests.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/HealthChecks/FlowStoreHealthCheckTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/HealthChecks/FlowStoreHealthCheckTests.cs
@@ -1,0 +1,106 @@
+using FlowOrchestrator.Core.HealthChecks;
+using FlowOrchestrator.Core.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace FlowOrchestrator.Core.Tests.HealthChecks;
+
+public class FlowStoreHealthCheckTests
+{
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsHealthy_WhenStoreRespondsSuccessfully()
+    {
+        // Arrange
+        var store = Substitute.For<IFlowStore>();
+        store.GetAllAsync().Returns(Task.FromResult<IReadOnlyList<FlowDefinitionRecord>>(Array.Empty<FlowDefinitionRecord>()));
+        var check = new FlowStoreHealthCheck(store);
+
+        // Act
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        // Assert
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+        Assert.Contains("reachable", result.Description, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, Assert.IsType<int>(result.Data["flow_count"]));
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsHealthy_WithFlowCount_WhenStoreHasDefinitions()
+    {
+        // Arrange
+        var store = Substitute.For<IFlowStore>();
+        var records = new[]
+        {
+            new FlowDefinitionRecord { Id = Guid.NewGuid(), Name = "A" },
+            new FlowDefinitionRecord { Id = Guid.NewGuid(), Name = "B" },
+            new FlowDefinitionRecord { Id = Guid.NewGuid(), Name = "C" },
+        };
+        store.GetAllAsync().Returns(Task.FromResult<IReadOnlyList<FlowDefinitionRecord>>(records));
+        var check = new FlowStoreHealthCheck(store);
+
+        // Act
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        // Assert
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+        Assert.Equal(3, Assert.IsType<int>(result.Data["flow_count"]));
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsUnhealthy_WhenStoreThrows()
+    {
+        // Arrange
+        var store = Substitute.For<IFlowStore>();
+        var failure = new InvalidOperationException("connection refused");
+        store.GetAllAsync().Returns<Task<IReadOnlyList<FlowDefinitionRecord>>>(_ => throw failure);
+        var check = new FlowStoreHealthCheck(store);
+
+        // Act
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        // Assert
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Same(failure, result.Exception);
+        Assert.Contains("unreachable", result.Description, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsUnhealthy_WhenProbeTimesOut()
+    {
+        // Arrange
+        var completed = new TaskCompletionSource<IReadOnlyList<FlowDefinitionRecord>>();
+        var store = Substitute.For<IFlowStore>();
+        // GetAllAsync will await this TCS — never completed by the test, the probe
+        // budget is what trips the timeout.
+        store.GetAllAsync().Returns(_ => completed.Task);
+        var check = new FlowStoreHealthCheck(store, timeout: TimeSpan.FromMilliseconds(50));
+
+        // Act
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        // Assert
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.Contains("timed out", result.Description, StringComparison.OrdinalIgnoreCase);
+
+        // Cleanup — release the dangling task so the test runner does not see leaked work.
+        completed.TrySetCanceled();
+    }
+
+    [Fact]
+    public void AddFlowOrchestratorHealthChecks_RegistersTheStorageCheck()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton(Substitute.For<IFlowStore>());
+
+        // Act
+        services.AddHealthChecks().AddFlowOrchestratorHealthChecks();
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        // Assert
+        Assert.Contains(options.Registrations, r => r.Name == "flow-orchestrator-storage");
+    }
+}

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Observability/EngineObservabilityTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Observability/EngineObservabilityTests.cs
@@ -1,0 +1,265 @@
+using System.Diagnostics;
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Configuration;
+using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Observability;
+using FlowOrchestrator.Core.Storage;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using CoreExecutionContext = FlowOrchestrator.Core.Execution.ExecutionContext;
+
+namespace FlowOrchestrator.Core.Tests.Observability;
+
+/// <summary>
+/// Phase 1 of the v1.19 production-grade observability work: validates the engine marks
+/// activities as <see cref="ActivityStatusCode.Error"/> on failure and opens a logger scope
+/// carrying <c>RunId</c> / <c>FlowId</c> / <c>StepKey</c> for every entry point.
+/// </summary>
+[Collection(nameof(FlowActivitySourceCollection))]
+public sealed class EngineObservabilityTests
+{
+    // ── Substitutes shared across tests ───────────────────────────────────────
+
+    private readonly IStepDispatcher _dispatcher = Substitute.For<IStepDispatcher>();
+    private readonly IFlowExecutor _flowExecutor = Substitute.For<IFlowExecutor>();
+    private readonly IFlowGraphPlanner _graphPlanner = new FlowGraphPlanner();
+    private readonly IStepExecutor _stepExecutor = Substitute.For<IStepExecutor>();
+    private readonly IFlowRunStore _runStore = Substitute.For<IFlowRunStore>();
+    private readonly IOutputsRepository _outputsRepo = Substitute.For<IOutputsRepository>();
+    private readonly IExecutionContextAccessor _ctxAccessor = Substitute.For<IExecutionContextAccessor>();
+    private readonly IFlowRepository _flowRepo = Substitute.For<IFlowRepository>();
+
+    public EngineObservabilityTests()
+    {
+        _runStore.TryRecordDispatchAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(Task.FromResult(true));
+    }
+
+    private FlowOrchestratorEngine CreateEngine(ILogger<FlowOrchestratorEngine> logger, FlowOrchestratorTelemetry? telemetry = null) =>
+        new(
+            _dispatcher,
+            _flowExecutor,
+            _graphPlanner,
+            _stepExecutor,
+            _runStore,
+            _outputsRepo,
+            _ctxAccessor,
+            _flowRepo,
+            [],
+            [],
+            new FlowRunControlOptions(),
+            new FlowObservabilityOptions { EnableEventPersistence = false, EnableOpenTelemetry = true },
+            telemetry ?? new FlowOrchestratorTelemetry(),
+            logger);
+
+    private static IFlowDefinition MakeFlow(string stepKey)
+    {
+        var flow = Substitute.For<IFlowDefinition>();
+        flow.Id.Returns(Guid.NewGuid());
+        var steps = new StepCollection
+        {
+            [stepKey] = new StepMetadata { Type = "Work" }
+        };
+        flow.Manifest.Returns(new FlowManifest { Steps = steps });
+        return flow;
+    }
+
+    private static ITriggerContext MakeTriggerCtx(IFlowDefinition flow) =>
+        new TriggerContext
+        {
+            RunId = Guid.NewGuid(),
+            Flow = flow,
+            Trigger = new Trigger("manual", "Manual", null)
+        };
+
+    // ── Activity error recording ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task RunStepAsync_WhenHandlerThrows_RecordsExceptionAndSetsActivityStatusError()
+    {
+        // Arrange
+        var stoppedActivities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = src => src.Name == FlowOrchestratorTelemetry.SourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = stoppedActivities.Add
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var bang = new InvalidOperationException("boom");
+        _stepExecutor.ExecuteAsync(Arg.Any<IExecutionContext>(), Arg.Any<IFlowDefinition>(), Arg.Any<IStepInstance>())
+            .ReturnsForAnyArgs<ValueTask<IStepResult>>(_ => throw bang);
+
+        var logger = Substitute.For<ILogger<FlowOrchestratorEngine>>();
+        var telemetry = new FlowOrchestratorTelemetry();
+        var engine = CreateEngine(logger, telemetry);
+
+        var runId = Guid.NewGuid();
+        var flow = MakeFlow("step1");
+        var step = new StepInstance("step1", "Work") { RunId = runId };
+
+        // Act
+        await engine.RunStepAsync(new CoreExecutionContext { RunId = runId }, flow, step);
+
+        // Assert
+        var stepActivity = stoppedActivities.SingleOrDefault(a => a.OperationName == "flow.step");
+        Assert.NotNull(stepActivity);
+        Assert.Equal(ActivityStatusCode.Error, stepActivity!.Status);
+        var exceptionEvent = Assert.Single(stepActivity.Events, e => e.Name == "exception");
+        var tagDict = exceptionEvent.Tags.ToDictionary(t => t.Key, t => t.Value);
+        Assert.Equal(typeof(InvalidOperationException).FullName, tagDict["exception.type"]);
+        Assert.Equal("boom", tagDict["exception.message"]);
+    }
+
+    [Fact]
+    public async Task TriggerAsync_WhenEngineThrows_RecordsExceptionOnTriggerActivity()
+    {
+        // Arrange
+        var stoppedActivities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = src => src.Name == FlowOrchestratorTelemetry.SourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = stoppedActivities.Add
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var logger = Substitute.For<ILogger<FlowOrchestratorEngine>>();
+        var telemetry = new FlowOrchestratorTelemetry();
+        var engine = CreateEngine(logger, telemetry);
+
+        // A flow with no steps causes TriggerAsync to throw "No entry step found".
+        var flow = Substitute.For<IFlowDefinition>();
+        flow.Id.Returns(Guid.NewGuid());
+        flow.Manifest.Returns(new FlowManifest { Steps = new StepCollection() });
+        var ctx = MakeTriggerCtx(flow);
+
+        // Act
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await engine.TriggerAsync(ctx));
+
+        // Assert
+        var triggerActivity = stoppedActivities.SingleOrDefault(a => a.OperationName == "flow.trigger");
+        Assert.NotNull(triggerActivity);
+        Assert.Equal(ActivityStatusCode.Error, triggerActivity!.Status);
+        Assert.Single(triggerActivity.Events, e => e.Name == "exception");
+    }
+
+    [Fact]
+    public async Task RunStepAsync_WhenHandlerSucceeds_DoesNotMarkActivityError()
+    {
+        // Arrange
+        var stoppedActivities = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = src => src.Name == FlowOrchestratorTelemetry.SourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = stoppedActivities.Add
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        _stepExecutor.ExecuteAsync(Arg.Any<IExecutionContext>(), Arg.Any<IFlowDefinition>(), Arg.Any<IStepInstance>())
+            .ReturnsForAnyArgs(new ValueTask<IStepResult>(new StepResult
+            {
+                Key = "step1",
+                Status = StepStatus.Succeeded
+            }));
+
+        var logger = Substitute.For<ILogger<FlowOrchestratorEngine>>();
+        var engine = CreateEngine(logger);
+
+        var runId = Guid.NewGuid();
+        var flow = MakeFlow("step1");
+
+        // Act
+        await engine.RunStepAsync(
+            new CoreExecutionContext { RunId = runId },
+            flow,
+            new StepInstance("step1", "Work") { RunId = runId });
+
+        // Assert
+        var stepActivity = stoppedActivities.SingleOrDefault(a => a.OperationName == "flow.step");
+        Assert.NotNull(stepActivity);
+        Assert.NotEqual(ActivityStatusCode.Error, stepActivity!.Status);
+        Assert.DoesNotContain(stepActivity.Events, e => e.Name == "exception");
+    }
+
+    // ── Logger scope correlation ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task TriggerAsync_OpensLogScopeWithRunIdAndFlowId()
+    {
+        // Arrange
+        var logger = new RecordingLogger<FlowOrchestratorEngine>();
+        var engine = CreateEngine(logger);
+        var flow = MakeFlow("step1");
+        var ctx = MakeTriggerCtx(flow);
+
+        // Act
+        await engine.TriggerAsync(ctx);
+
+        // Assert
+        Assert.Contains(logger.Scopes, s =>
+            s.ContainsKey("RunId") && s["RunId"]?.Equals(ctx.RunId) == true &&
+            s.ContainsKey("FlowId") && s["FlowId"]?.Equals(flow.Id) == true);
+    }
+
+    [Fact]
+    public async Task RunStepAsync_OpensLogScopeWithRunIdFlowIdAndStepKey()
+    {
+        // Arrange
+        var logger = new RecordingLogger<FlowOrchestratorEngine>();
+        var engine = CreateEngine(logger);
+
+        _stepExecutor.ExecuteAsync(Arg.Any<IExecutionContext>(), Arg.Any<IFlowDefinition>(), Arg.Any<IStepInstance>())
+            .ReturnsForAnyArgs(new ValueTask<IStepResult>(new StepResult
+            {
+                Key = "step1",
+                Status = StepStatus.Succeeded
+            }));
+
+        var runId = Guid.NewGuid();
+        var flow = MakeFlow("step1");
+
+        // Act
+        await engine.RunStepAsync(
+            new CoreExecutionContext { RunId = runId },
+            flow,
+            new StepInstance("step1", "Work") { RunId = runId });
+
+        // Assert
+        Assert.Contains(logger.Scopes, s =>
+            s.ContainsKey("RunId") && s["RunId"]?.Equals(runId) == true &&
+            s.ContainsKey("FlowId") && s["FlowId"]?.Equals(flow.Id) == true &&
+            s.ContainsKey("StepKey") && (string?)s["StepKey"] == "step1");
+    }
+
+    // ── Test logger that records every BeginScope state ───────────────────────
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<IReadOnlyDictionary<string, object?>> Scopes { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+        {
+            if (state is IEnumerable<KeyValuePair<string, object?>> kvps)
+            {
+                Scopes.Add(kvps.ToDictionary(k => k.Key, v => v.Value));
+            }
+            return NullScope.Instance;
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => false;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            // Intentionally no-op — these tests assert on scopes, not log lines.
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Observability/EngineSpanCoverageTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Observability/EngineSpanCoverageTests.cs
@@ -1,0 +1,237 @@
+using System.Diagnostics;
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Configuration;
+using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Observability;
+using FlowOrchestrator.Core.Storage;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using CoreExecutionContext = FlowOrchestrator.Core.Execution.ExecutionContext;
+
+namespace FlowOrchestrator.Core.Tests.Observability;
+
+/// <summary>Marker collection that serializes activity-source-touching tests; the FlowOrchestrator ActivitySource is process-wide so parallel listeners see each other's events.</summary>
+[CollectionDefinition(nameof(FlowActivitySourceCollection), DisableParallelization = true)]
+public sealed class FlowActivitySourceCollection
+{
+}
+
+/// <summary>
+/// Tests for the new spans introduced in Phase 3 of the v1.19 observability work:
+/// <c>flow.step.retry</c>, <c>flow.step.when</c>, and <c>flow.step.poll</c>.
+/// </summary>
+[Collection(nameof(FlowActivitySourceCollection))]
+public sealed class EngineSpanCoverageTests
+{
+    private readonly IStepDispatcher _dispatcher = Substitute.For<IStepDispatcher>();
+    private readonly IFlowExecutor _flowExecutor = Substitute.For<IFlowExecutor>();
+    private readonly IFlowGraphPlanner _graphPlanner = new FlowGraphPlanner();
+    private readonly IStepExecutor _stepExecutor = Substitute.For<IStepExecutor>();
+    private readonly IFlowRunStore _runStore = Substitute.For<IFlowRunStore>();
+    private readonly IOutputsRepository _outputsRepo = Substitute.For<IOutputsRepository>();
+    private readonly IExecutionContextAccessor _ctxAccessor = Substitute.For<IExecutionContextAccessor>();
+    private readonly IFlowRepository _flowRepo = Substitute.For<IFlowRepository>();
+    private readonly ILogger<FlowOrchestratorEngine> _logger = Substitute.For<ILogger<FlowOrchestratorEngine>>();
+
+    private readonly FlowOrchestratorTelemetry _telemetry = new();
+
+    public EngineSpanCoverageTests()
+    {
+        _runStore.TryRecordDispatchAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ReturnsForAnyArgs(Task.FromResult(true));
+    }
+
+    private FlowOrchestratorEngine CreateEngine(IFlowRunRuntimeStore? runtimeStore = null) =>
+        new(
+            _dispatcher,
+            _flowExecutor,
+            _graphPlanner,
+            _stepExecutor,
+            _runStore,
+            _outputsRepo,
+            _ctxAccessor,
+            _flowRepo,
+            runtimeStore is not null ? [runtimeStore] : [],
+            [],
+            new FlowRunControlOptions(),
+            new FlowObservabilityOptions { EnableEventPersistence = false, EnableOpenTelemetry = true },
+            _telemetry,
+            _logger);
+
+    private static IFlowDefinition MakeFlow(Guid flowId, string stepKey, RunAfterCollection? runAfter = null)
+    {
+        var flow = Substitute.For<IFlowDefinition>();
+        flow.Id.Returns(flowId);
+        flow.Manifest.Returns(new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                [stepKey] = new StepMetadata
+                {
+                    Type = "Work",
+                    RunAfter = runAfter ?? new RunAfterCollection(),
+                    Inputs = new Dictionary<string, object?>()
+                }
+            }
+        });
+        return flow;
+    }
+
+    private static (List<Activity> stopped, ActivityListener listener) StartListener()
+    {
+        var stopped = new List<Activity>();
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = src => src.Name == FlowOrchestratorTelemetry.SourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = stopped.Add
+        };
+        ActivitySource.AddActivityListener(listener);
+        return (stopped, listener);
+    }
+
+    [Fact]
+    public async Task RetryStepAsync_StartsFlowStepRetryActivity_AndIncrementsRetriesCounter()
+    {
+        // Arrange
+        var (stopped, listener) = StartListener();
+        using var _ = listener;
+
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        var flow = MakeFlow(flowId, "step1");
+        _flowRepo.GetAllFlowsAsync().Returns(new ValueTask<IReadOnlyList<IFlowDefinition>>(new[] { flow }));
+        _stepExecutor.ExecuteAsync(Arg.Any<IExecutionContext>(), Arg.Any<IFlowDefinition>(), Arg.Any<IStepInstance>())
+            .ReturnsForAnyArgs(new ValueTask<IStepResult>(new StepResult { Key = "step1", Status = StepStatus.Succeeded }));
+
+        var counterValues = new List<long>();
+        using var meterListener = new System.Diagnostics.Metrics.MeterListener
+        {
+            InstrumentPublished = (instr, l) =>
+            {
+                if (instr.Name == "flow_step_retries") l.EnableMeasurementEvents(instr);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((_, value, _, _) => counterValues.Add(value));
+        meterListener.Start();
+
+        // Act
+        await CreateEngine().RetryStepAsync(flowId, runId, "step1");
+
+        // Assert
+        var retryActivity = Assert.Single(stopped, a => a.OperationName == "flow.step.retry");
+        Assert.Equal(flowId.ToString(), retryActivity.GetTagItem("flow.id"));
+        Assert.Equal(runId.ToString(), retryActivity.GetTagItem("run.id"));
+        Assert.Equal("step1", retryActivity.GetTagItem("step.key"));
+
+        Assert.Single(counterValues);
+        Assert.Equal(1L, counterValues[0]);
+    }
+
+    [Fact]
+    public async Task TriggerAsync_WithFalseWhenClause_StartsFlowStepWhenActivity_AndIncrementsSkippedCounter()
+    {
+        // Arrange
+        var (stopped, listener) = StartListener();
+        using var _ = listener;
+
+        // Build a flow where step1 has a When that always evaluates false. Note: TryEvaluateWhenAndSkipAsync
+        // bails out early when no IFlowRunRuntimeStore is registered, so we must register one and
+        // make TryClaimStepAsync succeed.
+        var flowId = Guid.NewGuid();
+        var runtimeStore = Substitute.For<IFlowRunRuntimeStore>();
+        runtimeStore.TryClaimStepAsync(Arg.Any<Guid>(), Arg.Any<string>())
+            .ReturnsForAnyArgs(Task.FromResult(true));
+        runtimeStore.GetStepStatusesAsync(Arg.Any<Guid>())
+            .Returns(Task.FromResult<IReadOnlyDictionary<string, StepStatus>>(
+                new Dictionary<string, StepStatus> { ["step1"] = StepStatus.Skipped }));
+        runtimeStore.GetClaimedStepKeysAsync(Arg.Any<Guid>())
+            .Returns(Task.FromResult<IReadOnlyCollection<string>>(new[] { "step1" }));
+
+        var flow = Substitute.For<IFlowDefinition>();
+        flow.Id.Returns(flowId);
+        flow.Manifest.Returns(new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                ["step1"] = new StepMetadata
+                {
+                    Type = "Work",
+                    // Entry-step-with-When pattern: the synthetic empty-string key marks the
+                    // step as an entry while still carrying a When clause (see FlowGraphPlanner.IsEntryStep).
+                    RunAfter = new RunAfterCollection
+                    {
+                        [string.Empty] = new RunAfterCondition { When = "false" }
+                    },
+                    Inputs = new Dictionary<string, object?>()
+                }
+            }
+        });
+
+        var skippedValues = new List<long>();
+        using var meterListener = new System.Diagnostics.Metrics.MeterListener
+        {
+            InstrumentPublished = (instr, l) =>
+            {
+                if (instr.Name == "flow_step_skipped") l.EnableMeasurementEvents(instr);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((_, value, _, _) => skippedValues.Add(value));
+        meterListener.Start();
+
+        var ctx = new TriggerContext
+        {
+            RunId = Guid.NewGuid(),
+            Flow = flow,
+            Trigger = new Trigger("manual", "Manual", null)
+        };
+
+        // Act
+        await CreateEngine(runtimeStore).TriggerAsync(ctx);
+
+        // Assert
+        Assert.Single(stopped, a => a.OperationName == "flow.step.when");
+        Assert.NotEmpty(skippedValues);
+        Assert.Equal(1L, skippedValues[0]);
+    }
+
+    [Fact]
+    public async Task RunStepAsync_WhenStepReturnsPending_IncrementsPollAttemptsCounter()
+    {
+        // Arrange
+        var (stopped, listener) = StartListener();
+        using var _ = listener;
+
+        _stepExecutor.ExecuteAsync(Arg.Any<IExecutionContext>(), Arg.Any<IFlowDefinition>(), Arg.Any<IStepInstance>())
+            .ReturnsForAnyArgs(new ValueTask<IStepResult>(new StepResult
+            {
+                Key = "step1",
+                Status = StepStatus.Pending,
+                DelayNextStep = TimeSpan.FromSeconds(1)
+            }));
+
+        var pollValues = new List<long>();
+        using var meterListener = new System.Diagnostics.Metrics.MeterListener
+        {
+            InstrumentPublished = (instr, l) =>
+            {
+                if (instr.Name == "flow_step_poll_attempts") l.EnableMeasurementEvents(instr);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((_, value, _, _) => pollValues.Add(value));
+        meterListener.Start();
+
+        var runId = Guid.NewGuid();
+        var flow = MakeFlow(Guid.NewGuid(), "step1");
+
+        // Act
+        await CreateEngine().RunStepAsync(
+            new CoreExecutionContext { RunId = runId },
+            flow,
+            new StepInstance("step1", "Work") { RunId = runId });
+
+        // Assert
+        Assert.Single(pollValues);
+        Assert.Equal(1L, pollValues[0]);
+    }
+}

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Observability/InboundTraceContextTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Observability/InboundTraceContextTests.cs
@@ -1,0 +1,101 @@
+using System.Diagnostics;
+using FlowOrchestrator.Core.Observability;
+
+namespace FlowOrchestrator.Core.Tests.Observability;
+
+/// <summary>
+/// Unit tests for <see cref="InboundTraceContext"/> — the helper that lets the Dashboard's
+/// webhook and signal endpoints stitch flow-runs onto the caller's distributed trace.
+/// </summary>
+public sealed class InboundTraceContextTests
+{
+    private const string ValidTraceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+    [Fact]
+    public void TryParse_ReturnsTrue_AndYieldsRemoteContext_ForValidTraceparent()
+    {
+        // Arrange + Act
+        var ok = InboundTraceContext.TryParse(ValidTraceparent, tracestate: null, out var context);
+
+        // Assert
+        Assert.True(ok);
+        Assert.Equal("0af7651916cd43dd8448eb211c80319c", context.TraceId.ToString());
+        Assert.Equal("b7ad6b7169203331", context.SpanId.ToString());
+        Assert.True(context.IsRemote);
+    }
+
+    [Fact]
+    public void TryParse_ReturnsFalse_WhenTraceparentMissing()
+    {
+        // Arrange + Act
+        var ok = InboundTraceContext.TryParse(traceparent: null, tracestate: null, out var context);
+
+        // Assert
+        Assert.False(ok);
+        Assert.Equal(default, context);
+    }
+
+    [Fact]
+    public void TryParse_ReturnsFalse_ForMalformedTraceparent()
+    {
+        // Arrange + Act
+        var ok = InboundTraceContext.TryParse("not-a-traceparent", tracestate: null, out var context);
+
+        // Assert
+        Assert.False(ok);
+        Assert.Equal(default, context);
+    }
+
+    [Fact]
+    public void StartActivity_CreatesChildOfInboundContext_WhenHeaderPresent()
+    {
+        // Arrange
+        using var source = new ActivitySource(nameof(InboundTraceContextTests));
+        var captured = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = src => src.Name == nameof(InboundTraceContextTests),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = captured.Add
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        // Act
+        using (InboundTraceContext.StartActivity(source, "flow.webhook.receive", ActivityKind.Server, ValidTraceparent, null))
+        {
+        }
+
+        // Assert
+        var activity = Assert.Single(captured);
+        Assert.Equal("flow.webhook.receive", activity.OperationName);
+        Assert.Equal(ActivityKind.Server, activity.Kind);
+        Assert.Equal("0af7651916cd43dd8448eb211c80319c", activity.TraceId.ToString());
+        Assert.Equal("b7ad6b7169203331", activity.ParentSpanId.ToString());
+    }
+
+    [Fact]
+    public void StartActivity_CreatesRoot_WhenNoInboundHeader()
+    {
+        // Arrange
+        using var source = new ActivitySource(nameof(InboundTraceContextTests) + "_Root");
+        var captured = new List<Activity>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = src => src.Name == nameof(InboundTraceContextTests) + "_Root",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = captured.Add
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        // Act
+        using (InboundTraceContext.StartActivity(source, "flow.webhook.receive", ActivityKind.Server, null, null))
+        {
+        }
+
+        // Assert
+        var activity = Assert.Single(captured);
+        Assert.Equal("flow.webhook.receive", activity.OperationName);
+        // A root activity has a zero ParentSpanId.
+        Assert.Equal(default, activity.ParentSpanId);
+    }
+}

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Observability/SignalAndCronMetricsTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Observability/SignalAndCronMetricsTests.cs
@@ -1,0 +1,140 @@
+using System.Diagnostics.Metrics;
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Observability;
+using FlowOrchestrator.Core.Storage;
+using NSubstitute;
+
+namespace FlowOrchestrator.Core.Tests.Observability;
+
+/// <summary>
+/// Unit tests for the two histograms wired in the v1.19 observability work:
+/// <c>flow_signal_wait_ms</c> (parked-step wait time, recorded by <see cref="FlowSignalDispatcher"/>)
+/// and <c>flow_cron_lag_ms</c> (cron scheduled-vs-fired delta, recorded by the InMemory and
+/// Hangfire recurring dispatchers).
+/// </summary>
+public sealed class SignalAndCronMetricsTests
+{
+    [Fact]
+    public async Task FlowSignalDispatcher_RecordsSignalWaitMs_OnDelivery()
+    {
+        // Arrange
+        var telemetry = new FlowOrchestratorTelemetry();
+        var captured = new List<double>();
+        using var meterListener = new MeterListener
+        {
+            InstrumentPublished = (instr, l) =>
+            {
+                if (instr.Meter.Name == FlowOrchestratorTelemetry.SourceName && instr.Name == "flow_signal_wait_ms")
+                {
+                    l.EnableMeasurementEvents(instr);
+                }
+            },
+        };
+        meterListener.SetMeasurementEventCallback<double>((_, value, _, _) => captured.Add(value));
+        meterListener.Start();
+
+        var runId = Guid.NewGuid();
+        var stepKey = "wait_for_approval";
+        var signalName = "approve";
+        var createdAt = DateTimeOffset.UtcNow.AddSeconds(-5);
+        var deliveredAt = DateTimeOffset.UtcNow;
+
+        var signalStore = Substitute.For<IFlowSignalStore>();
+        signalStore.DeliverSignalAsync(runId, signalName, "{}", Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<SignalDeliveryResult>(new SignalDeliveryResult(SignalDeliveryStatus.Delivered, stepKey, deliveredAt)));
+        signalStore.GetWaiterAsync(runId, stepKey, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<FlowSignalWaiter?>(new FlowSignalWaiter
+            {
+                RunId = runId,
+                StepKey = stepKey,
+                SignalName = signalName,
+                CreatedAt = createdAt,
+                DeliveredAt = deliveredAt,
+            }));
+
+        var runStore = Substitute.For<IFlowRunStore>();
+        runStore.GetRunDetailAsync(runId).Returns(Task.FromResult<FlowRunRecord?>(new FlowRunRecord
+        {
+            Id = runId,
+            FlowId = Guid.NewGuid(),
+            FlowName = "Approval",
+            Status = "Running",
+            TriggerKey = "manual",
+            StartedAt = DateTimeOffset.UtcNow,
+        }));
+
+        var flowRepo = Substitute.For<IFlowRepository>();
+        flowRepo.GetAllFlowsAsync().Returns(new ValueTask<IReadOnlyList<IFlowDefinition>>(Array.Empty<IFlowDefinition>()));
+
+        var dispatcher = new FlowSignalDispatcher(
+            signalStore,
+            runStore,
+            flowRepo,
+            Substitute.For<IStepDispatcher>(),
+            Substitute.For<IOutputsRepository>(),
+            telemetry);
+
+        // Act
+        await dispatcher.DispatchAsync(runId, signalName, "{}");
+
+        // Assert
+        var recorded = Assert.Single(captured);
+        // ~5 seconds = ~5000 ms; allow generous slack for the wall-clock between Arrange and Act.
+        Assert.InRange(recorded, 4_000, 10_000);
+    }
+
+    [Fact]
+    public async Task FlowSignalDispatcher_DoesNotRecord_WhenTelemetryNotInjected()
+    {
+        // Arrange — same setup as above but telemetry == null
+        var captured = new List<double>();
+        using var meterListener = new MeterListener
+        {
+            InstrumentPublished = (instr, l) =>
+            {
+                if (instr.Meter.Name == FlowOrchestratorTelemetry.SourceName && instr.Name == "flow_signal_wait_ms")
+                {
+                    l.EnableMeasurementEvents(instr);
+                }
+            },
+        };
+        meterListener.SetMeasurementEventCallback<double>((_, value, _, _) => captured.Add(value));
+        meterListener.Start();
+
+        var runId = Guid.NewGuid();
+        var signalStore = Substitute.For<IFlowSignalStore>();
+        signalStore.DeliverSignalAsync(runId, "approve", "{}", Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<SignalDeliveryResult>(new SignalDeliveryResult(SignalDeliveryStatus.Delivered, "wait", DateTimeOffset.UtcNow)));
+
+        var runStore = Substitute.For<IFlowRunStore>();
+        runStore.GetRunDetailAsync(runId).Returns(Task.FromResult<FlowRunRecord?>(new FlowRunRecord
+        {
+            Id = runId,
+            FlowId = Guid.NewGuid(),
+            FlowName = "X",
+            Status = "Running",
+            TriggerKey = "manual",
+            StartedAt = DateTimeOffset.UtcNow,
+        }));
+
+        var flowRepo = Substitute.For<IFlowRepository>();
+        flowRepo.GetAllFlowsAsync().Returns(new ValueTask<IReadOnlyList<IFlowDefinition>>(Array.Empty<IFlowDefinition>()));
+
+        var dispatcher = new FlowSignalDispatcher(
+            signalStore,
+            runStore,
+            flowRepo,
+            Substitute.For<IStepDispatcher>(),
+            Substitute.For<IOutputsRepository>(),
+            telemetry: null);
+
+        // Act
+        await dispatcher.DispatchAsync(runId, "approve", "{}");
+
+        // Assert
+        Assert.Empty(captured);
+        // GetWaiterAsync should not be called when telemetry is null — saves a DB roundtrip.
+        await signalStore.DidNotReceive().GetWaiterAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/unit/FlowOrchestrator.Hangfire.UnitTests/Telemetry/TraceContextHangfireFilterTests.cs
+++ b/tests/unit/FlowOrchestrator.Hangfire.UnitTests/Telemetry/TraceContextHangfireFilterTests.cs
@@ -1,0 +1,101 @@
+using FlowOrchestrator.Core.Storage;
+using FlowOrchestrator.Hangfire;
+using FlowOrchestrator.Hangfire.Telemetry;
+using FlowOrchestrator.InMemory;
+using Hangfire;
+using Hangfire.Client;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FlowOrchestrator.Hangfire.Tests.Telemetry;
+
+/// <summary>Marks tests that touch <see cref="GlobalJobFilters"/> so xUnit serializes them — the global filter list is process-wide mutable state and parallel runs race on it.</summary>
+[CollectionDefinition(nameof(HangfireGlobalFiltersCollection), DisableParallelization = true)]
+public sealed class HangfireGlobalFiltersCollection
+{
+}
+
+/// <summary>
+/// Unit tests for the registration side of <see cref="TraceContextHangfireFilter"/> — verifying
+/// that calling <c>AddFlowOrchestrator(...).UseHangfire()</c> wires the filter into Hangfire's
+/// global filter list and that double-registration is idempotent.
+/// </summary>
+/// <remarks>
+/// Direct unit tests of <see cref="IClientFilter.OnCreating"/> / <see cref="IServerFilter.OnPerforming"/>
+/// are deferred to the integration test suite because constructing Hangfire's
+/// <see cref="CreatingContext"/> / <c>PerformingContext</c> requires a live <see cref="JobStorage"/>
+/// connection. The filter logic itself is small, single-purpose, and exercised end-to-end by the
+/// trace-propagation integration tests.
+/// </remarks>
+[Collection(nameof(HangfireGlobalFiltersCollection))]
+public sealed class TraceContextHangfireFilterTests : IDisposable
+{
+    public TraceContextHangfireFilterTests()
+    {
+        // Snapshot the filter list before each test so we can restore it afterwards.
+        _initialFilterCount = GlobalJobFilters.Filters.Where(f => f.Instance is TraceContextHangfireFilter).Count();
+    }
+
+    private readonly int _initialFilterCount;
+
+    public void Dispose()
+    {
+        // Best-effort cleanup so test runs do not leak state into one another. JobFilterCollection.Remove
+        // matches by .Instance reference, so we pass the wrapped filter instance, not the JobFilter wrapper.
+        var leaked = GlobalJobFilters.Filters
+            .Where(f => f.Instance is TraceContextHangfireFilter)
+            .Select(f => f.Instance)
+            .ToList();
+        for (var i = 0; i < leaked.Count - _initialFilterCount; i++)
+        {
+            GlobalJobFilters.Filters.Remove(leaked[i]);
+        }
+    }
+
+    [Fact]
+    public void AddFlowOrchestrator_WithUseHangfire_RegistersTraceContextHangfireFilter()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddFlowOrchestrator(b => b.UseInMemory().UseHangfire());
+
+        // Assert
+        Assert.Contains(
+            GlobalJobFilters.Filters.Where(f => f.Instance is TraceContextHangfireFilter),
+            _ => true);
+    }
+
+    [Fact]
+    public void AddFlowOrchestrator_WithoutUseHangfire_DoesNotRegisterFilter()
+    {
+        // Arrange
+        var initialCount = GlobalJobFilters.Filters.Where(f => f.Instance is TraceContextHangfireFilter).Count();
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddFlowOrchestrator(b => b.UseInMemory());
+
+        // Assert
+        var afterCount = GlobalJobFilters.Filters.Where(f => f.Instance is TraceContextHangfireFilter).Count();
+        Assert.Equal(initialCount, afterCount);
+    }
+
+    [Fact]
+    public void AddFlowOrchestrator_CalledTwice_DoesNotStackFilter()
+    {
+        // Arrange
+        var s1 = new ServiceCollection();
+        var s2 = new ServiceCollection();
+
+        // Act
+        s1.AddFlowOrchestrator(b => b.UseInMemory().UseHangfire());
+        var firstCount = GlobalJobFilters.Filters.Where(f => f.Instance is TraceContextHangfireFilter).Count();
+
+        s2.AddFlowOrchestrator(b => b.UseInMemory().UseHangfire());
+        var secondCount = GlobalJobFilters.Filters.Where(f => f.Instance is TraceContextHangfireFilter).Count();
+
+        // Assert
+        Assert.Equal(firstCount, secondCount);
+    }
+}


### PR DESCRIPTION
## Summary

Production-grade observability across logs, traces, and metrics; storage-reachability health check; two production-focused docs articles. Single release: **v1.19.0**.

### Observability (3-phase rollout)

**Phase 1 — Foundations + P0 correctness**
- New `FlowOrchestrator.Core.Observability` namespace consolidates `FlowOrchestratorTelemetry` (moved from `Core.Execution`), `FlowOrchestratorInstrumentationExtensions` (moved from `FlowOrchestrator.Hangfire`, with `[Obsolete]` shim), `LogEvents` EventId constants, `EngineLogScope`, `ActivityExtensions.RecordError` (OTel exception convention).
- Engine entry points wrap in `BeginScope({RunId, FlowId, StepKey, Attempt})` so nested logs carry correlation automatically.
- Failed steps/triggers mark `Activity.StatusCode = Error` and record an `exception` event — APMs see red spans instead of silent green.

**Phase 2 — Trace continuity (Hangfire AND InMemory)**
- `TraceContextHangfireFilter` (IClientFilter + IServerFilter) propagates W3C `traceparent` across enqueue/dequeue.
- `InMemoryStepEnvelope.ParentTraceContext` + runner-side wrapper restores trace across the `Channel<T>` boundary (parity with Hangfire).
- Dashboard webhook + signal endpoints extract inbound `traceparent` via new `InboundTraceContext` helper.

**Phase 3 — Span coverage + metrics + source-gen logging**
- New spans: `flow.step.retry`, `flow.step.when` (with expression/resolved/result tags), `flow.step.poll`.
- New instruments fully wired: counters `flow_step_retries`, `flow_step_skipped` (with `reason` tag — `when_false` / `prerequisites_unmet`), `flow_step_poll_attempts`; histograms `flow_signal_wait_ms` (FlowSignalDispatcher) and `flow_cron_lag_ms` (Hangfire + InMemory recurring dispatchers, tagged with `runtime`).
- Engine hot-path `ILogger` calls converted to source-generated `[LoggerMessage]` partial methods (`EngineLog.cs`).
- E2E integration test (`TraceContextPropagationTests`) spins up a real `BackgroundJobServer` over Hangfire.InMemory and asserts parent `TraceId` survives enqueue → dequeue.

### Health checks
- `AddFlowOrchestratorHealthChecks()` extension on `IHealthChecksBuilder`. Probes `IFlowStore.GetAllAsync()` with a configurable 5s budget; resolves whichever store is registered (SQL Server / PostgreSQL / in-memory).

### Production docs
- `articles/versioning.md` — three-layer mental model, safe / caution / breaking change tables, drain procedure, worked example.
- `articles/production-checklist.md` — twelve tables, multi-instance guarantees, monitoring, secrets / PII, capacity, upgrade path.
- `observability.md` — rewritten with per-span / per-metric tag tables, distributed-tracing diagram, sampling guidance, logger scopes + EventIds, and integration examples for Console / Serilog / NLog / OpenTelemetry Logs / App Insights / Datadog / Splunk / Seq / Loki.
- README + getting-started + core-concepts + storage refresh.

### Sample app
- `AddConsoleExporter()` for local trace + metric inspection (gated by `OBSERVABILITY_CONSOLE` config).
- `AddHealthChecks().AddFlowOrchestratorHealthChecks()` + `MapHealthChecks(""/health"")` wired in.

### Packages
- `OpenTelemetry.Api` (~30 KB) added to `FlowOrchestrator.Core` for OTel registration helpers.
- `Microsoft.Extensions.Diagnostics.HealthChecks` added to Core for the health-check abstractions.
- `OpenTelemetry.Exporter.Console` added to the sample app only.

### Dashboard regression caught + fixed mid-PR
- `FlowOrchestratorTelemetry` endpoint parameter is now nullable + `[FromServices]` so dashboards wired without observability still resolve. (Without this, 8 webhook integration tests fell back to model-binding and returned 400.)

## Test plan

- [x] `dotnet build` → 0 errors, 0 warnings
- [x] **Unit slnf — 825/825 pass** (275 tests × net8/9/10)
  - Core 190 (incl. 18 new observability + 5 health-check tests)
  - Hangfire 42 (incl. 3 trace-filter registration tests)
  - InMemory 39, SqlServer 4
- [x] **Integration slnf — 594/594 pass** (198 × 3)
  - 2 new E2E `TraceContextPropagationTests` (real BackgroundJobServer)
- [x] **Regression slnf — 105/105 pass** (35 × 3)
- [x] Live smoke on sample app (`RUNTIME=inmemory FLOW_STORAGE=inmemory`):
  - `GET /health` → `Healthy 200`
  - Webhook + `traceparent` → 9-span connected trace (HTTP → `flow.webhook.receive` → `flow.trigger` → `flow.runtime.execute` → `flow.step` × 3)
  - Failing step → `StatusCode: Error` + `exception` event with full stacktrace
  - `flow.step.when` span: `expression`, `resolved` (`5000 <= 1000`), `result: false`
  - `flow_signal_wait_ms` ≈ 2.2s with `flow_id` / `step_key` / `signal_name` tags
  - `flow_cron_lag_ms` ≈ 922ms with `runtime=in_memory` tag
  - `flow_step_skipped` recorded with both `reason=when_false` and `reason=prerequisites_unmet`
  - `flow_step_poll_attempts` recorded for the parked `WaitForSignal` step
  - BeginScope correlation visible in console logs (`RunId=… Step=… => …`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)