### PR TITLE
ci(docs): build only Libraries.slnf to dodge StaticWebAssets race

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,14 +36,14 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      - name: Restore solution
-        run: dotnet restore
+      - name: Restore libraries
+        run: dotnet restore FlowOrchestrator.Libraries.slnf
 
-      - name: Build solution (generates XML documentation files)
-        # net10.0 — docs only need one TFM; all three are validated in ci.yml.
-        # Using net10.0 (latest) avoids NETSDK1005 on SampleApp/AppHost which only
-        # target net10.0 when built on SDK 10 (FlowOrchestratorSampleTargetFramework).
-        run: dotnet build --no-restore --configuration Release -p:TargetFramework=net10.0
+      - name: Build libraries (generates XML documentation files)
+        # Build only the library projects — docs only consume src/**/*.csproj XML
+        # docs. Excluding SampleApp/AppHost dodges a parallel-MSBuild race on
+        # `rpswa.dswa.cache.json` from the StaticWebAssets SDK on net10.0.
+        run: dotnet build FlowOrchestrator.Libraries.slnf --no-restore --configuration Release -p:TargetFramework=net10.0
 
       - name: Restore .NET tools (pinned docfx version)
         run: dotnet tool restore


### PR DESCRIPTION
## Summary

- Docs deploy workflow on `main` failed with `IOException: rpswa.dswa.cache.json ... being used by another process` — parallel-MSBuild race in the StaticWebAssets SDK on net10.0 against `samples/FlowOrchestrator.SampleApp`.
- DocFX only consumes `../src/**/*.csproj` XML docs (see `docs/docfx.json` metadata src). SampleApp/AppHost are not part of the docs surface.
- Switch the build step to `FlowOrchestrator.Libraries.slnf`, which already excludes the sample projects. No SampleApp build → no `rpswa.dswa.cache.json` contention.

## Failing run

[Deploy Documentation #25382659722](https://github.com/hoangsnowy/FlowOrchestrator/actions/runs/25382659722) — build step exited 1 on the cache-write race.

## Test plan

- [ ] `Deploy Documentation` workflow runs green on this branch's push.
- [ ] DocFX site still includes API metadata for every `src/*` library (Core, Hangfire, InMemory, ServiceBus, SqlServer, PostgreSQL, Dashboard, Testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)