### PR TITLE
fix(ci): pin publish workflow to FlowOrchestrator.slnx

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,10 +31,10 @@ jobs:
             10.0.x
 
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore FlowOrchestrator.slnx
 
       - name: Build
-        run: dotnet build --no-restore --configuration Release
+        run: dotnet build FlowOrchestrator.slnx --no-restore --configuration Release
 
       - name: Test (Unit)
         run: dotnet test FlowOrchestrator.UnitTests.slnx --no-build --configuration Release --verbosity normal
@@ -61,7 +61,7 @@ jobs:
       - name: Pack (preview)
         if: steps.version.outputs.is_preview == 'true'
         run: >
-          dotnet pack
+          dotnet pack FlowOrchestrator.slnx
           --configuration Release
           --no-build
           --output ./nupkgs
@@ -71,7 +71,7 @@ jobs:
       - name: Pack (official)
         if: steps.version.outputs.is_preview == 'false'
         run: >
-          dotnet pack
+          dotnet pack FlowOrchestrator.slnx
           --configuration Release
           --no-build
           --output ./nupkgs


### PR DESCRIPTION
## Summary
After the `.sln` → `.slnx` migration in #59, the **publish** workflow's no-arg `dotnet restore` / `build` / `pack` steps now error with `MSB1011: Specify which project or solution file` because the repo contains five `.slnx` files instead of a single auto-discovered solution.

Fix: pin every step in `.github/workflows/publish.yml` to `FlowOrchestrator.slnx`.

## Failing run that motivated this
https://github.com/hoangsnowy/FlowOrchestrator/actions/runs/25443697457/job/74641786326

## Verified locally
- `dotnet restore FlowOrchestrator.slnx` — clean
- `dotnet build FlowOrchestrator.slnx -c Release` — 0 warn / 0 err
- `dotnet pack FlowOrchestrator.slnx -c Release --no-build` — produces the same 8 NuGet packages as before the migration: Core, Dashboard, Hangfire, InMemory, PostgreSQL, ServiceBus, SqlServer, Testing. SampleApp / AppHost / tests skipped via `IsPackable=false` (unchanged).

## Test plan
- [ ] CI green on this PR
- [ ] Next push to `main` (or tag `v*.*.*`) successfully runs the publish workflow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)