### PR TITLE
ci(publish): pin Test (Integration) to net10.0 to remove 3x flake exposure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
         run: dotnet test FlowOrchestrator.UnitTests.slnx --no-build --configuration Release --verbosity normal
 
       - name: Test (Integration)
-        run: dotnet test FlowOrchestrator.IntegrationTests.slnx --no-build --configuration Release --verbosity normal
+        run: dotnet test FlowOrchestrator.IntegrationTests.slnx --no-build --configuration Release -p:TargetFramework=net10.0 --verbosity normal
 
       - name: Determine version
         id: version


### PR DESCRIPTION
## Summary
- Pin `Test (Integration)` step in `publish.yml` to `-p:TargetFramework=net10.0`, matching `ci.yml`.
- Removes 3× ServiceBus emulator Testcontainer startups per release push (was running across net8/net9/net10), eliminating the structural flake source.
- Library packs are unaffected: the multi-TFM `dotnet build` step earlier in the workflow still produces all three TFM outputs; only the **test** TFM is pinned.

## Why
The previous push to `main` ([run 25617451300](https://github.com/hoangsnowy/FlowOrchestrator/actions/runs/25617451300)) failed at this step after **1 h 0 m 55 s** with three ServiceBus integration tests timing out at `ServiceBusEmulatorFixture.cs:60` (Testcontainers `WaitStrategy.WaitUntilAsync` could not see the `azure-sql-edge` / `servicebus-emulator` containers reach readiness). The subsequent `v1.25.1` tag publish passed on retry, confirming flake. The most recent push to `main` ([run 25630872919](https://github.com/hoangsnowy/FlowOrchestrator/actions/runs/25630872919)) was lucky and passed in 5 m, but the structural risk remains.

CI workflow already pins to net10.0 ([ci.yml:75](https://github.com/hoangsnowy/FlowOrchestrator/blob/main/.github/workflows/ci.yml#L75)) and has been stable.

## Test plan
- [ ] CI workflow on this PR is green (proves no behaviour change to CI — same single-TFM run).
- [ ] After merge, observe `Publish NuGet Packages` workflow on `main`: `Test (Integration)` step finishes in ≤ 6 min and workflow conclusion is `success`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)