### PR TITLE
fix(engine): advance DAG after manual retry + 1.26.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.26.1] - 2026-05-14
+
+### Fixed
+
+- **Manual retry now advances DAG dependents** — when a step failed,
+  `RunGraphContinuationAsync` eagerly marked direct blocked dependents as
+  `Skipped` with reason `"Prerequisite status did not satisfy runAfter conditions."`.
+  A subsequent successful manual retry of the failed step previously only reset
+  the step itself; the cascade-skipped dependents stayed final-`Skipped`, the
+  planner ignored them, and downstream work never advanced.
+  `engine.RetryStepAsync` now computes the transitive descendant set in the
+  manifest and calls a new
+  `IFlowRunStore.ResetCascadeSkippedDependentsAsync(runId, stepKeys)` to clear
+  the matching `Skipped` rows plus their claim and dispatch-ledger entries; the
+  existing post-retry continuation then re-evaluates the DAG and dispatches the
+  dependents naturally. Cascade-through-multiple-levels (A → B → C → D, B fails,
+  retry B) works via each step's own continuation. `FlowStepAttempts` rows are
+  preserved as audit trail; `When`-clause skips carry a different reason and
+  are deliberately left untouched. The new interface method has a default
+  no-op so external `IFlowRunStore` implementations continue to compile.
+  Three new unit tests cover the direct, recursive, and reason-preserving
+  cases.
+
+### Changed — dependency bumps
+
+- `Aspire.Hosting.PostgreSQL` 13.2.4 → 13.3.2
+- `Aspire.Hosting.SqlServer` 13.2.4 → 13.3.2
+- `Aspire.Hosting.Azure.ServiceBus` 13.2.4 → 13.3.2
+- `Microsoft.Extensions.{DependencyInjection,DependencyInjection.Abstractions,Diagnostics.HealthChecks,Diagnostics.HealthChecks.Abstractions,Hosting,Hosting.Abstractions,Logging,Logging.Abstractions}` 10.0.7 → 10.0.8
+- `Microsoft.Extensions.TimeProvider.Testing` 9.10.0 → 10.6.0
+- `System.Text.Json` 10.0.7 → 10.0.8
+
+### Known issues — e2e gate waiver
+
+The `e2e` skill `5.4 ForEach iteration` check fails on all four sample-app
+instances with a *pre-existing* bug (present in 1.26.0): `OrderBatchFlow`
+hangs when triggered with a non-empty `orderIds` array because
+`FlowOrchestratorEngine.Step.cs` line 210 wrongly rejects runtime child
+keys like `process_orders.0.validate_order` — `StepCollection.FindStep`
+resolves dot-notation through nested loop scopes and returns the child
+metadata, which trips the "no static DAG step" guard. The fix lives
+behind a separate spawned task. The failure is unrelated to this
+release's manual-retry change; remaining e2e checks (5.1 dashboard,
+5.2 cron, 5.3 manual trigger, 5.5 When-skip, 5.7 WaitForSignal,
+5.8 Hangfire dashboard, 5.9 SQL-only) pass on every applicable instance.
+Waiver documented per CLAUDE.md pre-release gate.
+
 ## [1.26.0] - 2026-05-10
 
 ### Changed — internal Core refactor (zero public-API change)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <RepositoryUrl>https://github.com/hoangsnowy/FlowOrchestrator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/hoangsnowy/FlowOrchestrator</PackageProjectUrl>
-    <VersionPrefix>1.26.0</VersionPrefix>
+    <VersionPrefix>1.26.1</VersionPrefix>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
 
   <!-- Aspire (orchestrator AppHost only) -->
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.4" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.0" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.2.4" />
     <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,7 +67,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.26" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,9 +16,9 @@
 
   <!-- Aspire (orchestrator AppHost only) -->
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.0" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.0" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.2" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.2" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.2" />
   </ItemGroup>
 
   <!--
@@ -40,16 +40,16 @@
     <PackageVersion Include="Hangfire.InMemory" Version="1.0.0" />
     <PackageVersion Include="Hangfire.SqlServer" Version="1.8.23" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Npgsql" Version="10.0.2" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.7" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
 
   <!-- Observability — keep all OpenTelemetry packages on the same release line. -->
@@ -67,7 +67,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.26" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.4" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.2.4" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.2.4" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.0" />
   </ItemGroup>
 
   <!--

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
   <!-- Aspire (orchestrator AppHost only) -->
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.0" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.2.4" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.0" />
     <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.0" />
   </ItemGroup>
 

--- a/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Continuation.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Continuation.cs
@@ -4,6 +4,7 @@ using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution.Internal;
 using FlowOrchestrator.Core.Expressions;
 using FlowOrchestrator.Core.Observability;
+using FlowOrchestrator.Core.Storage;
 
 namespace FlowOrchestrator.Core.Execution;
 
@@ -49,7 +50,7 @@ public sealed partial class FlowOrchestratorEngine
                 ctx.RunId,
                 blockedStepKey,
                 metadata?.Type ?? "Unknown",
-                "Prerequisite status did not satisfy runAfter conditions.").ConfigureAwait(false);
+                StepSkipReasons.PrerequisitesUnmet).ConfigureAwait(false);
 
             if (_observabilityOptions.EnableOpenTelemetry)
             {

--- a/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Step.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Step.cs
@@ -288,6 +288,17 @@ public sealed partial class FlowOrchestratorEngine
 
         await _runStore.RetryStepAsync(runId, stepKey).ConfigureAwait(false);
 
+        // When the original failure of this step caused the DAG continuation to eagerly
+        // mark downstream blocked steps as Skipped (with reason
+        // StepSkipReasons.PrerequisitesUnmet), those records would prevent the planner
+        // from re-evaluating them after the retry succeeds. Clear them transitively so
+        // the post-retry continuation can re-dispatch them naturally.
+        var cascadeDescendants = ComputeTransitiveDescendants(flow, stepKey);
+        if (cascadeDescendants.Count > 0)
+        {
+            await _runStore.ResetCascadeSkippedDependentsAsync(runId, cascadeDescendants).ConfigureAwait(false);
+        }
+
         await PublishEventSafelyAsync(new StepRetriedEvent
         {
             RunId = runId,
@@ -306,6 +317,47 @@ public sealed partial class FlowOrchestratorEngine
         ctx.TriggerHeaders = await _outputsRepository.GetTriggerHeadersAsync(runId).ConfigureAwait(false);
 
         return await RunStepAsync(ctx, flow, step, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the transitive set of top-level step keys whose <c>RunAfter</c> chain
+    /// (re)leads back to <paramref name="rootStepKey"/>. Used by <see cref="RetryStepAsync"/>
+    /// to identify the dependents whose cascade-skip records must be cleared so the post-retry
+    /// continuation can re-evaluate them. Scoped/loop child steps are intentionally
+    /// ignored — only the top-level manifest is walked.
+    /// </summary>
+    private static IReadOnlyCollection<string> ComputeTransitiveDescendants(IFlowDefinition flow, string rootStepKey)
+    {
+        var descendants = new HashSet<string>(StringComparer.Ordinal);
+        var frontier = new Queue<string>();
+        frontier.Enqueue(rootStepKey);
+
+        while (frontier.Count > 0)
+        {
+            var current = frontier.Dequeue();
+            foreach (var kvp in flow.Manifest.Steps)
+            {
+                var key = kvp.Key;
+                if (string.Equals(key, rootStepKey, StringComparison.Ordinal) || descendants.Contains(key))
+                {
+                    continue;
+                }
+
+                var meta = kvp.Value;
+                if (meta is null || meta.RunAfter is null || meta.RunAfter.Count == 0)
+                {
+                    continue;
+                }
+
+                if (meta.RunAfter.ContainsKey(current))
+                {
+                    descendants.Add(key);
+                    frontier.Enqueue(key);
+                }
+            }
+        }
+
+        return descendants;
     }
 
     private async Task RecordSkippedCurrentStepAsync(IExecutionContext ctx, IFlowDefinition flow, IStepInstance step, string terminalStatus)

--- a/src/FlowOrchestrator.Core/Storage/IFlowRunStore.cs
+++ b/src/FlowOrchestrator.Core/Storage/IFlowRunStore.cs
@@ -92,6 +92,25 @@ public interface IFlowRunStore
     Task RetryStepAsync(Guid runId, string stepKey);
 
     /// <summary>
+    /// Clears cascade-skip records (<see cref="StepSkipReasons.PrerequisitesUnmet"/>) for the
+    /// given step keys so the DAG planner re-evaluates them after a manual retry of an
+    /// upstream step. Removes the step row, claim row, and dispatch-ledger row for any
+    /// matching descendant — the attempt history (<c>FlowStepAttempts</c>) is preserved so
+    /// the dashboard still surfaces the prior "Skipped" attempt as audit trail.
+    /// </summary>
+    /// <remarks>
+    /// Only rows whose status is <c>Skipped</c> AND whose error message exactly matches
+    /// <see cref="StepSkipReasons.PrerequisitesUnmet"/> are cleared. Steps skipped via
+    /// <c>When</c>-clause evaluation carry a different reason and are intentionally left
+    /// untouched. Idempotent — calling with keys that have no matching row is a no-op.
+    /// Default implementation is a no-op so external <see cref="IFlowRunStore"/>
+    /// implementations continue to compile; in that case the post-retry DAG advance
+    /// behaves as pre-fix (downstream steps stay <c>Skipped</c>).
+    /// </remarks>
+    Task ResetCascadeSkippedDependentsAsync(Guid runId, IReadOnlyCollection<string> stepKeys)
+        => Task.CompletedTask;
+
+    /// <summary>
     /// Atomically records that a step has been dispatched for execution.
     /// Returns <see langword="true"/> if this is the first dispatch for this step in this run;
     /// <see langword="false"/> if the step was already dispatched (idempotent guard — caller should skip).

--- a/src/FlowOrchestrator.Core/Storage/StepSkipReasons.cs
+++ b/src/FlowOrchestrator.Core/Storage/StepSkipReasons.cs
@@ -1,0 +1,22 @@
+namespace FlowOrchestrator.Core.Storage;
+
+/// <summary>
+/// Well-known reason strings persisted on <c>FlowSteps.ErrorMessage</c> when a step
+/// is marked <see cref="Abstractions.StepStatus.Skipped"/>.
+/// </summary>
+/// <remarks>
+/// These constants are part of the public storage contract — the engine writes them
+/// at skip time and reads them back when reversing cascade-skips on retry.
+/// External tooling that inspects step records can rely on the exact text.
+/// </remarks>
+public static class StepSkipReasons
+{
+    /// <summary>
+    /// Recorded when a step's <c>runAfter</c> dependency reached a final status that
+    /// the dependency clause did not accept (e.g. <c>RunAfter[B] = Succeeded</c> but
+    /// B finished as <c>Failed</c>). Skips bearing this reason are reversible: a
+    /// successful manual retry of the upstream step clears them so the downstream
+    /// step can be re-evaluated.
+    /// </summary>
+    public const string PrerequisitesUnmet = "Prerequisite status did not satisfy runAfter conditions.";
+}

--- a/src/FlowOrchestrator.InMemory/InMemoryFlowRunStore.cs
+++ b/src/FlowOrchestrator.InMemory/InMemoryFlowRunStore.cs
@@ -358,6 +358,56 @@ public sealed class InMemoryFlowRunStore :
         return Task.CompletedTask;
     }
 
+    public Task ResetCascadeSkippedDependentsAsync(Guid runId, IReadOnlyCollection<string> stepKeys)
+    {
+        if (stepKeys is null || stepKeys.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        foreach (var stepKey in stepKeys)
+        {
+            // Only clear rows that were skipped specifically because an upstream final
+            // status didn't match — When-clause skips and manual cancellations carry a
+            // different reason and stay intact.
+            if (!_steps.TryGetValue((runId, stepKey), out var step))
+            {
+                continue;
+            }
+            if (!string.Equals(step.Status, StepStatus.Skipped.ToString(), StringComparison.Ordinal))
+            {
+                continue;
+            }
+            if (!string.Equals(step.ErrorMessage, StepSkipReasons.PrerequisitesUnmet, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            _steps.TryRemove((runId, stepKey), out _);
+            if (_stepKeysByRun.TryGetValue(runId, out var keySet))
+            {
+                keySet.TryRemove(stepKey, out _);
+            }
+
+            _stepClaims.TryRemove((runId, stepKey), out _);
+            if (_claimsByRun.TryGetValue(runId, out var claimSet))
+            {
+                claimSet.TryRemove(stepKey, out _);
+            }
+
+            _stepDispatches.TryRemove((runId, stepKey), out _);
+            if (_dispatchesByRun.TryGetValue(runId, out var dispatchSet))
+            {
+                dispatchSet.TryRemove(stepKey, out _);
+            }
+            // FlowStepAttempts entries are preserved so the dashboard still surfaces the
+            // prior cascade-skipped attempt as an audit trail; only the latest-status row
+            // is cleared so the planner re-evaluates.
+        }
+
+        return Task.CompletedTask;
+    }
+
     public Task<bool> TryRecordDispatchAsync(Guid runId, string stepKey, CancellationToken ct = default)
     {
         var added = _stepDispatches.TryAdd((runId, stepKey), null);

--- a/src/FlowOrchestrator.PostgreSQL/PostgreSqlFlowRunStore.cs
+++ b/src/FlowOrchestrator.PostgreSQL/PostgreSqlFlowRunStore.cs
@@ -319,6 +319,36 @@ public sealed class PostgreSqlFlowRunStore :
             new { RunId = runId, StepKey = stepKey });
     }
 
+    public async Task ResetCascadeSkippedDependentsAsync(Guid runId, IReadOnlyCollection<string> stepKeys)
+    {
+        if (stepKeys is null || stepKeys.Count == 0)
+        {
+            return;
+        }
+
+        var keyArray = stepKeys.ToArray();
+        await using var conn = new NpgsqlConnection(_connectionString);
+        // flow_step_attempts rows are intentionally NOT deleted — the prior cascade-skip
+        // attempt stays as audit history for the dashboard. Only the latest-status row
+        // (flow_steps) and the gate rows are cleared so the engine re-evaluates on the
+        // next continuation pass.
+        await conn.ExecuteAsync(
+            """
+            DELETE FROM flow_steps
+            WHERE run_id = @RunId
+              AND step_key = ANY(@StepKeys)
+              AND status = 'Skipped'
+              AND error_message = @Reason;
+
+            DELETE FROM flow_step_claims
+            WHERE run_id = @RunId AND step_key = ANY(@StepKeys);
+
+            DELETE FROM flow_step_dispatches
+            WHERE run_id = @RunId AND step_key = ANY(@StepKeys);
+            """,
+            new { RunId = runId, StepKeys = keyArray, Reason = StepSkipReasons.PrerequisitesUnmet }).ConfigureAwait(false);
+    }
+
     public async Task<bool> TryRecordDispatchAsync(Guid runId, string stepKey, CancellationToken ct = default)
     {
         await using var conn = new NpgsqlConnection(_connectionString);

--- a/src/FlowOrchestrator.SqlServer/SqlFlowRunStore.cs
+++ b/src/FlowOrchestrator.SqlServer/SqlFlowRunStore.cs
@@ -270,6 +270,35 @@ public sealed class SqlFlowRunStore :
             new { RunId = runId, StepKey = stepKey });
     }
 
+    public async Task ResetCascadeSkippedDependentsAsync(Guid runId, IReadOnlyCollection<string> stepKeys)
+    {
+        if (stepKeys is null || stepKeys.Count == 0)
+        {
+            return;
+        }
+
+        await using var conn = new SqlConnection(_connectionString);
+        // FlowStepAttempts rows are intentionally NOT deleted — the prior cascade-skip
+        // attempt stays as audit history for the dashboard. Only the latest-status row
+        // (FlowSteps) and the gate rows (Claims / Dispatches) are cleared so the engine
+        // re-evaluates the step on the next continuation pass.
+        await conn.ExecuteAsync(
+            """
+            DELETE FROM FlowSteps
+            WHERE RunId = @RunId
+              AND StepKey IN @StepKeys
+              AND Status = 'Skipped'
+              AND ErrorMessage = @Reason;
+
+            DELETE FROM FlowStepClaims
+            WHERE RunId = @RunId AND StepKey IN @StepKeys;
+
+            DELETE FROM FlowStepDispatches
+            WHERE RunId = @RunId AND StepKey IN @StepKeys;
+            """,
+            new { RunId = runId, StepKeys = stepKeys, Reason = StepSkipReasons.PrerequisitesUnmet }).ConfigureAwait(false);
+    }
+
     public async Task<bool> TryRecordDispatchAsync(Guid runId, string stepKey, CancellationToken ct = default)
     {
         await using var conn = new SqlConnection(_connectionString);

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RetryStepCascadeAdvanceTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RetryStepCascadeAdvanceTests.cs
@@ -1,0 +1,292 @@
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Configuration;
+using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Observability;
+using FlowOrchestrator.Core.Storage;
+using FlowOrchestrator.InMemory;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using CoreExecutionContext = FlowOrchestrator.Core.Execution.ExecutionContext;
+
+namespace FlowOrchestrator.Core.Tests.Execution;
+
+/// <summary>
+/// Regression for the manual-retry → DAG-advance gap: when a step's failure caused the
+/// continuation to eagerly mark downstream blocked steps as <see cref="StepStatus.Skipped"/>
+/// (<see cref="StepSkipReasons.PrerequisitesUnmet"/>), a successful manual retry of the
+/// failed step must clear those cascade-skip records and re-evaluate the DAG so the
+/// dependents actually run. Pre-fix the retry only reset the failed step itself — its
+/// downstream stayed Skipped forever.
+/// </summary>
+public sealed class RetryStepCascadeAdvanceTests
+{
+    private readonly IFlowExecutor _flowExecutor = Substitute.For<IFlowExecutor>();
+    private readonly IFlowGraphPlanner _graphPlanner = new FlowGraphPlanner();
+    private readonly IStepExecutor _stepExecutor = Substitute.For<IStepExecutor>();
+    private readonly IFlowStore _flowStore = Substitute.For<IFlowStore>();
+    private readonly IOutputsRepository _outputsRepo = Substitute.For<IOutputsRepository>();
+    private readonly IExecutionContextAccessor _ctxAccessor = Substitute.For<IExecutionContextAccessor>();
+    private readonly IFlowRepository _flowRepo = Substitute.For<IFlowRepository>();
+    private readonly ILogger<FlowOrchestratorEngine> _logger =
+        Substitute.For<ILogger<FlowOrchestratorEngine>>();
+
+    private static IFlowDefinition MakeChainedFlow(Guid id, params string[] stepKeys)
+    {
+        var flow = Substitute.For<IFlowDefinition>();
+        flow.Id.Returns(id);
+        var steps = new StepCollection();
+        for (var i = 0; i < stepKeys.Length; i++)
+        {
+            var key = stepKeys[i];
+            var meta = new StepMetadata { Type = "Work" };
+            if (i > 0)
+            {
+                meta.RunAfter[stepKeys[i - 1]] = [StepStatus.Succeeded];
+            }
+            steps[key] = meta;
+        }
+        flow.Manifest.Returns(new FlowManifest { Steps = steps });
+        return flow;
+    }
+
+    /// <summary>
+    /// Self-draining test rig: the substitute dispatcher captures every dispatch call into
+    /// a queue; <see cref="DrainAsync"/> pulls each captured step off the queue and invokes
+    /// the engine inline. Mirrors the InMemory runtime "dispatch → execute" loop without
+    /// scheduling delays or timing.
+    /// </summary>
+    private sealed class TestRig
+    {
+        public required FlowOrchestratorEngine Engine { get; init; }
+        public required InMemoryFlowRunStore Store { get; init; }
+        public required Queue<IStepInstance> PendingDispatch { get; init; }
+        public required List<string> EnqueuedKeys { get; init; }
+
+        public async Task DrainAsync(IFlowDefinition flow)
+        {
+            while (PendingDispatch.Count > 0)
+            {
+                var step = PendingDispatch.Dequeue();
+                await Engine.RunStepAsync(
+                    new CoreExecutionContext { RunId = step.RunId },
+                    flow,
+                    step);
+            }
+        }
+    }
+
+    private TestRig BuildRig(IFlowDefinition flow, Func<string, IStepResult> resultForStep)
+    {
+        var store = new InMemoryFlowRunStore();
+        var dispatcher = Substitute.For<IStepDispatcher>();
+        var pending = new Queue<IStepInstance>();
+        var enqueued = new List<string>();
+
+        ValueTask<string?> Capture(NSubstitute.Core.CallInfo call)
+        {
+            var step = call.Arg<IStepInstance>();
+            enqueued.Add(step.Key);
+            pending.Enqueue(step);
+            return new ValueTask<string?>("job-" + step.Key);
+        }
+
+        dispatcher.EnqueueStepAsync(
+                Arg.Any<IExecutionContext>(),
+                Arg.Any<IFlowDefinition>(),
+                Arg.Any<IStepInstance>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Capture);
+
+        dispatcher.ScheduleStepAsync(
+                Arg.Any<IExecutionContext>(),
+                Arg.Any<IFlowDefinition>(),
+                Arg.Any<IStepInstance>(),
+                Arg.Any<TimeSpan>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Capture);
+
+        _stepExecutor.ExecuteAsync(
+                Arg.Any<IExecutionContext>(),
+                Arg.Any<IFlowDefinition>(),
+                Arg.Any<IStepInstance>())
+            .Returns(call =>
+            {
+                var step = call.Arg<IStepInstance>();
+                return new ValueTask<IStepResult>(resultForStep(step.Key));
+            });
+
+        _flowRepo.GetAllFlowsAsync().Returns(new ValueTask<IReadOnlyList<IFlowDefinition>>(new[] { flow }));
+
+        var engine = new FlowOrchestratorEngine(
+            dispatcher,
+            _flowExecutor,
+            _graphPlanner,
+            _stepExecutor,
+            _flowStore,
+            store,
+            _outputsRepo,
+            _ctxAccessor,
+            _flowRepo,
+            [store],
+            [],
+            new FlowRunControlOptions(),
+            new FlowObservabilityOptions { EnableEventPersistence = false, EnableOpenTelemetry = false },
+            new FlowOrchestratorTelemetry(),
+            _logger);
+
+        return new TestRig
+        {
+            Engine = engine,
+            Store = store,
+            PendingDispatch = pending,
+            EnqueuedKeys = enqueued
+        };
+    }
+
+    [Fact]
+    public async Task RetryStepAsync_AfterDownstreamCascadeSkip_ReDispatchesDirectDependent()
+    {
+        // Arrange — A → B → C; A succeeds, B fails on first attempt and succeeds on retry.
+        var flow = MakeChainedFlow(Guid.NewGuid(), "a", "b", "c");
+        var runId = Guid.NewGuid();
+        var bAttempt = 0;
+
+        var rig = BuildRig(flow, key => key switch
+        {
+            "b" => ++bAttempt == 1
+                ? new StepResult { Key = "b", Status = StepStatus.Failed, FailedReason = "boom" }
+                : new StepResult { Key = "b", Status = StepStatus.Succeeded },
+            _ => new StepResult { Key = key, Status = StepStatus.Succeeded }
+        });
+
+        await rig.Store.StartRunAsync(flow.Id, "ChainFlow", runId, "manual", null, null);
+
+        // Act 1 — run A; the continuation enqueues B → drain runs B → B fails →
+        // continuation cascade-skips C → run terminates Failed.
+        await rig.Engine.RunStepAsync(
+            new CoreExecutionContext { RunId = runId },
+            flow,
+            new StepInstance("a", "Work") { RunId = runId });
+        await rig.DrainAsync(flow);
+
+        var statusesAfterFailure = await rig.Store.GetStepStatusesAsync(runId);
+        Assert.Equal(StepStatus.Succeeded, statusesAfterFailure["a"]);
+        Assert.Equal(StepStatus.Failed, statusesAfterFailure["b"]);
+        Assert.Equal(StepStatus.Skipped, statusesAfterFailure["c"]);
+        Assert.Equal("Failed", await rig.Store.GetRunStatusAsync(runId));
+
+        rig.EnqueuedKeys.Clear();
+
+        // Act 2 — manually retry B; the cascade-skip on C must be cleared so that B's
+        // post-retry continuation re-evaluates C and dispatches it.
+        await rig.Engine.RetryStepAsync(flow.Id, runId, "b");
+        await rig.DrainAsync(flow);
+
+        // Assert — C dispatched and ran; the run is now Succeeded.
+        var finalStatuses = await rig.Store.GetStepStatusesAsync(runId);
+        Assert.Equal(StepStatus.Succeeded, finalStatuses["b"]);
+        Assert.Equal(StepStatus.Succeeded, finalStatuses["c"]);
+        Assert.Equal("Succeeded", await rig.Store.GetRunStatusAsync(runId));
+        Assert.Contains("c", rig.EnqueuedKeys);
+    }
+
+    [Fact]
+    public async Task RetryStepAsync_AfterDownstreamCascadeSkip_RecursivelyAdvancesAllDescendants()
+    {
+        // Arrange — A → B → C → D; B fails initially, succeeds on retry. The continuation
+        // only propagates skip ONE level (C is marked Skipped); D stays unscheduled (absent
+        // from the status map) because its prerequisite C is not yet final at the moment
+        // the eager-skip loop runs. After the retry of B, the natural per-step continuation
+        // chain should advance: B → C → D. The fix must:
+        //   1. Clear C's cascade-skip record (direct dependent of B), and
+        //   2. Let C's own post-completion continuation dispatch D (transitive dependent).
+        var flow = MakeChainedFlow(Guid.NewGuid(), "a", "b", "c", "d");
+        var runId = Guid.NewGuid();
+        var bAttempt = 0;
+
+        var rig = BuildRig(flow, key => key switch
+        {
+            "b" => ++bAttempt == 1
+                ? new StepResult { Key = "b", Status = StepStatus.Failed, FailedReason = "boom" }
+                : new StepResult { Key = "b", Status = StepStatus.Succeeded },
+            _ => new StepResult { Key = key, Status = StepStatus.Succeeded }
+        });
+
+        await rig.Store.StartRunAsync(flow.Id, "ChainFlow", runId, "manual", null, null);
+
+        // Act 1 — initial run; B fails → C cascade-skipped (direct dependent), D stays
+        // absent from the status map → run terminates Failed.
+        await rig.Engine.RunStepAsync(
+            new CoreExecutionContext { RunId = runId },
+            flow,
+            new StepInstance("a", "Work") { RunId = runId });
+        await rig.DrainAsync(flow);
+
+        var statusesAfterFailure = await rig.Store.GetStepStatusesAsync(runId);
+        Assert.Equal(StepStatus.Succeeded, statusesAfterFailure["a"]);
+        Assert.Equal(StepStatus.Failed, statusesAfterFailure["b"]);
+        Assert.Equal(StepStatus.Skipped, statusesAfterFailure["c"]);
+        Assert.False(statusesAfterFailure.ContainsKey("d"));
+        Assert.Equal("Failed", await rig.Store.GetRunStatusAsync(runId));
+
+        rig.EnqueuedKeys.Clear();
+
+        // Act 2 — retry B. Reset clears C (direct cascade-skipped descendant). D was never
+        // recorded so nothing to reset there; once C succeeds the engine will dispatch D
+        // through the normal continuation path.
+        await rig.Engine.RetryStepAsync(flow.Id, runId, "b");
+        await rig.DrainAsync(flow);
+
+        // Assert — every step ran in sequence, final run status is Succeeded.
+        var finalStatuses = await rig.Store.GetStepStatusesAsync(runId);
+        Assert.Equal(StepStatus.Succeeded, finalStatuses["b"]);
+        Assert.Equal(StepStatus.Succeeded, finalStatuses["c"]);
+        Assert.Equal(StepStatus.Succeeded, finalStatuses["d"]);
+        Assert.Equal("Succeeded", await rig.Store.GetRunStatusAsync(runId));
+        Assert.Contains("c", rig.EnqueuedKeys);
+        Assert.Contains("d", rig.EnqueuedKeys);
+    }
+
+    [Fact]
+    public async Task RetryStepAsync_DoesNotResetSkippedStepsBearingDifferentReason()
+    {
+        // Arrange — flow A→B→C; B fails causing C to be cascade-skipped. Inject a separate
+        // step Z marked Skipped with a non-sentinel reason (simulating a When-clause skip).
+        // After retrying B, only C (sentinel reason) is cleared; Z must remain Skipped.
+        var flow = MakeChainedFlow(Guid.NewGuid(), "a", "b", "c");
+        var runId = Guid.NewGuid();
+        var bAttempt = 0;
+
+        var rig = BuildRig(flow, key => key switch
+        {
+            "b" => ++bAttempt == 1
+                ? new StepResult { Key = "b", Status = StepStatus.Failed, FailedReason = "boom" }
+                : new StepResult { Key = "b", Status = StepStatus.Succeeded },
+            _ => new StepResult { Key = key, Status = StepStatus.Succeeded }
+        });
+
+        await rig.Store.StartRunAsync(flow.Id, "ChainFlow", runId, "manual", null, null);
+
+        await rig.Engine.RunStepAsync(
+            new CoreExecutionContext { RunId = runId },
+            flow,
+            new StepInstance("a", "Work") { RunId = runId });
+        await rig.DrainAsync(flow);
+
+        var afterFailure = await rig.Store.GetStepStatusesAsync(runId);
+        Assert.Equal(StepStatus.Skipped, afterFailure["c"]);
+
+        // Inject a When-clause-style skip for an unrelated step key.
+        await ((IFlowRunRuntimeStore)rig.Store).RecordSkippedStepAsync(
+            runId, "z", "Work", "When clause 'x == 1' evaluated to false (0).");
+
+        // Act
+        await rig.Engine.RetryStepAsync(flow.Id, runId, "b");
+        await rig.DrainAsync(flow);
+
+        // Assert — C cleared and now Succeeded; Z untouched.
+        var final = await rig.Store.GetStepStatusesAsync(runId);
+        Assert.Equal(StepStatus.Succeeded, final["c"]);
+        Assert.Equal(StepStatus.Skipped, final["z"]);
+    }
+}


### PR DESCRIPTION
## Summary

- **Bug fix**: manual retry of a failed step now advances cascade-skipped DAG dependents. Pre-fix the engine eagerly marked direct dependents `Skipped` on first failure and the retry only reset the failed step — downstream work stayed blocked. `engine.RetryStepAsync` now walks transitive descendants in the manifest and clears reversible cascade-skip records (`StepSkipReasons.PrerequisitesUnmet`) via a new `IFlowRunStore.ResetCascadeSkippedDependentsAsync`. Default no-op on the interface keeps external stores compiling.
- **Dependency bumps** (closes #65 #66 #67 #68): Aspire 13.2.4 → 13.3.2, Microsoft.Extensions.* 10.0.7 → 10.0.8, TimeProvider.Testing 9.10.0 → 10.6.0, System.Text.Json 10.0.7 → 10.0.8. Microsoft.AspNetCore.TestHost stays pinned at 8.0.26 (major-version cross deferred).
- **Release**: bump `VersionPrefix` 1.26.0 → 1.26.1, CHANGELOG entry with full notes.

## What changed

- `IFlowRunStore.ResetCascadeSkippedDependentsAsync` + impls in `InMemoryFlowRunStore`, `SqlFlowRunStore`, `PostgreSqlFlowRunStore`. Deletes the `Skipped` step row + claim ledger + dispatch ledger when the reason matches the sentinel; preserves `FlowStepAttempts` as audit trail.
- `FlowOrchestratorEngine.RetryStepAsync` computes the transitive descendant set via BFS over `flow.Manifest.Steps` and calls the new method before invoking `RunStepAsync`. Cascade through multiple levels (A→B→C→D) flows through each step's own post-completion continuation.
- New sentinel constant `StepSkipReasons.PrerequisitesUnmet` shared between writer (`FlowOrchestratorEngine.Continuation`) and readers (3 storage impls).
- Three new unit tests in `RetryStepCascadeAdvanceTests`: direct dependent, recursive descendants, non-sentinel skip preservation.

## Test plan

- [x] `dotnet build` clean — 0 warnings, 0 errors.
- [x] `dotnet test FlowOrchestrator.UnitTests.slnx` — 523/523 × 3 TFMs (+3 new retry-cascade cases).
- [x] `dotnet test FlowOrchestrator.IntegrationTests.slnx` — 291/291 × 3 TFMs.
- [x] `dotnet test FlowOrchestrator.RegressionTests.slnx` — 54/54 × 3 TFMs (incl. `ManualRetryStateResetTests`).
- [x] `e2e` skill matrix on 4 sample-app instances: 25/36 pass, 4 fail = pre-existing `5.4 ForEach iteration` bug (tracked separately, waiver in CHANGELOG), 7 skipped (`5.6 webhook + HMAC` needs manual GitHub-scheme setup; `5.9 SQL-only` skipped on non-SqlServer instances).

## Reviewer notes

The e2e `5.4 ForEach` fail is documented in the CHANGELOG `Known issues — e2e gate waiver` section. Root cause: `FlowOrchestratorEngine.Step.cs:210` rejects runtime child keys like `process_orders.0.validate_order` because `StepCollection.FindStep` resolves dot-notation through nested loop scopes. Pre-existing on 1.26.0; unrelated to this release's manual-retry change. A separate task chip was spawned to land the fix in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)