### PR TITLE
fix(codeql): close 12 post-merge alerts via real refactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,54 @@ inline-comment suppression, no query-pack drops.
 - **`cs/constant-condition` ×2** — `ProcessOrderItemStep` tautological
   switch arm + `CallExternalApiStep` `(x || !x)` guard removed.
 
+#### Post-merge follow-up — 12 alerts still surfaced after `#71` merged
+
+The first sweep (#71) used inline `// codeql[cs/...]` comments next to side-
+effecting loops and the anonymous-type unification casts in
+`/api/schedules`. GitHub CodeQL does **not** honour those comments — it
+re-flagged 12 of them on the post-merge re-scan of `main`. Replaced with
+real refactors:
+
+- **`cs/useless-upcast` ×3** — `(Guid?)null` →  `default(Guid?)` in
+  `FlowOrchestratorEngine.Trigger.cs`; `(DateTime?)null` → `default(DateTime?)`
+  in `DashboardServiceCollectionExtensions` `/api/schedules`.
+- **`cs/linq/missed-select` ×5** — `SseFlowEventBroadcaster` iterates
+  `_connections.Values`; `FlowMermaidExporter` projects trigger IDs via
+  `.Select(t => "T_" + SafeId(t))`; `WebhookSecurityPipeline` resolves preset
+  CIDR lists via `.Select(KnownPublisherCidrs.TryGet).Where(...)`;
+  `DashboardServiceCollectionExtensions.HasEncoding` splits + trims via
+  `.Split(',').Select(p => p.Trim())` in both the outer and inner loops.
+- **`cs/linq/missed-where` ×1** — `InMemoryFlowRunStore.GetTimeseriesAsync`
+  filters `_runs.Values` via chained `.Where()` before the bucket-index
+  calculation.
+- **`cs/local-not-disposed` ×2** — `InMemoryStepRunnerHostedService` now
+  owns the per-runner `SemaphoreSlim` as a field with an override of
+  `Dispose`; `CallExternalApiStep` wraps `HttpRequestMessage` and
+  `HttpResponseMessage` in `using var`.
+- **`cs/catch-of-all-exceptions` ×1** — replaced the fake `// codeql[...]`
+  marker above `FlowOrchestratorEngine.Step.cs` handler-boundary catch with
+  a real WHY comment explaining the by-design swallow.
+
+The remaining 9 alerts are genuine false positives or won't-fix
+documented behaviour and were dismissed via the code-scanning API:
+
+- **`cs/useless-cast-to-self` ×3** in `/api/schedules` — `(string?)""`
+  casts are load-bearing for NRT (anonymous-type member must be `string?`
+  to unify with `activeJobs`' shape under `Concat`); CodeQL ignores NRT
+  annotations and reports as self-cast.
+- **`cs/linq/missed-where` ×3** — `HmacSignatureVerifier` constant-time
+  loop (must not short-circuit, security); `RunAfterConditionJsonConverter`
+  + `JsonValueConversion` both assign `out` parameters (cannot be
+  expressed as LINQ predicates).
+- **`cs/static-field-written-by-instance` ×3** — `TestFlow.cs` +
+  `ServiceBusCronRoundTripTests.cs` deliberately share an
+  `Interlocked.Increment`-guarded counter across DI scopes for test
+  signalling.
+
+All comments left in the source explain the WHY (not the `codeql[...]`
+suppression marker), so a future reader understands the constraint
+without relying on a parser that does not exist.
+
 #### Quality findings (170 → 0)
 
 - **`cs/catch-of-all-exceptions` ×37** — converted to

--- a/samples/FlowOrchestrator.SampleApp/Steps/CallExternalApiStep.cs
+++ b/samples/FlowOrchestrator.SampleApp/Steps/CallExternalApiStep.cs
@@ -59,7 +59,7 @@ public sealed class CallExternalApiStep : PollableStepHandler<CallExternalApiSte
             ctx.RunId, input.PollAttempt ?? 1, method, path);
 
         var client  = _httpClientFactory.CreateClient("ExternalApi");
-        var request = new HttpRequestMessage(new HttpMethod(method), path);
+        using var request = new HttpRequestMessage(new HttpMethod(method), path);
 
         if (input.Body is not null)
         {
@@ -67,7 +67,7 @@ public sealed class CallExternalApiStep : PollableStepHandler<CallExternalApiSte
             request.Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
         }
 
-        var response = await client.SendAsync(request).ConfigureAwait(false);
+        using var response = await client.SendAsync(request).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
         var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/src/FlowOrchestrator.Core/Diagnostics/FlowMermaidExporter.cs
+++ b/src/FlowOrchestrator.Core/Diagnostics/FlowMermaidExporter.cs
@@ -161,10 +161,8 @@ public static class FlowMermaidExporter
             return;
         }
 
-        // codeql[cs/linq/missed-select] loop has side effects beyond projection: emits StringBuilder edges, one per (trigger × entry) pair.
-        foreach (var triggerName in manifest.Triggers.Keys)
+        foreach (var triggerId in manifest.Triggers.Keys.Select(t => "T_" + SafeId(t)))
         {
-            var triggerId = "T_" + SafeId(triggerName);
             foreach (var entry in entrySteps)
             {
                 sb.Append("    ").Append(triggerId).Append(" --> ").Append(SafeId(entry)).AppendLine();

--- a/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Step.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Step.cs
@@ -89,7 +89,9 @@ public sealed partial class FlowOrchestratorEngine
                 result = await _stepExecutor.ExecuteAsync(ctx, flow, step).ConfigureAwait(false);
                 await _outputsRepository.SaveStepOutputAsync(ctx, flow, step, result).ConfigureAwait(false);
             }
-            // codeql[cs/catch-of-all-exceptions] handler boundary: any exception (incl. OCE) becomes a Failed StepResult by design
+            // Handler boundary: any exception (including OperationCanceledException) is captured
+            // and converted to a Failed StepResult. Step execution must never propagate exceptions
+            // out of RunStepAsync — the engine catches everything and persists the failure.
             catch (Exception ex)
             {
                 handlerException = ex;

--- a/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Trigger.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Trigger.cs
@@ -45,7 +45,7 @@ public sealed partial class FlowOrchestratorEngine
             {
                 EngineLog.TriggerRejectedDisabledFlow(_logger, triggerContext.Flow.Id, triggerContext.Trigger.Key);
                 activity?.SetTag("flow.disabled", true);
-                return new { runId = (Guid?)null, disabled = true };
+                return new { runId = default(Guid?), disabled = true };
             }
 
             var idempotencyKey = TryGetIdempotencyKey(triggerContext.TriggerHeaders);

--- a/src/FlowOrchestrator.Core/Serialization/JsonValueConversion.cs
+++ b/src/FlowOrchestrator.Core/Serialization/JsonValueConversion.cs
@@ -200,7 +200,8 @@ internal static class JsonValueConversion
         out object? value)
     {
         value = null;
-        // codeql[cs/linq/missed-where] loop has side effects beyond projection: assigns the `out value` parameter via TryGetValue on first match.
+        // Loop assigns the `out value` parameter via TryGetValue on first match — cannot be
+        // expressed as a pure Where().Any() because LINQ predicates can't write to out parameters.
         foreach (var candidateName in GetCandidateNames(property, options))
         {
             if (lookup.TryGetValue(candidateName, out value))

--- a/src/FlowOrchestrator.Core/Serialization/RunAfterConditionJsonConverter.cs
+++ b/src/FlowOrchestrator.Core/Serialization/RunAfterConditionJsonConverter.cs
@@ -91,7 +91,8 @@ public sealed class RunAfterConditionJsonConverter : JsonConverter<RunAfterCondi
 
     private static bool TryGetProperty(JsonElement element, string name, out JsonElement value)
     {
-        // codeql[cs/linq/missed-where] loop has side effects beyond projection: assigns the `out value` parameter on first match.
+        // Loop assigns the `out value` parameter on first match — cannot be expressed as a
+        // pure Where().Any() because LINQ predicates can't write to out parameters.
         foreach (var prop in element.EnumerateObject())
         {
             if (string.Equals(prop.Name, name, StringComparison.OrdinalIgnoreCase))

--- a/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
@@ -1038,11 +1038,12 @@ public static class DashboardServiceCollectionExtensions
                 flowName = s.FlowName,
                 triggerKey = s.TriggerKey,
                 cron = s.CronOverride ?? "",
-                nextExecution = (DateTime?)null,
-                lastExecution = (DateTime?)null,
-                // Literals widened to string? so the anonymous type matches activeJobs' nullable shape
-                // — keeps Concat happy without relaxing nullability annotations elsewhere.
-                // codeql[cs/useless-cast-to-self] cast is required for anonymous-type member type unification (string vs string?).
+                nextExecution = default(DateTime?),
+                lastExecution = default(DateTime?),
+                // Casts to string? are load-bearing for NRT — keep anonymous-type member shape
+                // identical to activeJobs (whose source IRecurringJobInfo has nullable strings),
+                // otherwise the Concat below fails CS8620. CodeQL strips NRT annotations and
+                // reports these as "cast-to-self"; they are not. False positives.
                 lastJobId = (string?)"",
                 lastJobState = (string?)"Paused",
                 timeZoneId = (string?)"",
@@ -1311,10 +1312,8 @@ public static class DashboardServiceCollectionExtensions
             return false;
         }
 
-        // codeql[cs/linq/missed-select] loop has side effects beyond projection: short-circuits with multiple early returns based on q-value parsing.
-        foreach (var part in acceptEncoding.Split(','))
+        foreach (var entry in acceptEncoding.Split(',').Select(p => p.Trim()))
         {
-            var entry = part.Trim();
             if (entry.Length == 0)
             {
                 continue;
@@ -1335,10 +1334,8 @@ public static class DashboardServiceCollectionExtensions
 
             // Walk the ";q=<value>" parameter list. Anything that's not a
             // valid double, or any q-value > 0, is treated as accepted.
-            // codeql[cs/linq/missed-select] loop has side effects beyond projection: short-circuits on first q parameter (returns false for q=0, true otherwise).
-            foreach (var rawParam in entry[(semi + 1)..].Split(';'))
+            foreach (var p in entry[(semi + 1)..].Split(';').Select(x => x.Trim()))
             {
-                var p = rawParam.Trim();
                 if (!p.StartsWith("q=", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;

--- a/src/FlowOrchestrator.Dashboard/Notifications/SseFlowEventBroadcaster.cs
+++ b/src/FlowOrchestrator.Dashboard/Notifications/SseFlowEventBroadcaster.cs
@@ -48,10 +48,8 @@ public sealed class SseFlowEventBroadcaster : IFlowEventNotifier
 
         // Snapshot is unnecessary — ConcurrentDictionary enumeration is safe and we tolerate
         // a connection registering or disposing mid-publish (it just gets the next event or none).
-        // codeql[cs/linq/missed-select] loop has side effects beyond projection: writes the event to every matching connection's channel.
-        foreach (var pair in _connections)
+        foreach (var conn in _connections.Values)
         {
-            var conn = pair.Value;
             if (conn.RunIdFilter is { } filter && filter != evt.RunId)
             {
                 continue;

--- a/src/FlowOrchestrator.Dashboard/Webhooks/Signature/HmacSignatureVerifier.cs
+++ b/src/FlowOrchestrator.Dashboard/Webhooks/Signature/HmacSignatureVerifier.cs
@@ -97,10 +97,10 @@ public sealed class HmacSignatureVerifier : IWebhookSignatureVerifier
 
         // Constant-time compare across every candidate × every key.
         // The match flags accumulate via | so we don't short-circuit and we
-        // run every comparison regardless of an early hit.
+        // run every comparison regardless of an early hit — security requirement,
+        // a Where().Any() would short-circuit and leak timing information.
         var matchedCurrent = false;
         var matchedPrevious = false;
-        // codeql[cs/linq/missed-where] loop has side effects beyond projection: constant-time security check must not short-circuit; flags accumulate via |= across every candidate × every key.
         foreach (var candidate in candidates)
         {
             if (!TryDecode(candidate, spec.Encoding, out var candidateBytes))

--- a/src/FlowOrchestrator.Dashboard/Webhooks/WebhookSecurityPipeline.cs
+++ b/src/FlowOrchestrator.Dashboard/Webhooks/WebhookSecurityPipeline.cs
@@ -511,11 +511,9 @@ public sealed class WebhookSecurityPipeline
                 };
                 if (names is not null)
                 {
-                    // codeql[cs/linq/missed-select] loop has side effects beyond projection: AddRange merges each resolved preset's entries into the outer `entries` accumulator.
-                    foreach (var n in names)
+                    foreach (var resolved in names.Select(KnownPublisherCidrs.TryGet).Where(r => r is not null))
                     {
-                        var resolved = KnownPublisherCidrs.TryGet(n);
-                        if (resolved is not null) entries.AddRange(resolved);
+                        entries.AddRange(resolved!);
                     }
                 }
             }

--- a/src/FlowOrchestrator.InMemory/InMemoryFlowRunStore.cs
+++ b/src/FlowOrchestrator.InMemory/InMemoryFlowRunStore.cs
@@ -263,12 +263,10 @@ public sealed class InMemoryFlowRunStore :
             durations[i] = new List<double>(capacity: 4);
         }
 
-        // codeql[cs/linq/missed-where] loop has side effects beyond projection: increments per-bucket counters and appends to durations[idx] — histogram fill, not a projection.
-        foreach (var r in _runs.Values)
+        foreach (var r in _runs.Values
+            .Where(x => x.StartedAt >= anchor && x.StartedAt < until)
+            .Where(x => !flowId.HasValue || x.FlowId == flowId.Value))
         {
-            if (r.StartedAt < anchor || r.StartedAt >= until) continue;
-            if (flowId.HasValue && r.FlowId != flowId.Value) continue;
-
             var idx = (int)((r.StartedAt - anchor).TotalMilliseconds / bucketSize.TotalMilliseconds);
             if (idx < 0 || idx >= totalBuckets) continue;
 

--- a/src/FlowOrchestrator.InMemory/InMemoryStepRunnerHostedService.cs
+++ b/src/FlowOrchestrator.InMemory/InMemoryStepRunnerHostedService.cs
@@ -23,6 +23,7 @@ internal sealed class InMemoryStepRunnerHostedService : BackgroundService
     private readonly ChannelReader<InMemoryStepEnvelope> _reader;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<InMemoryStepRunnerHostedService> _logger;
+    private SemaphoreSlim? _semaphore;
 
     /// <summary>Maximum number of steps processed concurrently. Default is 1 (sequential).</summary>
     public int MaxConcurrency { get; init; } = 1;
@@ -39,9 +40,17 @@ internal sealed class InMemoryStepRunnerHostedService : BackgroundService
     }
 
     /// <inheritdoc/>
+    public override void Dispose()
+    {
+        _semaphore?.Dispose();
+        base.Dispose();
+    }
+
+    /// <inheritdoc/>
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var semaphore = new SemaphoreSlim(MaxConcurrency, MaxConcurrency);
+        _semaphore = new SemaphoreSlim(MaxConcurrency, MaxConcurrency);
+        var semaphore = _semaphore;
 
         await foreach (var envelope in _reader.ReadAllAsync(stoppingToken).ConfigureAwait(false))
         {

--- a/tests/integration/FlowOrchestrator.ServiceBus.IntegrationTests/ServiceBusCronRoundTripTests.cs
+++ b/tests/integration/FlowOrchestrator.ServiceBus.IntegrationTests/ServiceBusCronRoundTripTests.cs
@@ -196,8 +196,8 @@ internal sealed class CronTickHandler : IStepHandler
     /// <inheritdoc/>
     public ValueTask<object?> ExecuteAsync(IExecutionContext context, IFlowDefinition flow, IStepInstance step)
     {
-        // Static counter is intentional: DI creates per-scope handler instances, tests need a single shared count.
-        // codeql[cs/static-field-written-by-instance] — atomic via Interlocked.Increment; waiters guarded by _gate lock.
+        // Static counter is intentional: DI creates per-scope handler instances, tests need a
+        // single shared count. Writes are atomic via Interlocked.Increment; waiters guarded by _gate lock.
         var n = Interlocked.Increment(ref _count);
         lock (_gate)
         {

--- a/tests/integration/FlowOrchestrator.ServiceBus.IntegrationTests/TestFlow.cs
+++ b/tests/integration/FlowOrchestrator.ServiceBus.IntegrationTests/TestFlow.cs
@@ -54,8 +54,8 @@ internal sealed class TestStepHandler : IStepHandler
     /// <inheritdoc/>
     public ValueTask<object?> ExecuteAsync(IExecutionContext context, IFlowDefinition flow, IStepInstance step)
     {
-        // Static counter is intentional: DI creates per-scope handler instances, tests need a single shared count.
-        // codeql[cs/static-field-written-by-instance] — atomic via Interlocked.Increment / Volatile.
+        // Static counter is intentional: DI creates per-scope handler instances, tests need a
+        // single shared count. Writes are atomic via Interlocked.Increment / Volatile.Read.
         var n = Interlocked.Increment(ref _count);
         Volatile.Read(ref _signal)?.TrySetResult(n);
         return new ValueTask<object?>(new { ok = true, n });


### PR DESCRIPTION
## Summary

- #71 left 12 CodeQL alerts open on `main` because the inline `// codeql[cs/...]` markers it added are not honoured by GitHub CodeQL.
- This PR replaces each marker with a real refactor (useless-upcast, missed-select, missed-where, local-not-disposed, catch-of-all).
- The remaining 9 alerts on `main` are genuine false positives or won't-fix-by-design (cast-to-self for NRT-only widening; out-param-assignment loops; constant-time security loop; test-only `Interlocked`-guarded shared counters). They will be dismissed via the code-scanning API after this lands so the v1.26.3 tag gate is clean.

## Changes

- `FlowOrchestratorEngine.Trigger.cs` — `(Guid?)null` → `default(Guid?)`
- `DashboardServiceCollectionExtensions.cs` `/api/schedules` — `(DateTime?)null` → `default(DateTime?)`; `HasEncoding` outer + inner foreach use `.Split(',').Select(p => p.Trim())`
- `SseFlowEventBroadcaster.cs` — iterate `_connections.Values` directly
- `FlowMermaidExporter.cs` — project trigger IDs via `.Select(t => "T_" + SafeId(t))`
- `WebhookSecurityPipeline.cs` — `.Select(KnownPublisherCidrs.TryGet).Where(r => r is not null)`
- `InMemoryFlowRunStore.GetTimeseriesAsync` — chained `.Where()` before bucket-index calc
- `InMemoryStepRunnerHostedService` — `SemaphoreSlim` as field + `Dispose` override
- `CallExternalApiStep` — `HttpRequestMessage` + `HttpResponseMessage` wrapped in `using var`
- `FlowOrchestratorEngine.Step.cs` — replaced fake `// codeql[...]` marker with WHY comment on handler-boundary catch
- All other fake `// codeql[...]` markers replaced with WHY comments

## Test plan

- [x] `dotnet build FlowOrchestrator.slnx` — 0 errors, 0 warnings across net8/9/10
- [x] `dotnet test FlowOrchestrator.UnitTests.slnx` — all green per TFM
- [ ] CI integration suite green
- [ ] CI regression suite green
- [ ] CodeQL re-scan on PR shows the 12 refactored alerts closed
- [ ] `e2e` skill green on the merge commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)