### PR TITLE
Release 1.27.0: tiered RUN search + skip reason + PG trace

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Setup Node.js
         if: matrix.language == 'javascript-typescript'
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,64 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.27.0] - 2026-05-24
+
+### Changed — RUN search performance + dependency roll-up
+
+- **RUN search no longer scans superseded step-attempt history.** Both the
+  SQL Server and PostgreSQL stores previously `LIKE`/`ILIKE`-scanned the
+  `OutputJson` of every row in `FlowSteps` **and** `FlowStepAttempts`. The
+  attempt-history scan (the dominant cost — its output duplicates the current
+  step row) is removed. Search still matches run identity columns
+  (id / flow name / trigger key / status / job id) and the **current** step
+  rows including their output JSON, so searching inside step output is
+  preserved. Searching by text that survives only in a superseded retry
+  attempt is the one behaviour that changes.
+- **Single-pass pagination count.** The page query now derives its total via
+  `COUNT(*) OVER()` instead of a second `COUNT(*)` query, halving the work for
+  a filtered/searched page.
+- **PostgreSQL substring search is now index-accelerated.** The migrator
+  best-effort creates the `pg_trgm` extension and GIN trigram indexes on the
+  searched columns (`flow_name`, `trigger_key`, and `flow_steps`
+  `step_key` / `error_message` / `output_json`), so `ILIKE '%term%'` can use an
+  index. Creation is wrapped so a missing extension or insufficient privilege
+  logs a warning and the migration still succeeds (search falls back to a
+  sequential scan).
+- **Optional start-time window on run search.** `IFlowRunStore.GetRunsPageAsync`
+  and the dashboard `GET /api/runs` endpoint accept `startedFrom` / `startedTo`
+  (`from` / `to` ISO-8601 query params) to bound the scan. The new parameters
+  are optional and additive.
+- **Tiered run search (quick vs deep).** A new non-breaking
+  `IFlowRunStore.GetRunsPageAsync(..., bool deepSearch, ...)` default-interface
+  overload lets callers opt out of the per-step search scan. `deepSearch: true`
+  (the default, and the behaviour of every existing overload) matches the current
+  step rows; `deepSearch: false` matches only the cheap top-level run columns and
+  is far cheaper for typeahead. The dashboard `GET /api/runs` endpoint accepts
+  `deep=false` (or `deep=0`) to select the quick path; the response shape is
+  unchanged. External `IFlowRunStore` implementers keep compiling and stay correct
+  via the default delegation.
+- **Command palette (Cmd/Ctrl+K) run search is server-backed.** Run lookup now
+  debounce-fetches the quick path (`/api/runs?deep=false`) with request
+  cancellation, so a run id outside the loaded page is findable instantly without
+  scanning step output.
+- **Dependencies:** Dapper 2.1.72 → 2.1.79, Testcontainers (+ MsSql + PostgreSql)
+  4.11.0 → 4.12.0, Aspire.Hosting.{PostgreSQL,SqlServer,Azure.ServiceBus}
+  13.3.2 → 13.3.4, Microsoft.AspNetCore.TestHost 8.0.26 → 8.0.27,
+  coverlet.collector 10.0.0 → 10.0.1, actions/setup-node 5 → 6.
+
+### Fixed
+
+- **Skip reason is shown in run step detail again.** A step that returns
+  `Skipped` with a reason persisted the message all the way to the API, but the
+  dashboard only rendered a message panel for `Failed` steps. Skipped steps now
+  display their reason in a skip-styled "Skip reason" panel.
+- **PostgreSQL now persists the When-clause "Why skipped" evaluation trace.** The
+  `evaluation_trace_json` column, its read path, and the trace-aware
+  `RecordSkippedStepAsync` overload existed only on the SQL Server backend; on
+  PostgreSQL the trace was silently dropped (the dashboard "Why skipped" panel was
+  always empty). The PostgreSQL migrator now adds the column to `flow_steps` /
+  `flow_step_attempts` and the store reads and writes it, matching SQL Server.
+
 ## [1.26.3] - 2026-05-16
 
 ### Security — second CodeQL sweep + telemetry-isolation regression fix

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <RepositoryUrl>https://github.com/hoangsnowy/FlowOrchestrator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/hoangsnowy/FlowOrchestrator</PackageProjectUrl>
-    <VersionPrefix>1.26.3</VersionPrefix>
+    <VersionPrefix>1.27.0</VersionPrefix>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,9 +16,9 @@
 
   <!-- Aspire (orchestrator AppHost only) -->
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.2" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.2" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.2" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.4" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.4" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.4" />
   </ItemGroup>
 
   <!--
@@ -34,7 +34,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageVersion Include="Cronos" Version="0.13.0" />
-    <PackageVersion Include="Dapper" Version="2.1.72" />
+    <PackageVersion Include="Dapper" Version="2.1.79" />
     <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.23" />
     <PackageVersion Include="Hangfire.Core" Version="1.8.23" />
     <PackageVersion Include="Hangfire.InMemory" Version="1.0.0" />
@@ -64,14 +64,14 @@
 
   <!-- Test infrastructure -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.26" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.27" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers" Version="4.11.0" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers" Version="4.12.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/docs/articles/conditional-execution.md
+++ b/docs/articles/conditional-execution.md
@@ -157,6 +157,10 @@ shows a **"Why skipped"** panel under the step in the run timeline. The panel di
 This makes "why didn't this step run?" answerable from the dashboard alone — no log
 diving required.
 
+For skips that are **not** driven by a `When` clause — a prerequisite-cascade skip,
+or a handler that returns `StepStatus.Skipped` with a `FailedReason` — the step detail
+shows the reason text in a **"Skip reason"** panel instead of the trace panel.
+
 ## Anti-pattern: throwing exceptions to skip a step
 
 Some authors fake conditional execution by throwing an exception inside a step handler,

--- a/docs/articles/dashboard.md
+++ b/docs/articles/dashboard.md
@@ -136,7 +136,7 @@ Idempotency-Key: {unique-key}    (optional — prevents duplicate runs)
 
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/flows/api/runs` | List runs — queryable: `?flowId=`, `?status=`, `?search=`, `?skip=`, `?take=` |
+| `GET` | `/flows/api/runs` | List runs — queryable: `?flowId=`, `?status=`, `?search=`, `?from=`, `?to=`, `?deep=`, `?skip=`, `?take=` |
 | `GET` | `/flows/api/runs/active` | List currently-running runs |
 | `GET` | `/flows/api/runs/stats` | Aggregate statistics for the dashboard overview |
 | `GET` | `/flows/api/runs/{id}` | Run detail with trigger headers/body |
@@ -145,6 +145,22 @@ Idempotency-Key: {unique-key}    (optional — prevents duplicate runs)
 | `GET` | `/flows/api/runs/{runId}/control` | Timeout, cancellation, idempotency state |
 | `POST` | `/flows/api/runs/{runId}/cancel` | Request cooperative cancellation |
 | `POST` | `/flows/api/runs/{runId}/steps/{stepKey}/retry` | Retry a failed step |
+
+**Run search (`?search=`)** matches (case-insensitively) the run's id, flow
+name, trigger key, status, and background job id, plus the run's **current**
+step rows — step key, error message, and output JSON. Superseded retry
+*attempt* history is not searched (its output duplicates the current step row).
+On PostgreSQL these substring searches are accelerated by `pg_trgm` GIN indexes
+that the migrator creates best-effort at startup.
+
+**Start-time window (`?from=` / `?to=`)** accepts ISO-8601 timestamps and bounds
+the search to runs started within `[from, to]`, which keeps a search over a large
+run history fast.
+
+**Quick vs deep search (`?deep=`)** defaults to deep (the step-row scan described
+above). Pass `deep=false` (or `deep=0`) for the quick path that matches only the
+top-level run columns (id / flow name / trigger key / status / job id) — much
+cheaper, used by the Cmd/Ctrl+K command palette for instant run typeahead.
 
 ### Realtime Event Stream (SSE)
 

--- a/docs/articles/storage.md
+++ b/docs/articles/storage.md
@@ -75,6 +75,14 @@ builder.Services.AddFlowOrchestrator(options =>
 
 `FlowOrchestratorPgMigrator` creates the same table set in PostgreSQL on startup. Uses `Npgsql` — no EF Core dependency. PostgreSQL table names are snake_case (`flow_runs`, `webhook_replay_nonces`, `webhook_rejections`, …).
 
+The migrator also makes a **best-effort** attempt to enable the `pg_trgm`
+extension and create GIN trigram indexes that accelerate the dashboard run
+search (`?search=`) — substring `ILIKE` matching on `flow_name`, `trigger_key`,
+and the `flow_steps` `step_key` / `error_message` / `output_json` columns. If
+the connection role lacks the `CREATE EXTENSION` privilege the step is skipped
+with a warning and search still works via a sequential scan; grant the privilege
+(or pre-create the extension) to keep search fast on large histories.
+
 ### Webhook hardening backends (v1.25)
 
 The replay-nonce + DLQ stores default to in-memory (single-replica only). For multi-replica deployments register the backend-specific implementations:

--- a/src/FlowOrchestrator.Core/Storage/IFlowRunStore.cs
+++ b/src/FlowOrchestrator.Core/Storage/IFlowRunStore.cs
@@ -51,9 +51,38 @@ public interface IFlowRunStore
     Task<IReadOnlyList<FlowRunRecord>> GetRunsAsync(Guid? flowId = null, int skip = 0, int take = 50);
 
     /// <summary>
-    /// Returns a paginated run list with total count, supporting filtering by flow, status, and search text.
+    /// Returns a paginated run list with total count, supporting filtering by flow, status,
+    /// free-text search, and an optional start-time window.
     /// </summary>
-    Task<(IReadOnlyList<FlowRunRecord> Runs, int TotalCount)> GetRunsPageAsync(Guid? flowId = null, string? status = null, int skip = 0, int take = 50, string? search = null);
+    /// <param name="flowId">Restricts results to a single flow when set.</param>
+    /// <param name="status">Restricts results to runs in the given status when set.</param>
+    /// <param name="skip">Number of leading rows to skip (offset pagination).</param>
+    /// <param name="take">Maximum number of rows to return.</param>
+    /// <param name="search">
+    /// Free-text term matched (case-insensitively) against run identity columns and the
+    /// current step records (step key, error message, output JSON). Step <i>attempt</i>
+    /// history is intentionally not searched — its output duplicates the current step row.
+    /// </param>
+    /// <param name="startedFrom">Lower inclusive bound on <see cref="FlowRunRecord.StartedAt"/> when set; bounds the scan.</param>
+    /// <param name="startedTo">Upper inclusive bound on <see cref="FlowRunRecord.StartedAt"/> when set; bounds the scan.</param>
+    Task<(IReadOnlyList<FlowRunRecord> Runs, int TotalCount)> GetRunsPageAsync(Guid? flowId = null, string? status = null, int skip = 0, int take = 50, string? search = null, DateTimeOffset? startedFrom = null, DateTimeOffset? startedTo = null);
+
+    /// <summary>
+    /// Tiered variant of <see cref="GetRunsPageAsync(Guid?, string?, int, int, string?, DateTimeOffset?, DateTimeOffset?)"/>
+    /// that lets the caller opt out of the per-step search scan via <c>deepSearch</c>.
+    /// </summary>
+    /// <remarks>
+    /// When <c>deepSearch</c> is <see langword="true"/> (the behaviour of the non-tiered overload),
+    /// <c>search</c> also matches the current step records (step key, error message, output JSON) via a
+    /// correlated sub-query. When <see langword="false"/>, only the top-level run columns
+    /// (id, flow name, trigger key, status, background job id) are matched — index-friendlier and far
+    /// cheaper, suited to typeahead such as the command palette.
+    /// The default implementation delegates to the deep overload, so existing
+    /// <see cref="IFlowRunStore"/> providers keep compiling and stay correct (they simply do not get
+    /// the quick-search speedup until they override this method).
+    /// </remarks>
+    Task<(IReadOnlyList<FlowRunRecord> Runs, int TotalCount)> GetRunsPageAsync(Guid? flowId, string? status, int skip, int take, string? search, bool deepSearch, DateTimeOffset? startedFrom = null, DateTimeOffset? startedTo = null)
+        => GetRunsPageAsync(flowId, status, skip, take, search, startedFrom, startedTo);
 
     /// <summary>
     /// Returns full run detail including all step records and their attempt history,

--- a/src/FlowOrchestrator.Dashboard/Assets/dashboard.css
+++ b/src/FlowOrchestrator.Dashboard/Assets/dashboard.css
@@ -390,6 +390,7 @@ input:focus-visible,select:focus-visible,textarea:focus-visible{outline:2px soli
 .btn-copy-icon:hover{background:var(--accent-light);color:var(--accent)}
 .step-detail-body{padding:10px 12px;font-family:'JetBrains Mono',monospace;font-size:11px;white-space:pre-wrap;word-break:break-word;max-height:200px;overflow:auto;color:var(--text)}
 .step-detail.step-detail-error .step-detail-body{background:var(--danger-bg);color:var(--danger-text)}
+.step-detail.step-detail-skip .step-detail-body{background:var(--skip-bg);color:var(--skip-text)}
 .step-actions{margin-top:6px;display:flex;gap:6px}
 .badge-cron{background:var(--accent-light);color:var(--accent);border:1px solid #F0C5B5;font-family:'JetBrains Mono',monospace;font-size:10px;font-weight:700;padding:2px 7px;border-radius:4px}
 .badge-paused{background:var(--surface2);color:var(--text-dim);border:1px solid var(--border)}

--- a/src/FlowOrchestrator.Dashboard/Assets/dashboard.js
+++ b/src/FlowOrchestrator.Dashboard/Assets/dashboard.js
@@ -179,6 +179,10 @@ function renderStepDebugPanels(step) {
   if (step.status === 'Skipped') {
     const tracePanel = renderWhyWhenSkippedPanel(step);
     if (tracePanel) return tracePanel;
+    // Surface the skip reason carried on errorMessage (handler-provided message or the
+    // prerequisite-cascade reason). Falls back to the generic hint only when no reason exists.
+    const reasonPanel = renderDetailPanel('Skip reason', step.errorMessage, true, 'skip');
+    if (reasonPanel) return reasonPanel;
     return '<div style="margin-top:5px;font-size:11px;color:var(--skip-text);font-style:italic">'
       + 'Not executed \u2014 retry the failed step above to resume this flow.'
       + '</div>';
@@ -458,20 +462,33 @@ let _cmdkOpen = false;
 let _cmdkResults = [];
 let _cmdkActiveIdx = 0;
 let _cmdkReturnFocus = null;
+// Server-backed quick run search for the palette: runs fetched via the cheap
+// top-level-only path (deep=false), merged with the client-side allRuns.
+let _cmdkServerRuns = [];
+let _cmdkRunsAbort = null;
+let _cmdkRunsDebounceTimer = null;
 
 function openCmdK() {
   if (_cmdkOpen) return;
   _cmdkOpen = true;
   _cmdkReturnFocus = document.activeElement;
+  _cmdkCancelRunsFetch();
+  _cmdkServerRuns = [];
   $('cmdk-backdrop').classList.add('open');
   const dlg = $('cmdk'); dlg.classList.add('open'); dlg.removeAttribute('hidden');
   const input = $('cmdk-input'); input.value = ''; input.focus();
   renderCmdK('');
 }
 
+function _cmdkCancelRunsFetch() {
+  if (_cmdkRunsDebounceTimer) { clearTimeout(_cmdkRunsDebounceTimer); _cmdkRunsDebounceTimer = null; }
+  if (_cmdkRunsAbort) { try { _cmdkRunsAbort.abort(); } catch {} _cmdkRunsAbort = null; }
+}
+
 function closeCmdK() {
   if (!_cmdkOpen) return;
   _cmdkOpen = false;
+  _cmdkCancelRunsFetch();
   $('cmdk-backdrop').classList.remove('open');
   const dlg = $('cmdk'); dlg.classList.remove('open'); dlg.setAttribute('hidden', '');
   if (_cmdkReturnFocus && typeof _cmdkReturnFocus.focus === 'function') {
@@ -503,9 +520,15 @@ function _cmdkBuildItems() {
   for (const f of (allFlows || [])) {
     items.push({ kind: 'flow', label: f.name, sub: 'Flow · v' + f.version, action: () => { closeCmdK(); navigate('flows'); openFlowDetail(f.id); } });
   }
-  for (const r of (allRuns || [])) {
+  // Client-side runs first (instant), then server quick-search runs; dedupe by id.
+  const seenRuns = new Set();
+  const pushRun = (r) => {
+    if (!r || !r.id || seenRuns.has(r.id)) return;
+    seenRuns.add(r.id);
     items.push({ kind: 'run', label: r.id.slice(0, 8) + '… ' + (r.flowName || ''), sub: 'Run · ' + r.status, action: () => { closeCmdK(); navigate('runs'); selectRun(r.id); } });
-  }
+  };
+  for (const r of (allRuns || [])) pushRun(r);
+  for (const r of (_cmdkServerRuns || [])) pushRun(r);
   items.push({ kind: 'action', label: 'Toggle dark mode', sub: 'Theme', action: () => { closeCmdK(); toggleTheme(); } });
   items.push({ kind: 'action', label: 'Density: Cozy', sub: 'Display', action: () => { closeCmdK(); setDensity('cozy'); } });
   items.push({ kind: 'action', label: 'Density: Compact', sub: 'Display', action: () => { closeCmdK(); setDensity('compact'); } });
@@ -561,6 +584,36 @@ function _cmdkActivate(idx) {
   if (it && typeof it.action === 'function') it.action();
 }
 
+// Palette input: instant client-side paint, then debounce-fetch the server quick
+// search (cheap top-level-only path) so runs outside the loaded page are findable.
+function _cmdkOnInput(value) {
+  renderCmdK(value);
+  const q = (value || '').trim();
+  _cmdkCancelRunsFetch();
+  if (q.length < 2) {
+    if (_cmdkServerRuns.length) { _cmdkServerRuns = []; renderCmdK(value); }
+    return;
+  }
+  _cmdkRunsDebounceTimer = setTimeout(() => { _cmdkFetchServerRuns(q); }, 150);
+}
+
+async function _cmdkFetchServerRuns(query) {
+  const ctrl = new AbortController();
+  _cmdkRunsAbort = ctrl;
+  try {
+    const runs = await fetchJSON(BASE + '/runs?take=20&deep=false&search=' + encodeURIComponent(query), { signal: ctrl.signal });
+    if (!_cmdkOpen || ctrl.signal.aborted) return;
+    _cmdkServerRuns = Array.isArray(runs) ? runs : [];
+    const inp = $('cmdk-input');
+    renderCmdK(inp ? inp.value : query);
+  } catch (e) {
+    if (isAbortError(e)) return;
+    // Non-fatal: the palette still shows client-side results.
+  } finally {
+    if (_cmdkRunsAbort === ctrl) _cmdkRunsAbort = null;
+  }
+}
+
 document.addEventListener('keydown', (e) => {
   // Open palette on Cmd/Ctrl+K from anywhere.
   if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
@@ -578,7 +631,7 @@ document.addEventListener('keydown', (e) => {
 // Bind input listener once on DOM ready (script runs after body so element exists).
 (function bindCmdK(){
   const input = document.getElementById('cmdk-input');
-  if (input) input.addEventListener('input', () => renderCmdK(input.value));
+  if (input) input.addEventListener('input', () => _cmdkOnInput(input.value));
 })();
 
 // ── Mobile sidebar (≤991px) ──────────────────────────────────────────

--- a/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -570,10 +571,20 @@ public static class DashboardServiceCollectionExtensions
             bool includeTotal = query.TryGetValue("includeTotal", out var includeTotalValues)
                 && bool.TryParse(includeTotalValues, out var includeTotalParsed)
                 && includeTotalParsed;
+            DateTimeOffset? startedFrom = query.TryGetValue("from", out var fromValues)
+                && DateTimeOffset.TryParse(fromValues, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var fromParsed)
+                ? fromParsed : null;
+            DateTimeOffset? startedTo = query.TryGetValue("to", out var toValues)
+                && DateTimeOffset.TryParse(toValues, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var toParsed)
+                ? toParsed : null;
+            // Deep search (default) also scans step rows; deep=false|0 is the cheap top-level-only
+            // quick search used by the command palette typeahead.
+            var deepRaw = query.TryGetValue("deep", out var deepValues) ? deepValues.ToString() : null;
+            bool deepSearch = !(string.Equals(deepRaw, "false", StringComparison.OrdinalIgnoreCase) || deepRaw == "0");
 
-            if (includeTotal || !string.IsNullOrWhiteSpace(status) || !string.IsNullOrWhiteSpace(search))
+            if (includeTotal || !string.IsNullOrWhiteSpace(status) || !string.IsNullOrWhiteSpace(search) || startedFrom.HasValue || startedTo.HasValue)
             {
-                var page = await store.GetRunsPageAsync(flowId, status, skip, take, search);
+                var page = await store.GetRunsPageAsync(flowId, status, skip, take, search, deepSearch, startedFrom, startedTo);
                 if (includeTotal)
                 {
                     await WriteJsonAsync(http.Response,new

--- a/src/FlowOrchestrator.InMemory/InMemoryFlowRunStore.cs
+++ b/src/FlowOrchestrator.InMemory/InMemoryFlowRunStore.cs
@@ -155,7 +155,7 @@ public sealed class InMemoryFlowRunStore :
 
     public Task<IReadOnlyList<FlowRunRecord>> GetRunsAsync(Guid? flowId = null, int skip = 0, int take = 50)
     {
-        IReadOnlyList<FlowRunRecord> result = ApplyRunsFilter(flowId, null, null)
+        IReadOnlyList<FlowRunRecord> result = ApplyRunsFilter(flowId, null, null, null, null, deepSearch: true)
             .OrderByDescending(r => r.StartedAt)
             .Skip(skip).Take(take)
             .ToList();
@@ -167,9 +167,22 @@ public sealed class InMemoryFlowRunStore :
         string? status = null,
         int skip = 0,
         int take = 50,
-        string? search = null)
+        string? search = null,
+        DateTimeOffset? startedFrom = null,
+        DateTimeOffset? startedTo = null)
+        => GetRunsPageAsync(flowId, status, skip, take, search, deepSearch: true, startedFrom, startedTo);
+
+    public Task<(IReadOnlyList<FlowRunRecord> Runs, int TotalCount)> GetRunsPageAsync(
+        Guid? flowId,
+        string? status,
+        int skip,
+        int take,
+        string? search,
+        bool deepSearch,
+        DateTimeOffset? startedFrom = null,
+        DateTimeOffset? startedTo = null)
     {
-        var filtered = ApplyRunsFilter(flowId, status, search).OrderByDescending(r => r.StartedAt).ToList();
+        var filtered = ApplyRunsFilter(flowId, status, search, startedFrom, startedTo, deepSearch).OrderByDescending(r => r.StartedAt).ToList();
         var totalCount = filtered.Count;
         IReadOnlyList<FlowRunRecord> runs = filtered.Skip(skip).Take(take).ToList();
         return Task.FromResult((runs, totalCount));
@@ -640,7 +653,7 @@ public sealed class InMemoryFlowRunStore :
         return Task.CompletedTask;
     }
 
-    private IEnumerable<FlowRunRecord> ApplyRunsFilter(Guid? flowId, string? status, string? search)
+    private IEnumerable<FlowRunRecord> ApplyRunsFilter(Guid? flowId, string? status, string? search, DateTimeOffset? startedFrom, DateTimeOffset? startedTo, bool deepSearch)
     {
         var query = _runs.Values.AsEnumerable();
 
@@ -650,13 +663,19 @@ public sealed class InMemoryFlowRunStore :
         if (!string.IsNullOrWhiteSpace(status))
             query = query.Where(r => string.Equals(r.Status, status, StringComparison.OrdinalIgnoreCase));
 
+        if (startedFrom.HasValue)
+            query = query.Where(r => r.StartedAt >= startedFrom.Value);
+
+        if (startedTo.HasValue)
+            query = query.Where(r => r.StartedAt <= startedTo.Value);
+
         if (!string.IsNullOrWhiteSpace(search))
-            query = query.Where(r => MatchesRunSearch(r, search));
+            query = query.Where(r => MatchesRunSearch(r, search, deepSearch));
 
         return query;
     }
 
-    private bool MatchesRunSearch(FlowRunRecord run, string search)
+    private bool MatchesRunSearch(FlowRunRecord run, string search, bool deepSearch)
     {
         if (ContainsIgnoreCase(run.Id.ToString(), search)
             || ContainsIgnoreCase(run.FlowName, search)
@@ -667,20 +686,16 @@ public sealed class InMemoryFlowRunStore :
             return true;
         }
 
-        var stepMatch = _steps.Values.Any(s =>
+        if (!deepSearch)
+            return false;
+
+        // Deep search also scans the current step rows (incl. OutputJson). Attempt history is
+        // intentionally not searched — it duplicates the current step row and is the dominant cost.
+        return _steps.Values.Any(s =>
             s.RunId == run.Id
             && (ContainsIgnoreCase(s.StepKey, search)
                 || ContainsIgnoreCase(s.ErrorMessage, search)
                 || ContainsIgnoreCase(s.OutputJson, search)));
-
-        if (stepMatch)
-            return true;
-
-        return _stepAttempts.Values.Any(a =>
-            a.RunId == run.Id
-            && (ContainsIgnoreCase(a.StepKey, search)
-                || ContainsIgnoreCase(a.ErrorMessage, search)
-                || ContainsIgnoreCase(a.OutputJson, search)));
     }
 
     private static bool ContainsIgnoreCase(string? value, string search)

--- a/src/FlowOrchestrator.PostgreSQL/PostgreSqlFlowOrchestratorMigrator.cs
+++ b/src/FlowOrchestrator.PostgreSQL/PostgreSqlFlowOrchestratorMigrator.cs
@@ -29,9 +29,13 @@ public sealed class PostgreSqlFlowOrchestratorMigrator : IHostedService
             await using var conn = new NpgsqlConnection(_connectionString);
             await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
 
-            await using var cmd = conn.CreateCommand();
-            cmd.CommandText = MigrationSql;
-            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            await using (var cmd = conn.CreateCommand())
+            {
+                cmd.CommandText = MigrationSql;
+                await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            await TryCreateTrigramIndexesAsync(conn, cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation("FlowOrchestrator PostgreSQL migrations completed.");
         }
@@ -43,6 +47,33 @@ public sealed class PostgreSqlFlowOrchestratorMigrator : IHostedService
     }
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>
+    /// Creates <c>pg_trgm</c> GIN indexes that accelerate the substring (<c>ILIKE</c>)
+    /// run-search query. Best-effort: the <c>pg_trgm</c> extension requires a privilege
+    /// that some managed PostgreSQL roles lack, so any failure here is logged as a warning
+    /// and swallowed — run search still works (the planner falls back to a sequential scan).
+    /// </summary>
+    /// <remarks>
+    /// Kept out of the mandatory <see cref="MigrationSql"/> batch so a missing-privilege
+    /// failure cannot abort the schema migration and prevent the host from starting.
+    /// </remarks>
+    private async Task TryCreateTrigramIndexesAsync(NpgsqlConnection conn, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = TrigramSql;
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            _logger.LogInformation("FlowOrchestrator PostgreSQL pg_trgm search indexes ensured.");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(
+                ex,
+                "FlowOrchestrator PostgreSQL pg_trgm index creation was skipped (extension unavailable or insufficient privilege). Run search remains functional via sequential scan.");
+        }
+    }
 
     private const string MigrationSql = """
         CREATE TABLE IF NOT EXISTS flow_definitions (
@@ -190,6 +221,10 @@ public sealed class PostgreSqlFlowOrchestratorMigrator : IHostedService
         ALTER TABLE flow_runs ADD COLUMN IF NOT EXISTS source_run_id UUID NULL;
         CREATE INDEX IF NOT EXISTS ix_flow_runs_source_run_id ON flow_runs (source_run_id) WHERE source_run_id IS NOT NULL;
 
+        -- When-clause evaluation trace columns (idempotent), parity with the SQL Server backend.
+        ALTER TABLE flow_steps ADD COLUMN IF NOT EXISTS evaluation_trace_json TEXT NULL;
+        ALTER TABLE flow_step_attempts ADD COLUMN IF NOT EXISTS evaluation_trace_json TEXT NULL;
+
         -- Webhook hardening tables (v1.25).
         CREATE TABLE IF NOT EXISTS webhook_replay_nonces (
             flow_id     UUID         NOT NULL,
@@ -218,5 +253,17 @@ public sealed class PostgreSqlFlowOrchestratorMigrator : IHostedService
         CREATE INDEX IF NOT EXISTS ix_webhook_rejections_flow_received ON webhook_rejections (flow_id, received_at DESC);
         CREATE INDEX IF NOT EXISTS ix_webhook_rejections_reason ON webhook_rejections (reason);
         CREATE INDEX IF NOT EXISTS ix_webhook_rejections_received_at ON webhook_rejections (received_at DESC);
+        """;
+
+    // Trigram (pg_trgm) GIN indexes for substring run-search acceleration. Run separately
+    // from MigrationSql via TryCreateTrigramIndexesAsync because CREATE EXTENSION may be denied
+    // on locked-down roles; a failure must not abort the mandatory schema migration.
+    private const string TrigramSql = """
+        CREATE EXTENSION IF NOT EXISTS pg_trgm;
+        CREATE INDEX IF NOT EXISTS ix_flow_runs_flow_name_trgm     ON flow_runs  USING gin (flow_name gin_trgm_ops);
+        CREATE INDEX IF NOT EXISTS ix_flow_runs_trigger_key_trgm   ON flow_runs  USING gin (trigger_key gin_trgm_ops);
+        CREATE INDEX IF NOT EXISTS ix_flow_steps_step_key_trgm      ON flow_steps USING gin (step_key gin_trgm_ops);
+        CREATE INDEX IF NOT EXISTS ix_flow_steps_error_message_trgm ON flow_steps USING gin (error_message gin_trgm_ops);
+        CREATE INDEX IF NOT EXISTS ix_flow_steps_output_json_trgm   ON flow_steps USING gin (output_json gin_trgm_ops);
         """;
 }

--- a/src/FlowOrchestrator.PostgreSQL/PostgreSqlFlowRunStore.cs
+++ b/src/FlowOrchestrator.PostgreSQL/PostgreSqlFlowRunStore.cs
@@ -135,12 +135,25 @@ public sealed class PostgreSqlFlowRunStore :
         return page.Runs;
     }
 
-    public async Task<(IReadOnlyList<FlowRunRecord> Runs, int TotalCount)> GetRunsPageAsync(
+    public Task<(IReadOnlyList<FlowRunRecord> Runs, int TotalCount)> GetRunsPageAsync(
         Guid? flowId = null,
         string? status = null,
         int skip = 0,
         int take = 50,
-        string? search = null)
+        string? search = null,
+        DateTimeOffset? startedFrom = null,
+        DateTimeOffset? startedTo = null)
+        => GetRunsPageAsync(flowId, status, skip, take, search, deepSearch: true, startedFrom, startedTo);
+
+    public async Task<(IReadOnlyList<FlowRunRecord> Runs, int TotalCount)> GetRunsPageAsync(
+        Guid? flowId,
+        string? status,
+        int skip,
+        int take,
+        string? search,
+        bool deepSearch,
+        DateTimeOffset? startedFrom = null,
+        DateTimeOffset? startedTo = null)
     {
         await using var conn = new NpgsqlConnection(_connectionString);
         var whereClauses = new List<string>();
@@ -148,19 +161,21 @@ public sealed class PostgreSqlFlowRunStore :
             whereClauses.Add("fr.flow_id = @FlowId");
         if (!string.IsNullOrWhiteSpace(status))
             whereClauses.Add("fr.status = @Status");
+        if (startedFrom.HasValue)
+            whereClauses.Add("fr.started_at >= @StartedFrom");
+        if (startedTo.HasValue)
+            whereClauses.Add("fr.started_at <= @StartedTo");
 
         var searchLike = (string?)null;
         if (!string.IsNullOrWhiteSpace(search))
         {
             searchLike = $"%{EscapeLikePattern(search)}%";
-            whereClauses.Add(
-                """
-                (
-                    fr.id::text ILIKE @SearchLike
-                    OR COALESCE(fr.flow_name, '') ILIKE @SearchLike
-                    OR COALESCE(fr.trigger_key, '') ILIKE @SearchLike
-                    OR COALESCE(fr.status, '') ILIKE @SearchLike
-                    OR COALESCE(fr.background_job_id, '') ILIKE @SearchLike
+            // Always match the cheap top-level run columns. The per-step EXISTS scan
+            // (incl. output_json; flow_step_attempts excluded as duplicated history) is only
+            // added for deep search; pg_trgm GIN indexes accelerate the ILIKE scans.
+            var stepExists = deepSearch
+                ? """
+
                     OR EXISTS (
                         SELECT 1
                         FROM flow_steps AS fs
@@ -171,39 +186,46 @@ public sealed class PostgreSqlFlowRunStore :
                                 OR COALESCE(fs.output_json, '') ILIKE @SearchLike
                               )
                     )
-                    OR EXISTS (
-                        SELECT 1
-                        FROM flow_step_attempts AS fsa
-                        WHERE fsa.run_id = fr.id
-                          AND (
-                                COALESCE(fsa.step_key, '') ILIKE @SearchLike
-                                OR COALESCE(fsa.error_message, '') ILIKE @SearchLike
-                                OR COALESCE(fsa.output_json, '') ILIKE @SearchLike
-                              )
-                    )
+                    """
+                : string.Empty;
+            whereClauses.Add(
+                """
+                (
+                    fr.id::text ILIKE @SearchLike
+                    OR COALESCE(fr.flow_name, '') ILIKE @SearchLike
+                    OR COALESCE(fr.trigger_key, '') ILIKE @SearchLike
+                    OR COALESCE(fr.status, '') ILIKE @SearchLike
+                    OR COALESCE(fr.background_job_id, '') ILIKE @SearchLike
+                """ + stepExists + """
+
                 )
                 """);
         }
 
         var whereSql = whereClauses.Count > 0 ? $" WHERE {string.Join(" AND ", whereClauses)}" : string.Empty;
-        var countSql = $"SELECT COUNT(*) FROM flow_runs AS fr{whereSql}";
+        // Single pass: COUNT(*) OVER() yields the full filtered total alongside the page,
+        // avoiding a second scan of the same predicate.
         var pageSql = $"""
             SELECT fr.id AS "Id", fr.flow_id AS "FlowId", fr.flow_name AS "FlowName",
                    fr.status AS "Status", fr.trigger_key AS "TriggerKey",
                    fr.trigger_data_json AS "TriggerDataJson", fr.background_job_id AS "BackgroundJobId",
                    fr.started_at AS "StartedAt", fr.completed_at AS "CompletedAt",
-                   fr.source_run_id AS "SourceRunId"
+                   fr.source_run_id AS "SourceRunId", COUNT(*) OVER()::int AS "TotalCount"
             FROM flow_runs AS fr
             """ + whereSql + """
              ORDER BY fr.started_at DESC
             LIMIT @Take OFFSET @Skip
             """;
 
-        var parameters = new { FlowId = flowId, Status = status, Skip = skip, Take = take, SearchLike = searchLike };
-        var totalCount = await conn.ExecuteScalarAsync<int>(countSql, parameters);
-        var rows = await conn.QueryAsync<FlowRunRecord>(pageSql, parameters);
+        var parameters = new { FlowId = flowId, Status = status, Skip = skip, Take = take, SearchLike = searchLike, StartedFrom = startedFrom, StartedTo = startedTo };
+        var totalCount = 0;
+        var rows = (await conn.QueryAsync<FlowRunRecord, int, FlowRunRecord>(
+            pageSql,
+            (run, total) => { totalCount = total; return run; },
+            parameters,
+            splitOn: "TotalCount")).AsList();
 
-        return (rows.AsList(), totalCount);
+        return (rows, totalCount);
     }
 
     public async Task<FlowRunRecord?> GetRunDetailAsync(Guid runId)
@@ -217,7 +239,8 @@ public sealed class PostgreSqlFlowRunStore :
             SELECT run_id AS "RunId", step_key AS "StepKey", step_type AS "StepType",
                    status AS "Status", input_json AS "InputJson", output_json AS "OutputJson",
                    error_message AS "ErrorMessage", job_id AS "JobId",
-                   started_at AS "StartedAt", completed_at AS "CompletedAt"
+                   started_at AS "StartedAt", completed_at AS "CompletedAt",
+                   evaluation_trace_json AS "EvaluationTraceJson"
             FROM flow_steps
             WHERE run_id = @RunId
             ORDER BY started_at
@@ -231,7 +254,8 @@ public sealed class PostgreSqlFlowRunStore :
                    step_type AS "StepType", status AS "Status",
                    input_json AS "InputJson", output_json AS "OutputJson",
                    error_message AS "ErrorMessage", job_id AS "JobId",
-                   started_at AS "StartedAt", completed_at AS "CompletedAt"
+                   started_at AS "StartedAt", completed_at AS "CompletedAt",
+                   evaluation_trace_json AS "EvaluationTraceJson"
             FROM flow_step_attempts
             WHERE run_id = @RunId
             ORDER BY step_key, attempt_no
@@ -440,6 +464,42 @@ public sealed class PostgreSqlFlowRunStore :
     {
         await RecordStepStartAsync(runId, stepKey, stepType, null, null).ConfigureAwait(false);
         await RecordStepCompleteAsync(runId, stepKey, StepStatus.Skipped.ToString(), null, reason).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Records a <see cref="StepStatus.Skipped"/> step and persists the When-clause
+    /// evaluation trace onto the current step row and its latest attempt.
+    /// </summary>
+    /// <remarks>
+    /// Overrides the runtime-store default so PostgreSQL surfaces the "Why skipped"
+    /// trace in run detail, matching the SQL Server backend.
+    /// </remarks>
+    public async Task RecordSkippedStepAsync(Guid runId, string stepKey, string stepType, string? reason, string? evaluationTraceJson)
+    {
+        await RecordStepStartAsync(runId, stepKey, stepType, null, null).ConfigureAwait(false);
+        await RecordStepCompleteAsync(runId, stepKey, StepStatus.Skipped.ToString(), null, reason).ConfigureAwait(false);
+        if (string.IsNullOrEmpty(evaluationTraceJson))
+            return;
+
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync().ConfigureAwait(false);
+        await using var tx = await conn.BeginTransactionAsync().ConfigureAwait(false);
+
+        await conn.ExecuteAsync(
+            "UPDATE flow_steps SET evaluation_trace_json = @Trace WHERE run_id = @RunId AND step_key = @StepKey",
+            new { RunId = runId, StepKey = stepKey, Trace = evaluationTraceJson }, tx).ConfigureAwait(false);
+
+        await conn.ExecuteAsync(
+            """
+            UPDATE flow_step_attempts SET evaluation_trace_json = @Trace
+            WHERE run_id = @RunId AND step_key = @StepKey
+              AND attempt_no = (
+                    SELECT MAX(attempt_no) FROM flow_step_attempts
+                    WHERE run_id = @RunId AND step_key = @StepKey)
+            """,
+            new { RunId = runId, StepKey = stepKey, Trace = evaluationTraceJson }, tx).ConfigureAwait(false);
+
+        await tx.CommitAsync().ConfigureAwait(false);
     }
 
     public async Task<string?> GetRunStatusAsync(Guid runId)

--- a/src/FlowOrchestrator.SqlServer/SqlFlowRunStore.cs
+++ b/src/FlowOrchestrator.SqlServer/SqlFlowRunStore.cs
@@ -124,12 +124,25 @@ public sealed class SqlFlowRunStore :
         return page.Runs;
     }
 
-    public async Task<(IReadOnlyList<FlowRunRecord> Runs, int TotalCount)> GetRunsPageAsync(
+    public Task<(IReadOnlyList<FlowRunRecord> Runs, int TotalCount)> GetRunsPageAsync(
         Guid? flowId = null,
         string? status = null,
         int skip = 0,
         int take = 50,
-        string? search = null)
+        string? search = null,
+        DateTimeOffset? startedFrom = null,
+        DateTimeOffset? startedTo = null)
+        => GetRunsPageAsync(flowId, status, skip, take, search, deepSearch: true, startedFrom, startedTo);
+
+    public async Task<(IReadOnlyList<FlowRunRecord> Runs, int TotalCount)> GetRunsPageAsync(
+        Guid? flowId,
+        string? status,
+        int skip,
+        int take,
+        string? search,
+        bool deepSearch,
+        DateTimeOffset? startedFrom = null,
+        DateTimeOffset? startedTo = null)
     {
         await using var conn = new SqlConnection(_connectionString);
         var whereClauses = new List<string>();
@@ -137,17 +150,20 @@ public sealed class SqlFlowRunStore :
             whereClauses.Add("fr.FlowId = @FlowId");
         if (!string.IsNullOrWhiteSpace(status))
             whereClauses.Add("fr.Status = @Status");
+        if (startedFrom.HasValue)
+            whereClauses.Add("fr.StartedAt >= @StartedFrom");
+        if (startedTo.HasValue)
+            whereClauses.Add("fr.StartedAt <= @StartedTo");
         var searchLike = (string?)null;
         if (!string.IsNullOrWhiteSpace(search))
         {
             searchLike = $"%{EscapeLikePattern(search)}%";
-            whereClauses.Add("""
-                (
-                    CAST(fr.Id AS NVARCHAR(36)) LIKE @SearchLike ESCAPE '\'
-                    OR ISNULL(fr.FlowName, '') LIKE @SearchLike ESCAPE '\'
-                    OR ISNULL(fr.TriggerKey, '') LIKE @SearchLike ESCAPE '\'
-                    OR ISNULL(fr.Status, '') LIKE @SearchLike ESCAPE '\'
-                    OR ISNULL(fr.BackgroundJobId, '') LIKE @SearchLike ESCAPE '\'
+            // Always match the cheap top-level run columns. The per-step EXISTS scan
+            // (incl. OutputJson; FlowStepAttempts is excluded as duplicated history) is only
+            // added for deep search — quick search stays index-friendlier for typeahead.
+            var stepExists = deepSearch
+                ? """
+
                     OR EXISTS (
                         SELECT 1
                         FROM FlowSteps AS fs
@@ -158,31 +174,38 @@ public sealed class SqlFlowRunStore :
                                 OR ISNULL(fs.OutputJson, '') LIKE @SearchLike ESCAPE '\'
                               )
                     )
-                    OR EXISTS (
-                        SELECT 1
-                        FROM FlowStepAttempts AS fsa
-                        WHERE fsa.RunId = fr.Id
-                          AND (
-                                ISNULL(fsa.StepKey, '') LIKE @SearchLike ESCAPE '\'
-                                OR ISNULL(fsa.ErrorMessage, '') LIKE @SearchLike ESCAPE '\'
-                                OR ISNULL(fsa.OutputJson, '') LIKE @SearchLike ESCAPE '\'
-                              )
-                    )
+                    """
+                : string.Empty;
+            whereClauses.Add("""
+                (
+                    CAST(fr.Id AS NVARCHAR(36)) LIKE @SearchLike ESCAPE '\'
+                    OR ISNULL(fr.FlowName, '') LIKE @SearchLike ESCAPE '\'
+                    OR ISNULL(fr.TriggerKey, '') LIKE @SearchLike ESCAPE '\'
+                    OR ISNULL(fr.Status, '') LIKE @SearchLike ESCAPE '\'
+                    OR ISNULL(fr.BackgroundJobId, '') LIKE @SearchLike ESCAPE '\'
+                """ + stepExists + """
+
                 )
                 """);
         }
 
         var whereSql = whereClauses.Count > 0 ? $" WHERE {string.Join(" AND ", whereClauses)}" : string.Empty;
-        var countSql = $"SELECT COUNT(*) FROM FlowRuns AS fr{whereSql}";
-        var pageSql = "SELECT fr.Id, fr.FlowId, fr.FlowName, fr.Status, fr.TriggerKey, fr.TriggerDataJson, fr.BackgroundJobId, fr.StartedAt, fr.CompletedAt, fr.SourceRunId FROM FlowRuns AS fr"
+        // Single pass: COUNT(*) OVER() yields the full filtered total alongside the page,
+        // avoiding a second scan of the same predicate. An empty page beyond the last row
+        // reports total 0, which matches the page being empty.
+        var pageSql = "SELECT fr.Id, fr.FlowId, fr.FlowName, fr.Status, fr.TriggerKey, fr.TriggerDataJson, fr.BackgroundJobId, fr.StartedAt, fr.CompletedAt, fr.SourceRunId, COUNT(*) OVER() AS TotalCount FROM FlowRuns AS fr"
             + whereSql
             + " ORDER BY fr.StartedAt DESC OFFSET @Skip ROWS FETCH NEXT @Take ROWS ONLY";
 
-        var parameters = new { FlowId = flowId, Status = status, Skip = skip, Take = take, SearchLike = searchLike };
-        var totalCount = await conn.ExecuteScalarAsync<int>(countSql, parameters);
-        var rows = await conn.QueryAsync<FlowRunRecord>(pageSql, parameters);
+        var parameters = new { FlowId = flowId, Status = status, Skip = skip, Take = take, SearchLike = searchLike, StartedFrom = startedFrom, StartedTo = startedTo };
+        var totalCount = 0;
+        var rows = (await conn.QueryAsync<FlowRunRecord, int, FlowRunRecord>(
+            pageSql,
+            (run, total) => { totalCount = total; return run; },
+            parameters,
+            splitOn: "TotalCount")).AsList();
 
-        return (rows.AsList(), totalCount);
+        return (rows, totalCount);
     }
 
     public async Task<FlowRunRecord?> GetRunDetailAsync(Guid runId)

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/RunEndpointTests.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/RunEndpointTests.cs
@@ -34,7 +34,7 @@ public sealed class RunEndpointTests : IDisposable
     {
         // Arrange
         var run = new FlowRunRecord { Id = Guid.NewGuid(), Status = "Succeeded", FlowName = "F" };
-        _server.FlowRunStore.GetRunsPageAsync(null, null, 0, 10, null)
+        _server.FlowRunStore.GetRunsPageAsync(null, null, 0, 10, null, true, null, null)
             .Returns(([run], 1));
 
         // Act
@@ -51,7 +51,7 @@ public sealed class RunEndpointTests : IDisposable
     public async Task GET_api_runs_with_status_filter_uses_GetRunsPageAsync()
     {
         // Arrange
-        _server.FlowRunStore.GetRunsPageAsync(null, "Failed", 0, 50, null)
+        _server.FlowRunStore.GetRunsPageAsync(null, "Failed", 0, 50, null, true, null, null)
             .Returns((Array.Empty<FlowRunRecord>(), 0));
 
         // Act
@@ -59,7 +59,22 @@ public sealed class RunEndpointTests : IDisposable
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        await _server.FlowRunStore.Received(1).GetRunsPageAsync(null, "Failed", 0, 50, null);
+        await _server.FlowRunStore.Received(1).GetRunsPageAsync(null, "Failed", 0, 50, null, true, null, null);
+    }
+
+    [Fact]
+    public async Task GET_api_runs_with_deep_false_uses_quick_search()
+    {
+        // Arrange
+        _server.FlowRunStore.GetRunsPageAsync(null, null, 0, 20, "abc", false, null, null)
+            .Returns((Array.Empty<FlowRunRecord>(), 0));
+
+        // Act
+        var response = await _client.GetAsync("/flows/api/runs?search=abc&take=20&deep=false");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await _server.FlowRunStore.Received(1).GetRunsPageAsync(null, null, 0, 20, "abc", false, null, null);
     }
 
     [Fact]

--- a/tests/integration/FlowOrchestrator.PostgreSQL.IntegrationTests/PostgreSqlFlowRunStoreTests.cs
+++ b/tests/integration/FlowOrchestrator.PostgreSQL.IntegrationTests/PostgreSqlFlowRunStoreTests.cs
@@ -1,14 +1,17 @@
 using FlowOrchestrator.Core.Storage;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace FlowOrchestrator.PostgreSQL.Tests;
 
 public sealed class PostgreSqlFlowRunStoreTests : IClassFixture<PostgreSqlFixture>
 {
     private readonly PostgreSqlFlowRunStore _store;
+    private readonly string _connectionString;
 
     public PostgreSqlFlowRunStoreTests(PostgreSqlFixture fixture)
     {
-        _store = new PostgreSqlFlowRunStore(fixture.ConnectionString);
+        _connectionString = fixture.ConnectionString;
+        _store = new PostgreSqlFlowRunStore(_connectionString);
     }
 
     [Fact]
@@ -186,5 +189,100 @@ public sealed class PostgreSqlFlowRunStoreTests : IClassFixture<PostgreSqlFixtur
         // Assert
         Assert.True(total >= 1);
         Assert.True(runs.All(r => r.FlowName == uniqueName));
+    }
+
+    [Fact]
+    public async Task GetRunsPageAsync_search_matches_current_step_output_json()
+    {
+        // Arrange
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        var token = $"txid{Guid.NewGuid():N}";
+        await _store.StartRunAsync(flowId, "OutputJsonFlow", runId, "manual", null, null);
+        await _store.RecordStepStartAsync(runId, "pay", "Pay", null, null);
+        await _store.RecordStepCompleteAsync(runId, "pay", "Succeeded", $"{{\"transactionId\":\"{token}\"}}", null);
+
+        // Act — search inside the current step's output JSON is preserved.
+        var (runs, total) = await _store.GetRunsPageAsync(null, null, 0, 10, token);
+
+        // Assert (also locks the single-pass COUNT(*) OVER() total to the exact match count)
+        Assert.Equal(1, total);
+        Assert.Single(runs);
+        Assert.Equal(runId, runs[0].Id);
+    }
+
+    [Fact]
+    public async Task GetRunsPageAsync_search_excludes_superseded_attempt_history()
+    {
+        // Arrange
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        var token = $"attempttok{Guid.NewGuid():N}";
+        await _store.StartRunAsync(flowId, "AttemptHistoryFlow", runId, "manual", null, null);
+        await _store.RecordStepStartAsync(runId, "pay", "Pay", null, null);
+        await _store.RecordStepCompleteAsync(runId, "pay", "Failed", null, $"gateway {token} failed");
+        await _store.RecordStepStartAsync(runId, "pay", "Pay", null, null);
+        await _store.RecordStepCompleteAsync(runId, "pay", "Succeeded", "{\"ok\":true}", null);
+
+        // Act — the token survives only in the superseded attempt history, which is no longer searched.
+        var (runs, total) = await _store.GetRunsPageAsync(null, null, 0, 10, token);
+
+        // Assert
+        Assert.Equal(0, total);
+        Assert.Empty(runs);
+    }
+
+    [Fact]
+    public async Task GetRunsPageAsync_filters_by_started_date_range()
+    {
+        // Arrange
+        var flowId = Guid.NewGuid();
+        await _store.StartRunAsync(flowId, "DateRangeFlow", Guid.NewGuid(), "manual", null, null);
+        var now = DateTimeOffset.UtcNow;
+
+        // Act
+        var (inRange, inTotal) = await _store.GetRunsPageAsync(flowId, null, 0, 10, null, now.AddHours(-1), now.AddHours(1));
+        var (afterRange, afterTotal) = await _store.GetRunsPageAsync(flowId, null, 0, 10, null, now.AddHours(1), null);
+
+        // Assert
+        Assert.Equal(1, inTotal);
+        Assert.Single(inRange);
+        Assert.Equal(0, afterTotal);
+        Assert.Empty(afterRange);
+    }
+
+    [Fact]
+    public async Task Migrator_is_idempotent_and_trigram_step_does_not_throw()
+    {
+        // Arrange — the fixture already ran the migrator once at startup.
+        var migrator = new PostgreSqlFlowOrchestratorMigrator(
+            _connectionString,
+            NullLogger<PostgreSqlFlowOrchestratorMigrator>.Instance);
+
+        // Act — a second run must be a no-op (CREATE ... IF NOT EXISTS / CREATE EXTENSION IF NOT EXISTS),
+        // and the optional pg_trgm trigram step must never abort the migration.
+        var ex = await Record.ExceptionAsync(() => migrator.StartAsync(CancellationToken.None));
+
+        // Assert
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public async Task RecordSkippedStepAsync_persists_evaluation_trace_json()
+    {
+        // Arrange
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        var trace = "{\"expression\":\"@triggerBody().amount > 1000\",\"resolved\":\"5 > 1000\",\"result\":false}";
+        await _store.StartRunAsync(flowId, "TraceFlow", runId, "manual", null, null);
+
+        // Act — the 5-arg overload must persist the When-clause trace (PG parity with SQL Server).
+        await _store.RecordSkippedStepAsync(runId, "branch", "Branch", "When clause false", trace);
+        var detail = await _store.GetRunDetailAsync(runId);
+
+        // Assert
+        var step = Assert.Single(detail!.Steps!, s => s.StepKey == "branch");
+        Assert.Equal("Skipped", step.Status);
+        Assert.Equal(trace, step.EvaluationTraceJson);
     }
 }

--- a/tests/integration/FlowOrchestrator.SqlServer.IntegrationTests/SqlFlowRunStoreTests.cs
+++ b/tests/integration/FlowOrchestrator.SqlServer.IntegrationTests/SqlFlowRunStoreTests.cs
@@ -187,4 +187,64 @@ public sealed class SqlFlowRunStoreTests : IClassFixture<SqlServerFixture>
         Assert.True(total >= 1);
         Assert.True(runs.All(r => r.FlowName == uniqueName));
     }
+
+    [Fact]
+    public async Task GetRunsPageAsync_search_matches_current_step_output_json()
+    {
+        // Arrange
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        var token = $"txid{Guid.NewGuid():N}";
+        await _store.StartRunAsync(flowId, "OutputJsonFlow", runId, "manual", null, null);
+        await _store.RecordStepStartAsync(runId, "pay", "Pay", null, null);
+        await _store.RecordStepCompleteAsync(runId, "pay", "Succeeded", $"{{\"transactionId\":\"{token}\"}}", null);
+
+        // Act — search inside the current step's output JSON is preserved.
+        var (runs, total) = await _store.GetRunsPageAsync(null, null, 0, 10, token);
+
+        // Assert (also locks the single-pass COUNT(*) OVER() total to the exact match count)
+        Assert.Equal(1, total);
+        Assert.Single(runs);
+        Assert.Equal(runId, runs[0].Id);
+    }
+
+    [Fact]
+    public async Task GetRunsPageAsync_search_excludes_superseded_attempt_history()
+    {
+        // Arrange
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        var token = $"attempttok{Guid.NewGuid():N}";
+        await _store.StartRunAsync(flowId, "AttemptHistoryFlow", runId, "manual", null, null);
+        await _store.RecordStepStartAsync(runId, "pay", "Pay", null, null);
+        await _store.RecordStepCompleteAsync(runId, "pay", "Failed", null, $"gateway {token} failed");
+        await _store.RecordStepStartAsync(runId, "pay", "Pay", null, null);
+        await _store.RecordStepCompleteAsync(runId, "pay", "Succeeded", "{\"ok\":true}", null);
+
+        // Act — the token survives only in the superseded attempt history, which is no longer searched.
+        var (runs, total) = await _store.GetRunsPageAsync(null, null, 0, 10, token);
+
+        // Assert
+        Assert.Equal(0, total);
+        Assert.Empty(runs);
+    }
+
+    [Fact]
+    public async Task GetRunsPageAsync_filters_by_started_date_range()
+    {
+        // Arrange
+        var flowId = Guid.NewGuid();
+        await _store.StartRunAsync(flowId, "DateRangeFlow", Guid.NewGuid(), "manual", null, null);
+        var now = DateTimeOffset.UtcNow;
+
+        // Act
+        var (inRange, inTotal) = await _store.GetRunsPageAsync(flowId, null, 0, 10, null, now.AddHours(-1), now.AddHours(1));
+        var (afterRange, afterTotal) = await _store.GetRunsPageAsync(flowId, null, 0, 10, null, now.AddHours(1), null);
+
+        // Assert
+        Assert.Equal(1, inTotal);
+        Assert.Single(inRange);
+        Assert.Equal(0, afterTotal);
+        Assert.Empty(afterRange);
+    }
 }

--- a/tests/unit/FlowOrchestrator.InMemory.UnitTests/InMemoryFlowRunStoreTests.cs
+++ b/tests/unit/FlowOrchestrator.InMemory.UnitTests/InMemoryFlowRunStoreTests.cs
@@ -234,7 +234,7 @@ public class InMemoryFlowRunStoreTests
     }
 
     [Fact]
-    public async Task GetRunsPageAsync_SearchesByAttemptHistoryErrorMessage()
+    public async Task GetRunsPageAsync_DoesNotSearchSupersededAttemptHistory()
     {
         // Arrange
         var runId = Guid.NewGuid();
@@ -244,13 +244,135 @@ public class InMemoryFlowRunStoreTests
         await _sut.RecordStepStartAsync(runId, "payment", "Payment", null, null);
         await _sut.RecordStepCompleteAsync(runId, "payment", "Succeeded", "{\"ok\":true}", null);
 
-        // Act
+        // Act — "timeout on first attempt" now lives only in the superseded attempt
+        // history (the current step row was overwritten by the successful retry).
+        // Attempt history is intentionally excluded from search.
         var page = await _sut.GetRunsPageAsync(search: "timeout on first");
 
         // Assert
-        Assert.Equal(1, page.TotalCount);
-        Assert.Single(page.Runs);
-        Assert.Equal(runId, page.Runs[0].Id);
+        Assert.Equal(0, page.TotalCount);
+        Assert.Empty(page.Runs);
+    }
+
+    [Fact]
+    public async Task GetRunsPageAsync_FiltersByStartedDateRange()
+    {
+        // Arrange
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        await _sut.StartRunAsync(flowId, "Flow1", runId, "manual", null, null);
+        var now = DateTimeOffset.UtcNow;
+
+        // Act
+        var inRange = await _sut.GetRunsPageAsync(flowId: flowId, startedFrom: now.AddHours(-1), startedTo: now.AddHours(1));
+        var afterRange = await _sut.GetRunsPageAsync(flowId: flowId, startedFrom: now.AddHours(1));
+
+        // Assert
+        Assert.Equal(1, inRange.TotalCount);
+        Assert.Single(inRange.Runs);
+        Assert.Equal(0, afterRange.TotalCount);
+        Assert.Empty(afterRange.Runs);
+    }
+
+    [Fact]
+    public async Task GetRunDetailAsync_SkippedStep_CarriesSkipReasonInErrorMessage()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        await _sut.StartRunAsync(Guid.NewGuid(), "Flow1", runId, "manual", null, null);
+        await _sut.RecordStepStartAsync(runId, "notify", "Notify", null, null);
+        await _sut.RecordStepCompleteAsync(runId, "notify", "Skipped", null, "Recipient opted out");
+
+        // Act — a handler-returned Skipped result's FailedReason is persisted as the
+        // step's ErrorMessage and surfaced in step detail (what the dashboard renders).
+        var detail = await _sut.GetRunDetailAsync(runId);
+
+        // Assert
+        var step = Assert.Single(detail!.Steps!);
+        Assert.Equal("Skipped", step.Status);
+        Assert.Equal("Recipient opted out", step.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task GetRunsPageAsync_QuickSearch_DoesNotMatchStepOutputOrError()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        await _sut.StartRunAsync(Guid.NewGuid(), "FlowQ", runId, "manual", null, null);
+        await _sut.RecordStepStartAsync(runId, "pay", "Pay", null, null);
+        await _sut.RecordStepCompleteAsync(runId, "pay", "Failed", "{\"tx\":\"deeponly7788\"}", "boom deepmsg9001");
+
+        // Act — quick search (deepSearch:false) scans only top-level run columns.
+        var byOutput = await _sut.GetRunsPageAsync(null, null, 0, 50, "deeponly7788", false);
+        var byError = await _sut.GetRunsPageAsync(null, null, 0, 50, "deepmsg9001", false);
+
+        // Assert
+        Assert.Empty(byOutput.Runs);
+        Assert.Empty(byError.Runs);
+    }
+
+    [Fact]
+    public async Task GetRunsPageAsync_QuickSearch_MatchesTopLevelColumns()
+    {
+        // Arrange
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        await _sut.StartRunAsync(flowId, "QuickFlowName", runId, "quicktrigger", null, "quickjob1");
+
+        // Act + Assert — every top-level column is matched by quick search.
+        foreach (var term in new[] { runId.ToString(), "QuickFlowName", "quicktrigger", "Running", "quickjob1" })
+        {
+            var page = await _sut.GetRunsPageAsync(null, null, 0, 50, term, false);
+            Assert.Contains(page.Runs, r => r.Id == runId);
+        }
+    }
+
+    [Fact]
+    public async Task GetRunsPageAsync_DeepSearch_AndLegacyOverload_MatchStepLevelTerm()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        await _sut.StartRunAsync(Guid.NewGuid(), "FlowD", runId, "manual", null, null);
+        await _sut.RecordStepStartAsync(runId, "pay", "Pay", null, null);
+        await _sut.RecordStepCompleteAsync(runId, "pay", "Succeeded", "{\"tx\":\"steplevel555\"}", null);
+
+        // Act — deep search and the legacy overload both reach into step output.
+        var deep = await _sut.GetRunsPageAsync(null, null, 0, 50, "steplevel555", true);
+        var legacy = await _sut.GetRunsPageAsync(search: "steplevel555");
+
+        // Assert
+        Assert.Contains(deep.Runs, r => r.Id == runId);
+        Assert.Contains(legacy.Runs, r => r.Id == runId);
+    }
+
+    [Fact]
+    public async Task GetRunsPageAsync_LegacyOverload_EqualsDeepSearch()
+    {
+        // Arrange
+        var flowId = Guid.NewGuid();
+        var ids = new List<Guid>();
+        for (var i = 0; i < 3; i++)
+        {
+            var rid = Guid.NewGuid();
+            ids.Add(rid);
+            await _sut.StartRunAsync(flowId, "ParityFlow", rid, "manual", null, null);
+            await _sut.RecordStepStartAsync(rid, "s", "T", null, null);
+            await _sut.RecordStepCompleteAsync(rid, "s", "Succeeded", "{\"k\":\"parityz\"}", null);
+        }
+
+        // Act — the legacy 5-arg overload must equal deepSearch:true for a fixed dataset.
+        var legacy = await _sut.GetRunsPageAsync(flowId, null, 0, 50, "parityz");
+        var deep = await _sut.GetRunsPageAsync(flowId, null, 0, 50, "parityz", true);
+
+        // Assert
+        Assert.Equal(3, legacy.TotalCount);
+        Assert.Equal(deep.TotalCount, legacy.TotalCount);
+        Assert.Equal(deep.Runs.Count, legacy.Runs.Count);
+        foreach (var id in ids)
+        {
+            Assert.Contains(legacy.Runs, r => r.Id == id);
+            Assert.Contains(deep.Runs, r => r.Id == id);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

**RUN search performance**
- Drop the redundant `FlowStepAttempts` scan from search (output duplicates the current step row); search still covers run identity columns + current step rows incl. output JSON.
- Single-pass pagination via `COUNT(*) OVER()` (no second COUNT query).
- New **non-breaking** `IFlowRunStore.GetRunsPageAsync(..., bool deepSearch, ...)` default-interface overload — `deepSearch:false` matches only top-level run columns (quick typeahead), `deepSearch:true` keeps the per-step scan. `/api/runs` accepts `deep=false`; un-updated stores delegate to deep and stay correct.
- Optional `startedFrom`/`startedTo` (`from`/`to`) start-time window to bound scans.
- PostgreSQL: migrator best-effort creates `pg_trgm` + GIN trigram indexes so `ILIKE` substring search is index-accelerated (graceful degrade without the extension).
- Command palette (Cmd/Ctrl+K) run lookup is server-backed via the quick path with request cancellation.

**Fixes**
- Dashboard shows the **Skip reason** for `Skipped` steps (was only rendered for `Failed`).
- PostgreSQL now persists the When-clause **"Why skipped" trace** (`evaluation_trace_json`), matching SQL Server (previously dropped on PG → empty trace panel).

**Deps:** consolidates dependabot PRs #73–#80 (Dapper, Testcontainers family, Aspire, TestHost, coverlet, setup-node).

## Test plan
- [x] `dotnet build` 0 warnings / 0 errors (net8/9/10)
- [x] Unit suite green
- [x] Integration suite green (SQL Server + PostgreSQL + Dashboard)
- [x] Regression suite green
- [x] e2e skill `RESULT: 33/33 passed` (all four sample instances incl. PG Why-skipped trace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)