### PR TITLE
chore(release): 1.27.3 — Aspire 13.3.5 AppHost bumps + WaitForSignal de-flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.27.3] - 2026-05-27
+
+### Dependencies
+
+- Bumped the Aspire AppHost hosting packages from **13.3.4 → 13.3.5**
+  (`Aspire.Hosting.PostgreSQL`, `Aspire.Hosting.SqlServer`,
+  `Aspire.Hosting.Azure.ServiceBus`). AppHost / sample-orchestration only — no
+  change to any shipped library package surface.
+
+### Tests
+
+- **De-flaked `WaitForSignalTests.HappyPath_SignalArrives_StepSucceeds_DownstreamConsumesPayload`.**
+  The assertion read `wait_for_approval`'s status from the `WaitForRunAsync`
+  snapshot, which could observe the step momentarily back in `Running` — a poll
+  re-dispatch queued before the signal can fire after the run is already
+  terminal and re-flip the pollable step. The test now reads the step's settled
+  status from a consistent run-store snapshot (the same race the sibling
+  `MultipleWaiters_*` test already guards against). Product behaviour unchanged.
+
 ## [1.27.2] - 2026-05-24
 
 ### Performance

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <RepositoryUrl>https://github.com/hoangsnowy/FlowOrchestrator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/hoangsnowy/FlowOrchestrator</PackageProjectUrl>
-    <VersionPrefix>1.27.2</VersionPrefix>
+    <VersionPrefix>1.27.3</VersionPrefix>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
 
   <!-- Aspire (orchestrator AppHost only) -->
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.4" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.5" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.4" />
     <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.5" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
   <!-- Aspire (orchestrator AppHost only) -->
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.5" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.4" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
     <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.5" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.4" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.4" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.4" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.5" />
   </ItemGroup>
 
   <!--

--- a/tests/integration/FlowOrchestrator.Testing.IntegrationTests/WaitForSignalTests.cs
+++ b/tests/integration/FlowOrchestrator.Testing.IntegrationTests/WaitForSignalTests.cs
@@ -30,6 +30,7 @@ public sealed class WaitForSignalTests
 
         var runId = await StartRunAsync(host);
         var signals = host.Services.GetRequiredService<IFlowSignalDispatcher>();
+        var runStore = host.Services.GetRequiredService<IFlowRunStore>();
 
         await WaitForWaiterAsync(host, runId, "wait_for_approval");
 
@@ -39,12 +40,19 @@ public sealed class WaitForSignalTests
 
         var result = await host.WaitForRunAsync(runId, TerminalTimeout);
 
+        // wait_for_approval is a pollable step: a poll re-dispatch queued before the
+        // signal can fire after the run is already terminal and momentarily re-flip the
+        // step to "Running" in the snapshot WaitForRunAsync returns. Read its settled
+        // status from a consistent run-store snapshot — same race as MultipleWaiters_*.
+        var settled = await WaitForStepStatusAsync(runStore, runId, "wait_for_approval", StepStatus.Succeeded);
+        var waitStep = settled!.Steps!.First(s => s.StepKey == "wait_for_approval");
+
         // Assert
         Assert.Equal(SignalDeliveryStatus.Delivered, delivery.Status);
         Assert.Equal("wait_for_approval", delivery.StepKey);
         Assert.False(result.TimedOut);
         Assert.Equal(RunStatus.Succeeded, result.Status);
-        Assert.Equal(StepStatus.Succeeded, result.Steps["wait_for_approval"].Status);
+        Assert.Equal("Succeeded", waitStep.Status);
         Assert.Equal(StepStatus.Succeeded, result.Steps["finalize"].Status);
         Assert.Equal("alice", result.Steps["finalize"].Output.GetProperty("Echoed").GetString());
     }


### PR DESCRIPTION
## Summary

- **Cherry-picked** the three Dependabot Aspire hosting bumps **13.3.4 → 13.3.5** (authorship preserved): `Aspire.Hosting.PostgreSQL` (#85), `Aspire.Hosting.SqlServer` (#86), `Aspire.Hosting.Azure.ServiceBus` (#84). AppHost / sample-orchestration only — no shipped library package surface changes.
- **Bumped `VersionPrefix` 1.27.2 → 1.27.3** + added the CHANGELOG `[1.27.3]` section.
- **De-flaked `WaitForSignalTests.HappyPath_SignalArrives_StepSucceeds_DownstreamConsumesPayload`** — the failure on PR #86's integration run (`Expected: Succeeded, Actual: Running`). Root cause is **not** the SqlServer bump: the test read the pollable `wait_for_approval` step's status from the `WaitForRunAsync` snapshot, which can catch a poll re-dispatch (queued before the signal) firing *after* the run is already terminal and momentarily re-flipping the step to `Running`. It now reads the settled status from a consistent run-store snapshot — the same race the sibling `MultipleWaiters_*` test already guards against. Product behaviour unchanged.

Supersedes #84 / #85 / #86 (their commits are cherry-picked here).

## Test plan

- [x] `dotnet build FlowOrchestrator.slnx` — 0 warnings, 0 errors
- [x] Unit suite green (net8/9/10)
- [x] `WaitForSignalTests` run 5× × 3 TFMs = 135/135 green (race confirmed gone)
- [ ] CI: unit + integration on this PR
- [ ] **Pre-release gate before tagging `v1.27.3`** (per CLAUDE.md): regression suite + `e2e` skill `RESULT: N/N` on the RC commit (needs Docker Desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)