### PR TITLE
chore: add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [hoangsnowy]


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` to display a **Sponsor** button on the repository page
- Points to GitHub Sponsors profile `hoangsnowy`

## Test plan
- [ ] Merge and verify the **Sponsor** button appears on the repo homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)