### PR TITLE
chore(deps): batch Dependabot bumps — Aspire 13.4.2, Npgsql 10.0.3, Test.Sdk 18.6.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
 
   <!-- Aspire (orchestrator AppHost only) -->
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.5" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.2" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.2" />
     <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.4.2" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,7 +48,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Npgsql" Version="10.0.2" />
+    <PackageVersion Include="Npgsql" Version="10.0.3" />
     <PackageVersion Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.5" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.2" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.5" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.4.2" />
   </ItemGroup>
 
   <!--

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,7 +65,7 @@
   <!-- Test infrastructure -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.27" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
   <!-- Aspire (orchestrator AppHost only) -->
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.5" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.5" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.2" />
     <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.3.5" />
   </ItemGroup>
 


### PR DESCRIPTION
## What

Consolidates the five open Dependabot version bumps into one PR (cherry-picked with `-x` so each original commit's SHA is recorded). All touch `Directory.Packages.props` (central package management).

| Package | From | To | Dependabot PR |
|---|---|---|---|
| Aspire.Hosting.SqlServer | 13.3.5 | 13.4.2 | #91 |
| Aspire.Hosting.Azure.ServiceBus | 13.3.5 | 13.4.2 | #89 |
| Aspire.Hosting.PostgreSQL | 13.3.5 | 13.4.2 | #90 |
| Microsoft.NET.Test.Sdk | 18.5.1 | 18.6.0 | #92 |
| Npgsql | 10.0.2 | 10.0.3 | #93 |

## Why batch

The three Aspire bumps each rewrote adjacent lines in the same `ItemGroup`, so merging them individually would have produced sequential conflicts. Cherry-picking onto one branch and resolving once keeps history clean and runs CI a single time.

## Verification

- `dotnet build FlowOrchestrator.slnx` — **0 errors, 0 warnings** with the new versions restored.
- `dotnet test FlowOrchestrator.UnitTests.slnx` — **all green** across net8.0 / net9.0 / net10.0 (confirms the Test.Sdk 18.6.0 runner bump works).

## Notes

- Aspire packages are AppHost-only (orchestrator sample); Npgsql backs the PostgreSQL storage adapter; Test.Sdk is test-runner infrastructure.
- Supersedes #89, #90, #91, #92, #93 — Dependabot will auto-close those once these versions land on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
