### PR TITLE
Dashboard run-search + ForEach loop fix + bundled dep bumps (#102–#107)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         tfm: [net8.0, net9.0, net10.0]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -60,7 +60,7 @@ jobs:
     needs: unit
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -100,7 +100,7 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0   # full history → DocFX "last modified" + contributor metadata
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
 
   <!-- Aspire (orchestrator AppHost only) -->
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.2" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.2" />
     <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.4.6" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -64,7 +64,7 @@
 
   <!-- Test infrastructure -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.27" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.28" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,7 +41,7 @@
     <PackageVersion Include="Hangfire.SqlServer" Version="1.8.23" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
   <!-- Aspire (orchestrator AppHost only) -->
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.2" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.4.6" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.2" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.2" />
-    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.4.2" />
+    <PackageVersion Include="Aspire.Hosting.Azure.ServiceBus" Version="13.4.6" />
   </ItemGroup>
 
   <!--

--- a/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Step.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Step.cs
@@ -230,7 +230,14 @@ public sealed partial class FlowOrchestratorEngine
             {
                 foreach (var child in hintChildren)
                 {
-                    if (flow.Manifest.Steps.FindStep(child.StepKey) is not null)
+                    // Reject hints that target a STATIC DAG step (one the planner dispatches on
+                    // its own) — but NOT loop fan-out children. A ForEach child key carries a
+                    // runtime iteration index ("{loop}.{index}.{child}"); StepCollection.FindStep
+                    // deliberately resolves such keys to the loop's template child, so without the
+                    // IsDynamicFanOutKey exemption this guard threw on every legitimate iteration,
+                    // leaving the loop step Succeeded while its children were never dispatched and
+                    // the downstream step never ran (the run hung forever).
+                    if (!IsDynamicFanOutKey(child.StepKey) && flow.Manifest.Steps.FindStep(child.StepKey) is not null)
                     {
                         throw new InvalidOperationException(
                             $"DispatchHint targeted static DAG step '{child.StepKey}'. " +
@@ -278,6 +285,29 @@ public sealed partial class FlowOrchestratorEngine
         {
             _contextAccessor.CurrentContext = null;
         }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="stepKey"/> is a dynamic loop
+    /// fan-out child — i.e. it carries a runtime iteration-index segment shaped
+    /// <c>{loopKey}.{index}.{childKey}</c>. Such keys are produced by
+    /// <see cref="ForEachStepHandler"/> and must NOT trip the static-DAG dispatch-hint guard,
+    /// even though <see cref="Abstractions.StepCollection.FindStep"/> resolves them to the
+    /// loop's template child. A key qualifies when any segment after the first parses as a
+    /// non-negative integer; the first segment is always the loop step's own (non-numeric) key.
+    /// </summary>
+    private static bool IsDynamicFanOutKey(string stepKey)
+    {
+        var segments = stepKey.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 1; i < segments.Length; i++)
+        {
+            if (int.TryParse(segments[i], out var index) && index >= 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <inheritdoc/>

--- a/src/FlowOrchestrator.Core/Execution/Internal/ForEachSourceResolver.cs
+++ b/src/FlowOrchestrator.Core/Execution/Internal/ForEachSourceResolver.cs
@@ -59,8 +59,14 @@ internal static class ForEachSourceResolver
                 return [];
             }
 
+            // Materialise each item into a plain CLR value graph rather than leaving it as a
+            // JsonElement. The item becomes __loopItem on each child step, which the engine may
+            // serialise through a runtime job store (Hangfire / Service Bus) using Newtonsoft.Json
+            // — and System.Text.Json.JsonElement does NOT round-trip through Newtonsoft, so a
+            // JsonElement item silently failed the child job and hung the run. Plain primitives /
+            // Dictionary / List round-trip through both serialisers and the handler input binder.
             return element.EnumerateArray()
-                .Select(x => (object?)x.Clone())
+                .Select(MaterializeJsonValue)
                 .ToList();
         }
 
@@ -81,6 +87,29 @@ internal static class ForEachSourceResolver
 
         return [];
     }
+
+    /// <summary>
+    /// Converts a <see cref="JsonElement"/> into a plain CLR value graph
+    /// (<see langword="string"/> / <see langword="long"/> / <see langword="double"/> /
+    /// <see langword="bool"/> / <see langword="null"/>, nested <see cref="Dictionary{TKey,TValue}"/>
+    /// for objects and <see cref="List{T}"/> for arrays). Unlike a raw <see cref="JsonElement"/>,
+    /// the result round-trips through Newtonsoft.Json (used by the Hangfire / Service Bus runtime
+    /// job stores) and the handler input binder.
+    /// </summary>
+    private static object? MaterializeJsonValue(JsonElement element) => element.ValueKind switch
+    {
+        JsonValueKind.String => element.GetString(),
+        // Cast to object so the conditional keeps long vs double — without it the ternary
+        // unifies to double and every integer item would box as 1.0 instead of 1.
+        JsonValueKind.Number => element.TryGetInt64(out var l) ? l : (object)element.GetDouble(),
+        JsonValueKind.True => true,
+        JsonValueKind.False => false,
+        JsonValueKind.Null or JsonValueKind.Undefined => null,
+        JsonValueKind.Object => element.EnumerateObject()
+            .ToDictionary(p => p.Name, p => MaterializeJsonValue(p.Value), StringComparer.Ordinal),
+        JsonValueKind.Array => element.EnumerateArray().Select(MaterializeJsonValue).ToList(),
+        _ => element.GetRawText()
+    };
 
     /// <summary>
     /// Fast-path check shared by the trigger-body and trigger-headers resolvers:

--- a/src/FlowOrchestrator.Dashboard/Assets/dashboard.css
+++ b/src/FlowOrchestrator.Dashboard/Assets/dashboard.css
@@ -272,6 +272,8 @@ input:focus-visible,select:focus-visible,textarea:focus-visible{outline:2px soli
 .badge-succeeded{background:var(--success-bg);color:var(--success-text);border:1px solid var(--success-border)}
 .badge-failed{background:var(--danger-bg);color:var(--danger-text);border:1px solid var(--danger-border)}
 .badge-skipped{background:var(--skip-bg);color:var(--skip-text);border:1px solid var(--skip-border)}
+.badge-cancelled{background:var(--skip-bg);color:var(--skip-text);border:1px solid var(--skip-border)}
+.badge-timedout{background:var(--warn-bg);color:var(--warn-text);border:1px solid var(--warn-border)}
 
 .flow-detail-panel{display:none;flex-direction:column;flex:1;overflow:hidden}
 .flow-detail-panel.show{display:flex}

--- a/src/FlowOrchestrator.Dashboard/Assets/index.html
+++ b/src/FlowOrchestrator.Dashboard/Assets/index.html
@@ -219,6 +219,8 @@
             <option value="Succeeded">Succeeded</option>
             <option value="Skipped">Blocked</option>
             <option value="Failed">Failed</option>
+            <option value="Cancelled">Cancelled</option>
+            <option value="TimedOut">Timed Out</option>
           </select>
         </div>
       </header>

--- a/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
+++ b/src/FlowOrchestrator.Dashboard/DashboardServiceCollectionExtensions.cs
@@ -605,6 +605,11 @@ public static class DashboardServiceCollectionExtensions
             Guid? flowId = query.TryGetValue("flowId", out var flowIdValues) && Guid.TryParse(flowIdValues, out var fid) ? fid : null;
             string? status = query.TryGetValue("status", out var statusValues) ? statusValues.ToString() : null;
             string? search = query.TryGetValue("search", out var searchValues) ? searchValues.ToString() : null;
+            // The dashboard renders the "Skipped" run status under the display label "Blocked",
+            // so a user typing what they see in the run search box would otherwise match nothing
+            // (the store searches the raw status column). Resolve the display label back to its
+            // canonical status token here — keeping the "Blocked" vocabulary inside the UI layer.
+            search = RunStatusDisplay.ResolveSearchAlias(search);
             int skip = query.TryGetValue("skip", out var skipValues) && int.TryParse(skipValues, out var s) ? s : 0;
             int take = query.TryGetValue("take", out var takeValues) && int.TryParse(takeValues, out var t) ? t : 50;
             bool includeTotal = query.TryGetValue("includeTotal", out var includeTotalValues)

--- a/src/FlowOrchestrator.Dashboard/RunStatusDisplay.cs
+++ b/src/FlowOrchestrator.Dashboard/RunStatusDisplay.cs
@@ -1,0 +1,31 @@
+namespace FlowOrchestrator.Dashboard;
+
+/// <summary>
+/// Maps between the canonical run-status tokens persisted by the engine and the
+/// display labels the dashboard SPA shows to users. The only divergence today is
+/// the <c>Skipped</c> status, surfaced as <c>"Blocked"</c> in the UI.
+/// </summary>
+internal static class RunStatusDisplay
+{
+    /// <summary>
+    /// Rewrites a free-text run-search term so a display label the user typed resolves to
+    /// the canonical status token the store matches against. A term that exactly equals a
+    /// known display alias (case-insensitive, e.g. <c>"Blocked"</c>) becomes its canonical
+    /// status (<c>"Skipped"</c>); any other value — including <see langword="null"/> or
+    /// whitespace — is returned unchanged so ordinary substring search is preserved.
+    /// </summary>
+    /// <param name="search">The raw search term from the run list / command palette query string.</param>
+    /// <returns>The canonical status token when the term is a display alias; otherwise the original term.</returns>
+    public static string? ResolveSearchAlias(string? search)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+        {
+            return search;
+        }
+
+        // "Blocked" is the dashboard's display label for the canonical "Skipped" run status.
+        return search.Trim().Equals("Blocked", StringComparison.OrdinalIgnoreCase)
+            ? "Skipped"
+            : search;
+    }
+}

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/DashboardJsContractTests.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/DashboardJsContractTests.cs
@@ -157,6 +157,22 @@ public sealed class DashboardJsContractTests : IDisposable
         Assert.Contains("function restoreRunsFiltersFromRoute(", html);
     }
 
+    // ── Run status filter covers every terminal status ───────────────────────
+
+    [Fact]
+    public async Task GET_root_run_status_filter_lists_cancelled_and_timedout()
+    {
+        // Arrange — runs can terminate as Cancelled or TimedOut (RunTerminationClassifier
+        // + engine control flow), so the status dropdown must offer them as filter options.
+
+        // Act
+        var html = await _body.Value;
+
+        // Assert
+        Assert.Contains("<option value=\"Cancelled\">Cancelled</option>", html, StringComparison.Ordinal);
+        Assert.Contains("<option value=\"TimedOut\">Timed Out</option>", html, StringComparison.Ordinal);
+    }
+
     // ── Memory cleanup on unload ──────────────────────────────────────────────
 
     [Fact]

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/RunEndpointTests.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/RunEndpointTests.cs
@@ -78,6 +78,22 @@ public sealed class RunEndpointTests : IDisposable
     }
 
     [Fact]
+    public async Task GET_api_runs_resolves_blocked_search_alias_to_skipped_status()
+    {
+        // Arrange — "Blocked" is the dashboard's display label for the canonical "Skipped"
+        // run status; a user searching the label must still match Skipped runs.
+        _server.FlowRunStore.GetRunsPageAsync(null, null, 0, 50, "Skipped", true, null, null)
+            .Returns((Array.Empty<FlowRunRecord>(), 0));
+
+        // Act
+        var response = await _client.GetAsync("/flows/api/runs?search=blocked");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await _server.FlowRunStore.Received(1).GetRunsPageAsync(null, null, 0, 50, "Skipped", true, null, null);
+    }
+
+    [Fact]
     public async Task GET_api_runs_active_returns_200()
     {
         // Arrange

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/RunStatusDisplayTests.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/RunStatusDisplayTests.cs
@@ -1,0 +1,54 @@
+namespace FlowOrchestrator.Dashboard.Tests;
+
+/// <summary>
+/// Unit coverage for <see cref="RunStatusDisplay.ResolveSearchAlias"/> — the seam that lets a
+/// run search by the dashboard's display label ("Blocked") match the canonical status token.
+/// </summary>
+public sealed class RunStatusDisplayTests
+{
+    [Theory]
+    [InlineData("blocked")]
+    [InlineData("Blocked")]
+    [InlineData("BLOCKED")]
+    [InlineData("  blocked  ")]
+    public void ResolveSearchAlias_BlockedDisplayLabel_MapsToSkipped(string term)
+    {
+        // Arrange
+
+        // Act
+        var resolved = RunStatusDisplay.ResolveSearchAlias(term);
+
+        // Assert
+        Assert.Equal("Skipped", resolved);
+    }
+
+    [Theory]
+    [InlineData("Failed", "Failed")]
+    [InlineData("order-flow", "order-flow")]
+    [InlineData("block", "block")]
+    public void ResolveSearchAlias_NonAliasTerm_ReturnsOriginal(string term, string expected)
+    {
+        // Arrange
+
+        // Act
+        var resolved = RunStatusDisplay.ResolveSearchAlias(term);
+
+        // Assert
+        Assert.Equal(expected, resolved);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveSearchAlias_NullOrWhitespace_ReturnsUnchanged(string? term)
+    {
+        // Arrange
+
+        // Act
+        var resolved = RunStatusDisplay.ResolveSearchAlias(term);
+
+        // Assert
+        Assert.Equal(term, resolved);
+    }
+}

--- a/tests/integration/FlowOrchestrator.Testing.IntegrationTests/Fixtures/ForEachTestFlow.cs
+++ b/tests/integration/FlowOrchestrator.Testing.IntegrationTests/Fixtures/ForEachTestFlow.cs
@@ -1,0 +1,61 @@
+using FlowOrchestrator.Core.Abstractions;
+
+namespace FlowOrchestrator.Testing.Tests.Fixtures;
+
+/// <summary>
+/// ForEach test flow: <c>prepare</c> → <c>process_items</c> (a ForEach loop over
+/// <c>@triggerBody()?.items</c>) → <c>finalize</c>. The loop child <c>iterate</c> runs once per
+/// item; <c>finalize</c> runs after the loop step completes.
+/// </summary>
+/// <remarks>
+/// Regression fixture for the dispatch-hint guard: a ForEach with a NON-empty collection must
+/// fan out its runtime children (<c>process_items.{index}.iterate</c>) and still advance to the
+/// downstream step. Previously every such child key tripped the "static DAG step" guard, so the
+/// loop reported Succeeded while no child ran and the run hung forever.
+/// </remarks>
+public sealed class ForEachTestFlow : IFlowDefinition
+{
+    /// <summary>Stable flow identifier.</summary>
+    public Guid Id { get; } = new("22222222-2222-2222-2222-222222222222");
+
+    /// <summary>Schema version.</summary>
+    public string Version => "1.0";
+
+    /// <summary>Trigger + step manifest with a single ForEach loop.</summary>
+    public FlowManifest Manifest { get; set; } = new()
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            ["prepare"] = new StepMetadata
+            {
+                Type = "Echo",
+                Inputs = new Dictionary<string, object?> { ["label"] = "start" }
+            },
+            ["process_items"] = new LoopStepMetadata
+            {
+                Type = "ForEach",
+                RunAfter = new RunAfterCollection { ["prepare"] = [StepStatus.Succeeded] },
+                ForEach = "@triggerBody()?.items",
+                ConcurrencyLimit = 2,
+                Steps = new StepCollection
+                {
+                    ["iterate"] = new StepMetadata
+                    {
+                        Type = "Echo",
+                        Inputs = new Dictionary<string, object?>()
+                    }
+                }
+            },
+            ["finalize"] = new StepMetadata
+            {
+                Type = "Echo",
+                RunAfter = new RunAfterCollection { ["process_items"] = [StepStatus.Succeeded] },
+                Inputs = new Dictionary<string, object?> { ["label"] = "done" }
+            }
+        }
+    };
+}

--- a/tests/integration/FlowOrchestrator.Testing.IntegrationTests/ForEachIterationTests.cs
+++ b/tests/integration/FlowOrchestrator.Testing.IntegrationTests/ForEachIterationTests.cs
@@ -1,0 +1,60 @@
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Testing.Tests.Fixtures;
+
+namespace FlowOrchestrator.Testing.Tests;
+
+/// <summary>
+/// End-to-end coverage for ForEach loop fan-out through the real engine + InMemory runtime.
+/// Regression for the dispatch-hint guard that treated each runtime loop-child key
+/// (<c>{loop}.{index}.{child}</c>) as a static DAG step and threw, leaving the loop step
+/// Succeeded while its children never dispatched and the downstream step never ran.
+/// </summary>
+public sealed class ForEachIterationTests
+{
+    [Fact]
+    public async Task ForEachWithItems_dispatchesEveryChild_andRunsDownstream()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<ForEachTestFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithHandler<ForEachStepHandler>("ForEach")
+            .BuildAsync();
+
+        // Act
+        var result = await host.TriggerAsync(
+            body: new { items = new[] { "a", "b", "c" } },
+            timeout: TimeSpan.FromSeconds(15));
+
+        // Assert
+        Assert.False(result.TimedOut);
+        Assert.Equal(RunStatus.Succeeded, result.Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["process_items"].Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["finalize"].Status);
+        for (var index = 0; index < 3; index++)
+        {
+            Assert.Equal(StepStatus.Succeeded, result.Steps[$"process_items.{index}.iterate"].Status);
+        }
+    }
+
+    [Fact]
+    public async Task ForEachWithEmptyCollection_completesWithoutIterations()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<ForEachTestFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithHandler<ForEachStepHandler>("ForEach")
+            .BuildAsync();
+
+        // Act
+        var result = await host.TriggerAsync(
+            body: new { items = Array.Empty<string>() },
+            timeout: TimeSpan.FromSeconds(15));
+
+        // Assert
+        Assert.False(result.TimedOut);
+        Assert.Equal(RunStatus.Succeeded, result.Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["finalize"].Status);
+        Assert.DoesNotContain(result.Steps.Keys, key => key.StartsWith("process_items.0.", StringComparison.Ordinal));
+    }
+}

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/ForEachItemMaterializationTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/ForEachItemMaterializationTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Execution;
+using NSubstitute;
+using CoreExecutionContext = FlowOrchestrator.Core.Execution.ExecutionContext;
+
+namespace FlowOrchestrator.Core.Tests.Execution;
+
+/// <summary>
+/// Regression: ForEach must materialise iteration items into plain CLR values before they
+/// become <c>__loopItem</c> on each child step. A raw <see cref="JsonElement"/> does NOT
+/// round-trip through Newtonsoft.Json (the Hangfire / Service Bus runtime job stores), so a
+/// JsonElement item silently failed the child job and hung the run on those runtimes.
+/// </summary>
+public sealed class ForEachItemMaterializationTests
+{
+    [Fact]
+    public async Task ExecuteAsync_JsonArraySource_ChildLoopItemsAreClrStrings_NotJsonElement()
+    {
+        // Arrange
+        var loop = new LoopStepMetadata
+        {
+            Type = "ForEach",
+            ForEach = "@triggerBody()?.orderIds",
+            Steps = new StepCollection { ["validate"] = new StepMetadata { Type = "Work" } }
+        };
+        var flow = Substitute.For<IFlowDefinition>();
+        flow.Id.Returns(Guid.NewGuid());
+        flow.Manifest.Returns(new FlowManifest { Steps = new StepCollection { ["loop"] = loop } });
+
+        var ctx = new CoreExecutionContext
+        {
+            RunId = Guid.NewGuid(),
+            TriggerData = JsonDocument.Parse("""{"orderIds":["ORD-001","ORD-002","ORD-003"]}""").RootElement,
+            TriggerHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        };
+        var step = new StepInstance("loop", "ForEach") { RunId = ctx.RunId };
+
+        // Act
+        var result = await new ForEachStepHandler().ExecuteAsync(ctx, flow, step);
+
+        // Assert
+        var stepResult = Assert.IsType<StepResult>(result);
+        Assert.Equal(StepStatus.Succeeded, stepResult.Status);
+        Assert.NotNull(stepResult.DispatchHint);
+        var loopItems = stepResult.DispatchHint!.Spawn.Select(child => child.Inputs["__loopItem"]).ToList();
+        Assert.Equal(3, loopItems.Count);
+        Assert.All(loopItems, item => Assert.IsType<string>(item));
+        Assert.Equal(new[] { "ORD-001", "ORD-002", "ORD-003" }, loopItems.Cast<string>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_JsonObjectItems_MaterialiseToDictionaries_NotJsonElement()
+    {
+        // Arrange — object-shaped items must also materialise to a Newtonsoft-friendly graph.
+        var loop = new LoopStepMetadata
+        {
+            Type = "ForEach",
+            ForEach = "@triggerBody()?.orders",
+            Steps = new StepCollection { ["validate"] = new StepMetadata { Type = "Work" } }
+        };
+        var flow = Substitute.For<IFlowDefinition>();
+        flow.Id.Returns(Guid.NewGuid());
+        flow.Manifest.Returns(new FlowManifest { Steps = new StepCollection { ["loop"] = loop } });
+
+        var ctx = new CoreExecutionContext
+        {
+            RunId = Guid.NewGuid(),
+            TriggerData = JsonDocument.Parse("""{"orders":[{"id":1},{"id":2}]}""").RootElement,
+            TriggerHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        };
+        var step = new StepInstance("loop", "ForEach") { RunId = ctx.RunId };
+
+        // Act
+        var result = await new ForEachStepHandler().ExecuteAsync(ctx, flow, step);
+
+        // Assert
+        var stepResult = Assert.IsType<StepResult>(result);
+        var loopItems = stepResult.DispatchHint!.Spawn.Select(child => child.Inputs["__loopItem"]).ToList();
+        Assert.Equal(2, loopItems.Count);
+        Assert.All(loopItems, item => Assert.IsType<Dictionary<string, object?>>(item));
+        Assert.Equal(1L, ((Dictionary<string, object?>)loopItems[0]!)["id"]);
+    }
+}


### PR DESCRIPTION
Combines three independent, verified changes into one PR (dashboard run-search fix, ForEach loop-execution fix, and the six open Dependabot bumps). Supersedes #109.

---

## 1. Dashboard run search reaches all statuses

- **`Cancelled` / `TimedOut` runs were unfilterable** — the status dropdown only listed Running/Succeeded/Skipped/Failed, even though runs persist `Cancelled` and `TimedOut`. Added both options + token-based badge styles (were unstyled).
- **Searching the visible label "Blocked" matched nothing** — the SPA renders the canonical `Skipped` status as **Blocked**, but the store searches the raw status column. The `/runs` endpoint now resolves that display alias to `Skipped` (`RunStatusDisplay.ResolveSearchAlias`); covers the main list and the command-palette quick search.

## 2. ForEach loop fix — runs hung when the collection was non-empty (all runtimes)

A ForEach run with >=1 item hung: loop step `Succeeded`, but no child ran and the downstream step never started. Two defects:

- **Dispatch-hint guard rejected loop children** — the guard in `RunStepAsync` threw on any hint child that `StepCollection.FindStep` resolves, but loop child keys `{loop}.{index}.{child}` deliberately resolve to the template child. Fixed with `IsDynamicFanOutKey` (exempts runtime iteration keys).
- **Items were `JsonElement`, broke Hangfire / Service Bus** — `ForEachSourceResolver` left each item as `System.Text.Json.JsonElement` (set as `__loopItem`); the Hangfire/Service Bus runtimes serialize the child step via Newtonsoft.Json, which can't round-trip a `JsonElement`, so child jobs failed at deserialize. Now materialized to a plain CLR value graph (integers box as `long`).

## 3. Bundled Dependabot bumps (cherry-picked, originals left open)

#102 TestHost 8.0.27→8.0.28 · #103 DI.Abstractions 10.0.8→10.0.9 · #104 actions/checkout 6→7 · #105 Aspire.ServiceBus · #106 Aspire.PostgreSQL · #107 Aspire.SqlServer (all 13.4.2→13.4.6; resolved a `Directory.Packages.props` conflict). Dependabot auto-closes them once the bumps land on `main`.

## Test plan

- `dotnet build FlowOrchestrator.slnx -c Release` → **0 warnings, 0 errors** (net8/9/10, with the bumps).
- Full unit suite green (Core 289, +`ForEachItemMaterializationTests`).
- Integration: `Dashboard.IntegrationTests` 226/TFM (+ run-search alias / dropdown contract), `Testing.IntegrationTests` 17/TFM (+ `ForEachIterationTests`).
- **e2e (Aspire AppHost, all four instances):**
  - ForEach `OrderBatchFlow` items[3] → run `Succeeded`, 3 children, `finalize_batch` Succeeded on **sqlserver/Hangfire, postgresql/Hangfire, inmemory, servicebus** (all previously hung).
  - Dashboard run-search surface verified (new status options served, run lifecycle across runtimes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
