### PR TITLE
fix(engine): dispatch ForEach loop children for non-empty collections

### DIFF
--- a/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Step.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Step.cs
@@ -230,7 +230,14 @@ public sealed partial class FlowOrchestratorEngine
             {
                 foreach (var child in hintChildren)
                 {
-                    if (flow.Manifest.Steps.FindStep(child.StepKey) is not null)
+                    // Reject hints that target a STATIC DAG step (one the planner dispatches on
+                    // its own) — but NOT loop fan-out children. A ForEach child key carries a
+                    // runtime iteration index ("{loop}.{index}.{child}"); StepCollection.FindStep
+                    // deliberately resolves such keys to the loop's template child, so without the
+                    // IsDynamicFanOutKey exemption this guard threw on every legitimate iteration,
+                    // leaving the loop step Succeeded while its children were never dispatched and
+                    // the downstream step never ran (the run hung forever).
+                    if (!IsDynamicFanOutKey(child.StepKey) && flow.Manifest.Steps.FindStep(child.StepKey) is not null)
                     {
                         throw new InvalidOperationException(
                             $"DispatchHint targeted static DAG step '{child.StepKey}'. " +
@@ -278,6 +285,29 @@ public sealed partial class FlowOrchestratorEngine
         {
             _contextAccessor.CurrentContext = null;
         }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="stepKey"/> is a dynamic loop
+    /// fan-out child — i.e. it carries a runtime iteration-index segment shaped
+    /// <c>{loopKey}.{index}.{childKey}</c>. Such keys are produced by
+    /// <see cref="ForEachStepHandler"/> and must NOT trip the static-DAG dispatch-hint guard,
+    /// even though <see cref="Abstractions.StepCollection.FindStep"/> resolves them to the
+    /// loop's template child. A key qualifies when any segment after the first parses as a
+    /// non-negative integer; the first segment is always the loop step's own (non-numeric) key.
+    /// </summary>
+    private static bool IsDynamicFanOutKey(string stepKey)
+    {
+        var segments = stepKey.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        for (var i = 1; i < segments.Length; i++)
+        {
+            if (int.TryParse(segments[i], out var index) && index >= 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <inheritdoc/>

--- a/src/FlowOrchestrator.Core/Execution/Internal/ForEachSourceResolver.cs
+++ b/src/FlowOrchestrator.Core/Execution/Internal/ForEachSourceResolver.cs
@@ -59,8 +59,14 @@ internal static class ForEachSourceResolver
                 return [];
             }
 
+            // Materialise each item into a plain CLR value graph rather than leaving it as a
+            // JsonElement. The item becomes __loopItem on each child step, which the engine may
+            // serialise through a runtime job store (Hangfire / Service Bus) using Newtonsoft.Json
+            // — and System.Text.Json.JsonElement does NOT round-trip through Newtonsoft, so a
+            // JsonElement item silently failed the child job and hung the run. Plain primitives /
+            // Dictionary / List round-trip through both serialisers and the handler input binder.
             return element.EnumerateArray()
-                .Select(x => (object?)x.Clone())
+                .Select(MaterializeJsonValue)
                 .ToList();
         }
 
@@ -81,6 +87,29 @@ internal static class ForEachSourceResolver
 
         return [];
     }
+
+    /// <summary>
+    /// Converts a <see cref="JsonElement"/> into a plain CLR value graph
+    /// (<see langword="string"/> / <see langword="long"/> / <see langword="double"/> /
+    /// <see langword="bool"/> / <see langword="null"/>, nested <see cref="Dictionary{TKey,TValue}"/>
+    /// for objects and <see cref="List{T}"/> for arrays). Unlike a raw <see cref="JsonElement"/>,
+    /// the result round-trips through Newtonsoft.Json (used by the Hangfire / Service Bus runtime
+    /// job stores) and the handler input binder.
+    /// </summary>
+    private static object? MaterializeJsonValue(JsonElement element) => element.ValueKind switch
+    {
+        JsonValueKind.String => element.GetString(),
+        // Cast to object so the conditional keeps long vs double — without it the ternary
+        // unifies to double and every integer item would box as 1.0 instead of 1.
+        JsonValueKind.Number => element.TryGetInt64(out var l) ? l : (object)element.GetDouble(),
+        JsonValueKind.True => true,
+        JsonValueKind.False => false,
+        JsonValueKind.Null or JsonValueKind.Undefined => null,
+        JsonValueKind.Object => element.EnumerateObject()
+            .ToDictionary(p => p.Name, p => MaterializeJsonValue(p.Value), StringComparer.Ordinal),
+        JsonValueKind.Array => element.EnumerateArray().Select(MaterializeJsonValue).ToList(),
+        _ => element.GetRawText()
+    };
 
     /// <summary>
     /// Fast-path check shared by the trigger-body and trigger-headers resolvers:

--- a/tests/integration/FlowOrchestrator.Testing.IntegrationTests/Fixtures/ForEachTestFlow.cs
+++ b/tests/integration/FlowOrchestrator.Testing.IntegrationTests/Fixtures/ForEachTestFlow.cs
@@ -1,0 +1,61 @@
+using FlowOrchestrator.Core.Abstractions;
+
+namespace FlowOrchestrator.Testing.Tests.Fixtures;
+
+/// <summary>
+/// ForEach test flow: <c>prepare</c> → <c>process_items</c> (a ForEach loop over
+/// <c>@triggerBody()?.items</c>) → <c>finalize</c>. The loop child <c>iterate</c> runs once per
+/// item; <c>finalize</c> runs after the loop step completes.
+/// </summary>
+/// <remarks>
+/// Regression fixture for the dispatch-hint guard: a ForEach with a NON-empty collection must
+/// fan out its runtime children (<c>process_items.{index}.iterate</c>) and still advance to the
+/// downstream step. Previously every such child key tripped the "static DAG step" guard, so the
+/// loop reported Succeeded while no child ran and the run hung forever.
+/// </remarks>
+public sealed class ForEachTestFlow : IFlowDefinition
+{
+    /// <summary>Stable flow identifier.</summary>
+    public Guid Id { get; } = new("22222222-2222-2222-2222-222222222222");
+
+    /// <summary>Schema version.</summary>
+    public string Version => "1.0";
+
+    /// <summary>Trigger + step manifest with a single ForEach loop.</summary>
+    public FlowManifest Manifest { get; set; } = new()
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            ["prepare"] = new StepMetadata
+            {
+                Type = "Echo",
+                Inputs = new Dictionary<string, object?> { ["label"] = "start" }
+            },
+            ["process_items"] = new LoopStepMetadata
+            {
+                Type = "ForEach",
+                RunAfter = new RunAfterCollection { ["prepare"] = [StepStatus.Succeeded] },
+                ForEach = "@triggerBody()?.items",
+                ConcurrencyLimit = 2,
+                Steps = new StepCollection
+                {
+                    ["iterate"] = new StepMetadata
+                    {
+                        Type = "Echo",
+                        Inputs = new Dictionary<string, object?>()
+                    }
+                }
+            },
+            ["finalize"] = new StepMetadata
+            {
+                Type = "Echo",
+                RunAfter = new RunAfterCollection { ["process_items"] = [StepStatus.Succeeded] },
+                Inputs = new Dictionary<string, object?> { ["label"] = "done" }
+            }
+        }
+    };
+}

--- a/tests/integration/FlowOrchestrator.Testing.IntegrationTests/ForEachIterationTests.cs
+++ b/tests/integration/FlowOrchestrator.Testing.IntegrationTests/ForEachIterationTests.cs
@@ -1,0 +1,60 @@
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Testing.Tests.Fixtures;
+
+namespace FlowOrchestrator.Testing.Tests;
+
+/// <summary>
+/// End-to-end coverage for ForEach loop fan-out through the real engine + InMemory runtime.
+/// Regression for the dispatch-hint guard that treated each runtime loop-child key
+/// (<c>{loop}.{index}.{child}</c>) as a static DAG step and threw, leaving the loop step
+/// Succeeded while its children never dispatched and the downstream step never ran.
+/// </summary>
+public sealed class ForEachIterationTests
+{
+    [Fact]
+    public async Task ForEachWithItems_dispatchesEveryChild_andRunsDownstream()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<ForEachTestFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithHandler<ForEachStepHandler>("ForEach")
+            .BuildAsync();
+
+        // Act
+        var result = await host.TriggerAsync(
+            body: new { items = new[] { "a", "b", "c" } },
+            timeout: TimeSpan.FromSeconds(15));
+
+        // Assert
+        Assert.False(result.TimedOut);
+        Assert.Equal(RunStatus.Succeeded, result.Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["process_items"].Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["finalize"].Status);
+        for (var index = 0; index < 3; index++)
+        {
+            Assert.Equal(StepStatus.Succeeded, result.Steps[$"process_items.{index}.iterate"].Status);
+        }
+    }
+
+    [Fact]
+    public async Task ForEachWithEmptyCollection_completesWithoutIterations()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<ForEachTestFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithHandler<ForEachStepHandler>("ForEach")
+            .BuildAsync();
+
+        // Act
+        var result = await host.TriggerAsync(
+            body: new { items = Array.Empty<string>() },
+            timeout: TimeSpan.FromSeconds(15));
+
+        // Assert
+        Assert.False(result.TimedOut);
+        Assert.Equal(RunStatus.Succeeded, result.Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["finalize"].Status);
+        Assert.DoesNotContain(result.Steps.Keys, key => key.StartsWith("process_items.0.", StringComparison.Ordinal));
+    }
+}

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/ForEachItemMaterializationTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/ForEachItemMaterializationTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Execution;
+using NSubstitute;
+using CoreExecutionContext = FlowOrchestrator.Core.Execution.ExecutionContext;
+
+namespace FlowOrchestrator.Core.Tests.Execution;
+
+/// <summary>
+/// Regression: ForEach must materialise iteration items into plain CLR values before they
+/// become <c>__loopItem</c> on each child step. A raw <see cref="JsonElement"/> does NOT
+/// round-trip through Newtonsoft.Json (the Hangfire / Service Bus runtime job stores), so a
+/// JsonElement item silently failed the child job and hung the run on those runtimes.
+/// </summary>
+public sealed class ForEachItemMaterializationTests
+{
+    [Fact]
+    public async Task ExecuteAsync_JsonArraySource_ChildLoopItemsAreClrStrings_NotJsonElement()
+    {
+        // Arrange
+        var loop = new LoopStepMetadata
+        {
+            Type = "ForEach",
+            ForEach = "@triggerBody()?.orderIds",
+            Steps = new StepCollection { ["validate"] = new StepMetadata { Type = "Work" } }
+        };
+        var flow = Substitute.For<IFlowDefinition>();
+        flow.Id.Returns(Guid.NewGuid());
+        flow.Manifest.Returns(new FlowManifest { Steps = new StepCollection { ["loop"] = loop } });
+
+        var ctx = new CoreExecutionContext
+        {
+            RunId = Guid.NewGuid(),
+            TriggerData = JsonDocument.Parse("""{"orderIds":["ORD-001","ORD-002","ORD-003"]}""").RootElement,
+            TriggerHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        };
+        var step = new StepInstance("loop", "ForEach") { RunId = ctx.RunId };
+
+        // Act
+        var result = await new ForEachStepHandler().ExecuteAsync(ctx, flow, step);
+
+        // Assert
+        var stepResult = Assert.IsType<StepResult>(result);
+        Assert.Equal(StepStatus.Succeeded, stepResult.Status);
+        Assert.NotNull(stepResult.DispatchHint);
+        var loopItems = stepResult.DispatchHint!.Spawn.Select(child => child.Inputs["__loopItem"]).ToList();
+        Assert.Equal(3, loopItems.Count);
+        Assert.All(loopItems, item => Assert.IsType<string>(item));
+        Assert.Equal(new[] { "ORD-001", "ORD-002", "ORD-003" }, loopItems.Cast<string>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_JsonObjectItems_MaterialiseToDictionaries_NotJsonElement()
+    {
+        // Arrange — object-shaped items must also materialise to a Newtonsoft-friendly graph.
+        var loop = new LoopStepMetadata
+        {
+            Type = "ForEach",
+            ForEach = "@triggerBody()?.orders",
+            Steps = new StepCollection { ["validate"] = new StepMetadata { Type = "Work" } }
+        };
+        var flow = Substitute.For<IFlowDefinition>();
+        flow.Id.Returns(Guid.NewGuid());
+        flow.Manifest.Returns(new FlowManifest { Steps = new StepCollection { ["loop"] = loop } });
+
+        var ctx = new CoreExecutionContext
+        {
+            RunId = Guid.NewGuid(),
+            TriggerData = JsonDocument.Parse("""{"orders":[{"id":1},{"id":2}]}""").RootElement,
+            TriggerHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        };
+        var step = new StepInstance("loop", "ForEach") { RunId = ctx.RunId };
+
+        // Act
+        var result = await new ForEachStepHandler().ExecuteAsync(ctx, flow, step);
+
+        // Assert
+        var stepResult = Assert.IsType<StepResult>(result);
+        var loopItems = stepResult.DispatchHint!.Spawn.Select(child => child.Inputs["__loopItem"]).ToList();
+        Assert.Equal(2, loopItems.Count);
+        Assert.All(loopItems, item => Assert.IsType<Dictionary<string, object?>>(item));
+        Assert.Equal(1L, ((Dictionary<string, object?>)loopItems[0]!)["id"]);
+    }
+}


### PR DESCRIPTION
## Summary

A ForEach loop run whose collection had **>=1 item hung forever**, on **every runtime**: the loop step was recorded `Succeeded`, but no child iteration ran and the downstream step never started. Empty collections worked, which masked it. Two independent defects, both fixed here:

Found during the e2e run of the dashboard PR (#108); confirmed independent of it and fixed against `main`.

## Bug 1 — dispatch-hint guard rejected loop children (all runtimes)

In `FlowOrchestratorEngine.RunStepAsync`, the dispatch-hint guard rejects any hint child whose key resolves via `StepCollection.FindStep` (to stop hints targeting static DAG steps). But a loop child key — `{loop}.{index}.{child}` — **deliberately** resolves to the loop's template child (`FindStep` skips the numeric iteration segment). So the guard threw on every legitimate iteration, *after* the loop step was recorded `Succeeded` and *before* the graph continuation ran → children never dispatched, downstream never fired, run stuck `Running`.

**Fix:** exempt dynamic loop fan-out keys (those carrying a runtime iteration-index segment) from the guard via `IsDynamicFanOutKey`. The guard still rejects hints targeting genuine static steps.

## Bug 2 — ForEach items were JsonElement, broke Hangfire / Service Bus

`ForEachSourceResolver.ToItemList` returned each item as a `System.Text.Json.JsonElement` and set it as `__loopItem` on each child. That is fine in-process (InMemory), but the **Hangfire** and **Service Bus** runtimes serialize the dispatched child step through **Newtonsoft.Json**, which cannot round-trip a `JsonElement` — so each child job failed at the deserialize boundary and never executed (with Bug 1 fixed, the loop + downstream completed but the children produced no step rows). This was masked by Bug 1 (the guard threw before any child was ever dispatched).

**Fix:** materialize each JSON item into a plain CLR value graph (`string` / `long` / `double` / `bool` / `null`, `Dictionary` for objects, `List` for arrays) — round-trips through both serializers and the handler input binder. Integers now box as `long` (the conditional previously unified `long`/`double` to `double`).

## Test plan

- `dotnet build FlowOrchestrator.slnx` → 0 errors (pre-existing `NU1902/NU1903` MessagePack transitive warnings via Aspire AppHost only — unrelated).
- Full unit suite green; `FlowOrchestrator.Core.UnitTests` **289** incl. new `ForEachItemMaterializationTests` (string + object items materialize to CLR, no `JsonElement` leak into `__loopItem`).
- `FlowOrchestrator.Testing.IntegrationTests` **17/17** per TFM incl. new end-to-end `ForEachIterationTests` (3-item loop dispatches all children + runs downstream; empty path still clean).
- **e2e (Aspire AppHost, fresh stack, all four instances):** `OrderBatchFlow` with `orderIds:[3]` → **run `Succeeded`, 3 `validate_order` children Succeeded, `finalize_batch` Succeeded** on every runtime:
  - `flow-sqlserver` (Hangfire) ✓
  - `flow-postgresql` (Hangfire) ✓
  - `flow-inmemory` (InMemory) ✓
  - `flow-servicebus` (Service Bus) ✓

  (Previously hung on all four.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
