### PR TITLE
fix: dashboard Retry past timeout deadline + periodic timeout enforcement (bundles all 9 Dependabot bumps)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Setup Node.js
         if: matrix.language == 'javascript-typescript'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.29.0] - 2026-07-19
+
+### Added
+
+- **Retry now refreshes a run's execution window.** New
+  `IFlowRunControlStore.ExtendDeadlineAsync(runId, newTimeoutAtUtc)` (shipped as a
+  default interface method so existing custom control stores compile unchanged),
+  implemented in InMemory / SQL Server / PostgreSQL. `RetryStepAsync` calls it
+  before re-dispatch so a step retried after the run's timeout deadline lapsed
+  actually re-executes instead of being skipped by the termination gate.
+- **Periodic timeout-enforcement service.** New `IRunTimeoutEnforcer` +
+  `FlowTimeoutEnforcementHostedService`, governed by
+  `FlowRunControlOptions.TimeoutEnforcementInterval` (default 30 s; null/non-positive
+  disables). It proactively completes genuinely stuck runs (past their deadline with
+  no in-flight work) as `TimedOut`, so a run whose step threw and left nothing
+  scheduled no longer sits `Running` indefinitely.
+- **Idempotent run completion.** New `IFlowRunStore.CompleteRunIfActiveAsync`
+  (default interface method) — a guarded, atomic `Running → terminal` transition
+  that reports whether the caller won the race, so a run's lifecycle event fires
+  exactly once even with concurrent completers (graph continuation + timeout sweep,
+  single- or multi-instance).
+
+### Fixed
+
+- **Dashboard Retry was a permanent no-op past a run's timeout deadline.**
+  `RetryStepAsync` reset only the run/step rows, never the control record, so once
+  `TimeoutAtUtc` lapsed (or the run was latched `TimedOut`) the re-dispatched step
+  was skipped as `"Run is TimedOut."` before the handler ran — the run was
+  unrecoverable from the dashboard. It now refreshes the deadline (un-latching only
+  timeout-induced termination, preserving a genuine user cancel).
+- **A stuck `Running` run no longer sits forever.** `MarkTimedOutAsync`'s
+  "timeout-enforcement background service" now actually exists (see Added).
+- **Timeout enforcement no longer mislabels a user cancellation.** A genuine user
+  cancel wins over a merely-lapsed deadline, and the sweep finalizes a stuck,
+  user-cancelled run as `Cancelled` (without latching the timeout), so a later retry
+  still preserves the cancellation.
+- **`MarkTimedOutAsync` return-value contract aligned across backends.** SQL Server
+  and PostgreSQL now guard on `timed_out_at_utc IS NULL`, so a repeat call is a true
+  no-op returning `false`, matching the InMemory store.
+
+### Dependencies
+
+- Microsoft.Extensions.Logging 10.0.8 → 10.0.9; OpenTelemetry 1.15.3 → 1.16.0;
+  OpenTelemetry.Instrumentation.AspNetCore 1.15.2 → 1.16.0; System.Text.Json
+  10.0.8 → 10.0.9; Testcontainers 4.12.0 → 4.13.0; actions/setup-node 6 → 7;
+  Azure.Messaging.ServiceBus 7.20.1 → 7.20.2; Microsoft.NET.Test.Sdk 18.7.0 →
+  18.8.0; NSubstitute 5.3.0 → 6.0.0 (test-suite migrated to its nullable-annotated API).
+
 ## [1.28.0] - 2026-06-05
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <RepositoryUrl>https://github.com/hoangsnowy/FlowOrchestrator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/hoangsnowy/FlowOrchestrator</PackageProjectUrl>
-    <VersionPrefix>1.28.2</VersionPrefix>
+    <VersionPrefix>1.29.0</VersionPrefix>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,7 +46,7 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Npgsql" Version="10.0.3" />
     <PackageVersion Include="System.Text.Json" Version="10.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -70,7 +70,7 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.12.0" />
-    <PackageVersion Include="Testcontainers" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers" Version="4.13.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
   -->
   <ItemGroup>
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.2" />
     <PackageVersion Include="Cronos" Version="0.13.0" />
     <PackageVersion Include="Dapper" Version="2.1.79" />
     <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.23" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Npgsql" Version="10.0.3" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.8" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
 
   <!-- Observability — keep all OpenTelemetry packages on the same release line. -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,7 +66,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.28" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.0" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.12.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -59,7 +59,7 @@
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
   </ItemGroup>
 
   <!-- Test infrastructure -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,7 +65,7 @@
   <!-- Test infrastructure -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.28" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,7 +54,7 @@
 
   <!-- Observability — keep all OpenTelemetry packages on the same release line. -->
   <ItemGroup>
-    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/src/FlowOrchestrator.Core/Configuration/FlowSchedulerOptions.cs
+++ b/src/FlowOrchestrator.Core/Configuration/FlowSchedulerOptions.cs
@@ -21,10 +21,24 @@ public sealed class FlowSchedulerOptions
 public sealed class FlowRunControlOptions
 {
     /// <summary>
-    /// Default timeout applied to every run. Steps check this deadline and exit if exceeded.
-    /// <see langword="null"/> disables timeout enforcement globally.
+    /// Default timeout applied to every run. Enforcement is twofold: lazily when a step is dispatched
+    /// after the deadline (the step is skipped and the run marked <c>TimedOut</c>), and proactively by
+    /// the periodic sweep governed by <see cref="TimeoutEnforcementInterval"/>. A per-run override may
+    /// be supplied via the trigger payload's <c>runTimeoutSeconds</c>. <see langword="null"/> disables
+    /// the default timeout globally.
     /// </summary>
     public TimeSpan? DefaultRunTimeout { get; set; }
+
+    /// <summary>
+    /// How often the periodic timeout-enforcement sweep runs, proactively marking runs whose
+    /// <c>TimeoutAtUtc</c> has passed as <c>TimedOut</c> so a stuck run does not sit <c>Running</c>
+    /// indefinitely. <see langword="null"/> or a non-positive value disables the sweep.
+    /// </summary>
+    /// <remarks>
+    /// The sweep is cheap when no run has a deadline (no <see cref="DefaultRunTimeout"/> and no per-run
+    /// override) — it queries active runs and finds nothing to do.
+    /// </remarks>
+    public TimeSpan? TimeoutEnforcementInterval { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// Name of the HTTP header that carries the caller-supplied idempotency key

--- a/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Control.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Control.cs
@@ -102,7 +102,15 @@ public sealed partial class FlowOrchestratorEngine
             return;
         }
 
-        await _runStore.CompleteRunAsync(runId, status).ConfigureAwait(false);
+        // Idempotent, race-safe completion: only the call that actually transitions the run out of
+        // Running publishes the lifecycle event and bumps telemetry. Collapses the race between the
+        // graph continuation and the periodic timeout sweep (single- or multi-instance) without a
+        // distributed lock — the TOCTOU between HasInFlightWorkAsync and the write is closed by the
+        // guarded transition inside CompleteRunIfActiveAsync.
+        if (!await _runStore.CompleteRunIfActiveAsync(runId, status).ConfigureAwait(false))
+        {
+            return;
+        }
 
         if (_observabilityOptions.EnableOpenTelemetry)
         {
@@ -156,15 +164,19 @@ public sealed partial class FlowOrchestratorEngine
             return "TimedOut";
         }
 
+        // A genuine user cancellation (CancelRequested set while never timed out) wins over a merely
+        // lapsed deadline — otherwise a cancelled run whose deadline also passed would be mislabelled
+        // TimedOut, and a subsequent retry would then clear the cancel latch. Checked BEFORE the
+        // deadline branch so cancel intent is honoured.
+        if (control.CancelRequested)
+        {
+            return "Cancelled";
+        }
+
         if (control.TimeoutAtUtc is not null && DateTimeOffset.UtcNow >= control.TimeoutAtUtc.Value)
         {
             await _runControlStore.MarkTimedOutAsync(runId, "Run timed out before scheduling next step.").ConfigureAwait(false);
             return "TimedOut";
-        }
-
-        if (control.CancelRequested)
-        {
-            return "Cancelled";
         }
 
         return null;
@@ -215,7 +227,18 @@ public sealed partial class FlowOrchestratorEngine
                     continue;
                 }
 
-                // Stuck run: latch the timeout on the control record and complete the run as TimedOut.
+                // A stuck run that the user already cancelled must be finalised as Cancelled, not
+                // mislabelled TimedOut. Because the eligibility gate above excluded TimedOutAtUtc, a
+                // set CancelRequested here can only be a genuine user cancel — so complete as Cancelled
+                // WITHOUT latching the timeout, preserving the cancel across any later retry.
+                if (control.CancelRequested)
+                {
+                    await TryCompleteRunAsync(run.Id, "Cancelled").ConfigureAwait(false);
+                    continue;
+                }
+
+                // Stuck run past its deadline: latch the timeout on the control record and complete
+                // the run as TimedOut.
                 await _runControlStore.MarkTimedOutAsync(run.Id, "Run exceeded its timeout deadline.").ConfigureAwait(false);
                 await TryCompleteRunAsync(run.Id, "TimedOut").ConfigureAwait(false);
             }

--- a/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Control.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Control.cs
@@ -53,35 +53,53 @@ public sealed partial class FlowOrchestratorEngine
         return true;
     }
 
+    /// <summary>
+    /// Returns <see langword="true"/> when the run still has a step that is in flight, claimed by a
+    /// worker, or dispatched-but-not-yet-picked-up — i.e. work that could still advance or complete
+    /// the run. Used to gate run completion and to keep the periodic timeout sweep from latching a run
+    /// that is not actually stuck.
+    /// </summary>
+    private async Task<bool> HasInFlightWorkAsync(Guid runId)
+    {
+        if (_runtimeStore is null)
+        {
+            return false;
+        }
+
+        var statuses = await _runtimeStore.GetStepStatusesAsync(runId).ConfigureAwait(false);
+        if (statuses.Values.Any(IsInFlight))
+        {
+            return true;
+        }
+
+        var claimed = await _runtimeStore.GetClaimedStepKeysAsync(runId).ConfigureAwait(false);
+        if (claimed.Except(statuses.Keys, StringComparer.Ordinal).Any())
+        {
+            return true;
+        }
+
+        // Dispatch ledger check — closes a CI-only race observed in the v1.23.0 publish run
+        // (HappyPathTests.LinearFlow_runs_to_completion: Expected 3 steps, got 2). A step
+        // can have been dispatched (TryRecordDispatchAsync = true, EnqueueStepAsync queued
+        // the work) but not yet picked up by the consumer — in that window neither the step
+        // status nor the claim ledger reflects it, so the prior two checks pass and the
+        // engine completes the run prematurely. Under CI CPU contention the gap between
+        // dispatch and claim widens enough for this to fire. Guarding against it makes
+        // termination strictly safer with no production downside.
+        var dispatched = await _runStore.GetDispatchedStepKeysAsync(runId).ConfigureAwait(false);
+        if (dispatched.Except(statuses.Keys, StringComparer.Ordinal).Any())
+        {
+            return true;
+        }
+
+        return false;
+    }
+
     private async Task TryCompleteRunAsync(Guid runId, string status)
     {
-        if (_runtimeStore is not null)
+        if (await HasInFlightWorkAsync(runId).ConfigureAwait(false))
         {
-            var statuses = await _runtimeStore.GetStepStatusesAsync(runId).ConfigureAwait(false);
-            if (statuses.Values.Any(IsInFlight))
-            {
-                return;
-            }
-
-            var claimed = await _runtimeStore.GetClaimedStepKeysAsync(runId).ConfigureAwait(false);
-            if (claimed.Except(statuses.Keys, StringComparer.Ordinal).Any())
-            {
-                return;
-            }
-
-            // Dispatch ledger check — closes a CI-only race observed in the v1.23.0 publish run
-            // (HappyPathTests.LinearFlow_runs_to_completion: Expected 3 steps, got 2). A step
-            // can have been dispatched (TryRecordDispatchAsync = true, EnqueueStepAsync queued
-            // the work) but not yet picked up by the consumer — in that window neither the step
-            // status nor the claim ledger reflects it, so the prior two checks pass and the
-            // engine completes the run prematurely. Under CI CPU contention the gap between
-            // dispatch and claim widens enough for this to fire. Guarding against it makes
-            // termination strictly safer with no production downside.
-            var dispatched = await _runStore.GetDispatchedStepKeysAsync(runId).ConfigureAwait(false);
-            if (dispatched.Except(statuses.Keys, StringComparer.Ordinal).Any())
-            {
-                return;
-            }
+            return;
         }
 
         await _runStore.CompleteRunAsync(runId, status).ConfigureAwait(false);
@@ -186,9 +204,18 @@ public sealed partial class FlowOrchestratorEngine
                     continue;
                 }
 
-                // Latch the timeout, then attempt completion. TryCompleteRunAsync respects the
-                // in-flight / claim / dispatch guards — a run with a live worker stays Running and
-                // converges to TimedOut when that step next hits the termination gate.
+                // Only enforce on genuinely stuck runs. A run with a live/queued step is not stuck —
+                // its deadline is enforced by the dispatch-time gate on that step's next dispatch. If
+                // we latched TimedOut here while the final in-flight step then completed successfully,
+                // the graph continuation (which classifies terminal status from step statuses, not the
+                // control record) would complete the run as Succeeded, leaving the control record and
+                // the run status inconsistent. Skipping in-flight runs avoids that entirely.
+                if (await HasInFlightWorkAsync(run.Id).ConfigureAwait(false))
+                {
+                    continue;
+                }
+
+                // Stuck run: latch the timeout on the control record and complete the run as TimedOut.
                 await _runControlStore.MarkTimedOutAsync(run.Id, "Run exceeded its timeout deadline.").ConfigureAwait(false);
                 await TryCompleteRunAsync(run.Id, "TimedOut").ConfigureAwait(false);
             }

--- a/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Control.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Control.cs
@@ -152,6 +152,54 @@ public sealed partial class FlowOrchestratorEngine
         return null;
     }
 
+    /// <inheritdoc/>
+    public async Task EnforceDueTimeoutsAsync(CancellationToken cancellationToken = default)
+    {
+        if (_runControlStore is null)
+        {
+            return;
+        }
+
+        var activeRuns = await _runStore.GetActiveRunsAsync().ConfigureAwait(false);
+        if (activeRuns.Count == 0)
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        foreach (var run in activeRuns)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            try
+            {
+                var control = await _runControlStore.GetRunControlAsync(run.Id).ConfigureAwait(false);
+
+                // Only lapsed, not-already-timed-out runs are eligible.
+                if (control?.TimeoutAtUtc is null
+                    || control.TimedOutAtUtc is not null
+                    || now < control.TimeoutAtUtc.Value)
+                {
+                    continue;
+                }
+
+                // Latch the timeout, then attempt completion. TryCompleteRunAsync respects the
+                // in-flight / claim / dispatch guards — a run with a live worker stays Running and
+                // converges to TimedOut when that step next hits the termination gate.
+                await _runControlStore.MarkTimedOutAsync(run.Id, "Run exceeded its timeout deadline.").ConfigureAwait(false);
+                await TryCompleteRunAsync(run.Id, "TimedOut").ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // Per-run isolation: a single bad run must never abort the whole sweep.
+                EngineLog.TimeoutEnforcementRunFailed(_logger, ex, run.Id);
+            }
+        }
+    }
+
     /// <summary>
     /// Persists a lifecycle event via <see cref="IOutputsRepository.RecordEventAsync"/>, swallowing
     /// every exception (including <see cref="OperationCanceledException"/>). Event persistence is

--- a/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Step.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Step.cs
@@ -369,6 +369,16 @@ public sealed partial class FlowOrchestratorEngine
         ctx.TriggerData = await _outputsRepository.GetTriggerDataAsync(runId).ConfigureAwait(false);
         ctx.TriggerHeaders = await _outputsRepository.GetTriggerHeadersAsync(runId).ConfigureAwait(false);
 
+        // Give the run a fresh execution window before re-dispatch. Without this, a step retried after
+        // the run's timeout deadline lapsed (or after the run was latched TimedOut) would be immediately
+        // skipped by the termination gate in RunStepAsync — the handler would never run. The refreshed
+        // deadline reuses trigger-time resolution so it still honours the runaway-loop bound.
+        if (_runControlStore is not null)
+        {
+            var refreshedDeadline = ResolveTimeoutAtUtc(ctx.TriggerData);
+            await _runControlStore.ExtendDeadlineAsync(runId, refreshedDeadline).ConfigureAwait(false);
+        }
+
         return await RunStepAsync(ctx, flow, step, ct).ConfigureAwait(false);
     }
 

--- a/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.cs
@@ -33,7 +33,7 @@ namespace FlowOrchestrator.Core.Execution;
 /// (<c>FlowOrchestratorEngine.Control.cs</c>).
 /// </para>
 /// </remarks>
-public sealed partial class FlowOrchestratorEngine : IFlowOrchestrator
+public sealed partial class FlowOrchestratorEngine : IFlowOrchestrator, IRunTimeoutEnforcer
 {
     private readonly IStepDispatcher _dispatcher;
     private readonly IFlowExecutor _flowExecutor;

--- a/src/FlowOrchestrator.Core/Execution/IRunTimeoutEnforcer.cs
+++ b/src/FlowOrchestrator.Core/Execution/IRunTimeoutEnforcer.cs
@@ -1,0 +1,25 @@
+namespace FlowOrchestrator.Core.Execution;
+
+/// <summary>
+/// Proactively enforces run-level timeout deadlines. Implemented by <see cref="FlowOrchestratorEngine"/>
+/// and driven by the periodic <c>FlowTimeoutEnforcementHostedService</c>.
+/// </summary>
+/// <remarks>
+/// Separated from <see cref="IFlowOrchestrator"/> so the hosted service can depend on just the
+/// enforcement entry point without coupling to the full orchestration surface, and so runtime shims
+/// are unaffected.
+/// </remarks>
+public interface IRunTimeoutEnforcer
+{
+    /// <summary>
+    /// Scans every active run and marks those whose timeout deadline has already passed as
+    /// <c>TimedOut</c>, completing the run when no step is still in flight.
+    /// </summary>
+    /// <param name="cancellationToken">Token that aborts the sweep between runs.</param>
+    /// <remarks>
+    /// A no-op when no <see cref="Storage.IFlowRunControlStore"/> is registered. Runs with an
+    /// in-flight step are latched <c>TimedOut</c> but not force-completed — the in-flight guard in
+    /// run completion converges the run once the step finishes.
+    /// </remarks>
+    Task EnforceDueTimeoutsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/FlowOrchestrator.Core/Hosting/FlowTimeoutEnforcementHostedService.cs
+++ b/src/FlowOrchestrator.Core/Hosting/FlowTimeoutEnforcementHostedService.cs
@@ -1,0 +1,70 @@
+using FlowOrchestrator.Core.Configuration;
+using FlowOrchestrator.Core.Execution;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace FlowOrchestrator.Core.Hosting;
+
+/// <summary>
+/// Background service that periodically enforces run-level timeout deadlines, marking any active run
+/// whose <c>TimeoutAtUtc</c> has passed as <c>TimedOut</c>. Without it a run whose step throws and
+/// leaves nothing scheduled would sit <c>Running</c> indefinitely — the timeout would only ever be
+/// applied lazily, if and when another step happened to be dispatched.
+/// </summary>
+/// <remarks>
+/// Disabled when <see cref="FlowRunControlOptions.TimeoutEnforcementInterval"/> is <see langword="null"/>
+/// or non-positive. The enforcer (<see cref="IRunTimeoutEnforcer"/>) is resolved from a fresh scope on
+/// every tick because the engine depends on scoped services (e.g. the execution-context accessor).
+/// </remarks>
+public sealed class FlowTimeoutEnforcementHostedService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly FlowRunControlOptions _options;
+    private readonly ILogger<FlowTimeoutEnforcementHostedService> _logger;
+
+    /// <summary>Initialises the timeout-enforcement service with its dependencies.</summary>
+    public FlowTimeoutEnforcementHostedService(
+        IServiceScopeFactory scopeFactory,
+        FlowRunControlOptions options,
+        ILogger<FlowTimeoutEnforcementHostedService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var interval = _options.TimeoutEnforcementInterval;
+        if (interval is null || interval.Value <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        using var timer = new PeriodicTimer(interval.Value);
+        while (await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+        {
+            await SweepOnceAsync(stoppingToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task SweepOnceAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var enforcer = scope.ServiceProvider.GetRequiredService<IRunTimeoutEnforcer>();
+            await enforcer.EnforceDueTimeoutsAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Periodic timeout-enforcement sweep failed; will retry on the next tick.");
+        }
+    }
+}

--- a/src/FlowOrchestrator.Core/Observability/EngineLog.cs
+++ b/src/FlowOrchestrator.Core/Observability/EngineLog.cs
@@ -46,6 +46,9 @@ internal static partial class EngineLog
     [LoggerMessage(EventId = 3004, Level = LogLevel.Warning, Message = "Failed to re-assert dispatch ledger for step {StepKey} after a failed pending reschedule.")]
     public static partial void DispatchReassertFailed(ILogger logger, Exception ex, string stepKey);
 
+    [LoggerMessage(EventId = 3005, Level = LogLevel.Warning, Message = "Timeout enforcement failed for run {RunId}; continuing with next run.")]
+    public static partial void TimeoutEnforcementRunFailed(ILogger logger, Exception ex, Guid runId);
+
     [LoggerMessage(EventId = 9000, Level = LogLevel.Debug, Message = "No IFlowRunRuntimeStore registered. Running in legacy sequential mode — parallel graph evaluation and step-claim deduplication are disabled.")]
     public static partial void LegacySequentialMode(ILogger logger);
 

--- a/src/FlowOrchestrator.Core/Storage/IFlowRunControlStore.cs
+++ b/src/FlowOrchestrator.Core/Storage/IFlowRunControlStore.cs
@@ -24,10 +24,37 @@ public interface IFlowRunControlStore
     Task<bool> RequestCancelAsync(Guid runId, string? reason);
 
     /// <summary>
-    /// Marks the run as timed out. Called by the timeout-enforcement background service.
+    /// Marks the run as timed out.
     /// </summary>
     /// <returns><see langword="true"/> if the record was found and updated; <see langword="false"/> otherwise.</returns>
+    /// <remarks>
+    /// Invoked from two places: lazily by the engine when a step is dispatched after the deadline has
+    /// passed, and proactively by the periodic timeout-enforcement hosted service
+    /// (<c>FlowTimeoutEnforcementHostedService</c>). Also sets the cancellation latch so in-flight
+    /// steps short-circuit on their next dispatch — a fresh execution window can be granted afterwards
+    /// via <see cref="ExtendDeadlineAsync"/>.
+    /// </remarks>
     Task<bool> MarkTimedOutAsync(Guid runId, string? reason);
+
+    /// <summary>
+    /// Grants a run a fresh execution window: sets <c>TimeoutAtUtc</c> to <paramref name="newTimeoutAtUtc"/>
+    /// (or clears the deadline when <see langword="null"/>) and un-latches any <em>timeout-induced</em>
+    /// termination — clears <c>TimedOutAtUtc</c> and the cancellation fields that
+    /// <see cref="MarkTimedOutAsync"/> set. A genuine user cancellation (recorded via
+    /// <see cref="RequestCancelAsync"/> while the run had not timed out) is preserved.
+    /// </summary>
+    /// <param name="runId">The run whose deadline is being refreshed.</param>
+    /// <param name="newTimeoutAtUtc">
+    /// The new absolute deadline, or <see langword="null"/> to leave the run without a timeout bound.
+    /// </param>
+    /// <returns><see langword="true"/> if the record was found and updated; <see langword="false"/> otherwise.</returns>
+    /// <remarks>
+    /// Called by <c>FlowOrchestratorEngine.RetryStepAsync</c> before re-dispatch so a step retried after
+    /// the run's deadline lapsed can actually re-execute instead of being skipped by the termination gate.
+    /// Default implementation is a no-op returning <see langword="false"/> so existing custom
+    /// <see cref="IFlowRunControlStore"/> implementations continue to compile.
+    /// </remarks>
+    Task<bool> ExtendDeadlineAsync(Guid runId, DateTimeOffset? newTimeoutAtUtc) => Task.FromResult(false);
 
     /// <summary>
     /// Looks up an existing run that was started with the given idempotency key.

--- a/src/FlowOrchestrator.Core/Storage/IFlowRunStore.cs
+++ b/src/FlowOrchestrator.Core/Storage/IFlowRunStore.cs
@@ -45,6 +45,30 @@ public interface IFlowRunStore
     Task CompleteRunAsync(Guid runId, string status);
 
     /// <summary>
+    /// Transitions the run to a terminal <paramref name="status"/> only if it is still active
+    /// (<c>Running</c>), reporting whether this call performed the transition. Makes run completion
+    /// idempotent and safe against concurrent completers — notably the graph continuation and the
+    /// periodic timeout sweep (single- or multi-instance) — so a run's lifecycle event is published
+    /// exactly once and its terminal status is set by exactly one writer.
+    /// </summary>
+    /// <param name="runId">The run to complete.</param>
+    /// <param name="status">The terminal status to set.</param>
+    /// <returns>
+    /// <see langword="true"/> if this call transitioned a <c>Running</c> run to <paramref name="status"/>;
+    /// <see langword="false"/> if the run was already in a terminal state (another writer won).
+    /// </returns>
+    /// <remarks>
+    /// Default implementation delegates to <see cref="CompleteRunAsync"/> and reports <see langword="true"/>,
+    /// so existing custom <see cref="IFlowRunStore"/> implementations compile unchanged (retaining their
+    /// prior, non-idempotent completion behaviour).
+    /// </remarks>
+    async Task<bool> CompleteRunIfActiveAsync(Guid runId, string status)
+    {
+        await CompleteRunAsync(runId, status).ConfigureAwait(false);
+        return true;
+    }
+
+    /// <summary>
     /// Returns a page of run records, optionally filtered by <paramref name="flowId"/>.
     /// Results are ordered by start time descending.
     /// </summary>

--- a/src/FlowOrchestrator.Hangfire/FlowOrchestratorServiceCollectionExtensions.cs
+++ b/src/FlowOrchestrator.Hangfire/FlowOrchestratorServiceCollectionExtensions.cs
@@ -75,12 +75,16 @@ public static class FlowOrchestratorServiceCollectionExtensions
         services.AddHostedService<FlowSyncHostedService>();
         services.AddHostedService<FlowRetentionHostedService>();
         services.AddHostedService<FlowRunRecoveryHostedService>();
+        services.AddHostedService<FlowTimeoutEnforcementHostedService>();
 
         services.AddTransient<IFlowExecutor, FlowExecutor>();
         services.AddSingleton<IFlowGraphPlanner, FlowGraphPlanner>();
         services.AddTransient<IStepExecutor, DefaultStepExecutor>();
 
         services.AddTransient<IFlowOrchestrator, FlowOrchestratorEngine>();
+        // Same engine instance type also drives the periodic timeout sweep. Resolved per-tick inside
+        // a scope by FlowTimeoutEnforcementHostedService (the engine has scoped dependencies).
+        services.AddTransient<IRunTimeoutEnforcer, FlowOrchestratorEngine>();
 
         // Runtime-specific adapters: use TryAdd so that an alternative runtime (e.g. UseInMemoryRuntime())
         // registered earlier inside the configure callback takes priority over the Hangfire defaults.

--- a/src/FlowOrchestrator.InMemory/InMemoryFlowRunStore.cs
+++ b/src/FlowOrchestrator.InMemory/InMemoryFlowRunStore.cs
@@ -598,6 +598,31 @@ public sealed class InMemoryFlowRunStore :
         return Task.FromResult(true);
     }
 
+    /// <inheritdoc/>
+    public Task<bool> ExtendDeadlineAsync(Guid runId, DateTimeOffset? newTimeoutAtUtc)
+    {
+        // Mirror the SQL backends: return false when no control record exists rather than
+        // creating one. See RequestCancelAsync for the contract rationale.
+        if (!_runControls.TryGetValue(runId, out var control))
+        {
+            return Task.FromResult(false);
+        }
+
+        control.TimeoutAtUtc = newTimeoutAtUtc;
+
+        // Only un-latch a timeout-induced termination. A genuine user cancellation
+        // (CancelRequested set while TimedOutAtUtc was null) must survive a retry.
+        if (control.TimedOutAtUtc is not null)
+        {
+            control.TimedOutAtUtc = null;
+            control.CancelRequested = false;
+            control.CancelReason = null;
+            control.CancelRequestedAtUtc = null;
+        }
+
+        return Task.FromResult(true);
+    }
+
     public Task<Guid?> FindRunIdByIdempotencyKeyAsync(Guid flowId, string triggerKey, string idempotencyKey)
     {
         var key = NormalizeIdempotencyKey(flowId, triggerKey, idempotencyKey);

--- a/src/FlowOrchestrator.InMemory/InMemoryFlowRunStore.cs
+++ b/src/FlowOrchestrator.InMemory/InMemoryFlowRunStore.cs
@@ -153,6 +153,29 @@ public sealed class InMemoryFlowRunStore :
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc/>
+    public Task<bool> CompleteRunIfActiveAsync(Guid runId, string status)
+    {
+        // Serialise the check-then-set on the run record so two concurrent completers (graph
+        // continuation + timeout sweep) can never both observe Running and both transition it.
+        if (!_runs.TryGetValue(runId, out var run))
+        {
+            return Task.FromResult(false);
+        }
+
+        lock (run)
+        {
+            if (!string.Equals(run.Status, "Running", StringComparison.Ordinal))
+            {
+                return Task.FromResult(false);
+            }
+
+            run.Status = status;
+            run.CompletedAt = DateTimeOffset.UtcNow;
+            return Task.FromResult(true);
+        }
+    }
+
     public Task<IReadOnlyList<FlowRunRecord>> GetRunsAsync(Guid? flowId = null, int skip = 0, int take = 50)
     {
         IReadOnlyList<FlowRunRecord> result = ApplyRunsFilter(flowId, null, null, null, null, deepSearch: true)

--- a/src/FlowOrchestrator.PostgreSQL/PostgreSqlFlowRunStore.cs
+++ b/src/FlowOrchestrator.PostgreSQL/PostgreSqlFlowRunStore.cs
@@ -151,6 +151,18 @@ public sealed class PostgreSqlFlowRunStore :
             new { Id = runId, Status = status });
     }
 
+    /// <inheritdoc/>
+    public async Task<bool> CompleteRunIfActiveAsync(Guid runId, string status)
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        // Guarded, atomic transition: only a still-Running run is completed, and rows-affected tells
+        // the caller whether THIS call won the race — so the lifecycle event fires exactly once.
+        var affected = await conn.ExecuteAsync(
+            "UPDATE flow_runs SET status = @Status, completed_at = NOW() WHERE id = @Id AND status = 'Running'",
+            new { Id = runId, Status = status });
+        return affected > 0;
+    }
+
     public async Task<IReadOnlyList<FlowRunRecord>> GetRunsAsync(Guid? flowId = null, int skip = 0, int take = 50)
     {
         var page = await GetRunsPageAsync(flowId, null, skip, take, null);
@@ -610,11 +622,12 @@ public sealed class PostgreSqlFlowRunStore :
         var affected = await conn.ExecuteAsync(
             """
             UPDATE flow_run_controls
-            SET timed_out_at_utc = COALESCE(timed_out_at_utc, NOW()),
+            SET timed_out_at_utc = NOW(),
                 cancel_requested = TRUE,
                 cancel_reason = COALESCE(@Reason, cancel_reason, 'Run timed out.'),
                 cancel_requested_at_utc = COALESCE(cancel_requested_at_utc, NOW())
             WHERE run_id = @RunId
+              AND timed_out_at_utc IS NULL
             """,
             new { RunId = runId, Reason = reason });
 

--- a/src/FlowOrchestrator.PostgreSQL/PostgreSqlFlowRunStore.cs
+++ b/src/FlowOrchestrator.PostgreSQL/PostgreSqlFlowRunStore.cs
@@ -621,6 +621,28 @@ public sealed class PostgreSqlFlowRunStore :
         return affected > 0;
     }
 
+    /// <inheritdoc/>
+    public async Task<bool> ExtendDeadlineAsync(Guid runId, DateTimeOffset? newTimeoutAtUtc)
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        // Every SET expression reads the pre-update row, so the CASEs evaluate the OLD timed_out_at_utc:
+        // un-latch the cancel fields only when the termination was timeout-induced, preserving a
+        // genuine user cancellation. timed_out_at_utc is cleared unconditionally.
+        var affected = await conn.ExecuteAsync(
+            """
+            UPDATE flow_run_controls
+            SET timeout_at_utc = @NewTimeoutAtUtc,
+                cancel_requested        = CASE WHEN timed_out_at_utc IS NOT NULL THEN FALSE ELSE cancel_requested END,
+                cancel_reason           = CASE WHEN timed_out_at_utc IS NOT NULL THEN NULL  ELSE cancel_reason END,
+                cancel_requested_at_utc = CASE WHEN timed_out_at_utc IS NOT NULL THEN NULL  ELSE cancel_requested_at_utc END,
+                timed_out_at_utc        = NULL
+            WHERE run_id = @RunId
+            """,
+            new { RunId = runId, NewTimeoutAtUtc = newTimeoutAtUtc });
+
+        return affected > 0;
+    }
+
     public async Task<Guid?> FindRunIdByIdempotencyKeyAsync(Guid flowId, string triggerKey, string idempotencyKey)
     {
         await using var conn = new NpgsqlConnection(_connectionString);

--- a/src/FlowOrchestrator.SqlServer/SqlFlowRunStore.cs
+++ b/src/FlowOrchestrator.SqlServer/SqlFlowRunStore.cs
@@ -118,6 +118,18 @@ public sealed class SqlFlowRunStore :
             new { Id = runId, Status = status });
     }
 
+    /// <inheritdoc/>
+    public async Task<bool> CompleteRunIfActiveAsync(Guid runId, string status)
+    {
+        await using var conn = new SqlConnection(_connectionString);
+        // Guarded, atomic transition: only a still-Running run is completed, and rows-affected tells
+        // the caller whether THIS call won the race — so the lifecycle event fires exactly once.
+        var affected = await conn.ExecuteAsync(
+            "UPDATE FlowRuns SET Status = @Status, CompletedAt = SYSDATETIMEOFFSET() WHERE Id = @Id AND Status = 'Running'",
+            new { Id = runId, Status = status });
+        return affected > 0;
+    }
+
     public async Task<IReadOnlyList<FlowRunRecord>> GetRunsAsync(Guid? flowId = null, int skip = 0, int take = 50)
     {
         var page = await GetRunsPageAsync(flowId, null, skip, take, null);
@@ -532,11 +544,12 @@ public sealed class SqlFlowRunStore :
         var affected = await conn.ExecuteAsync(
             """
             UPDATE FlowRunControls
-            SET TimedOutAtUtc = COALESCE(TimedOutAtUtc, SYSDATETIMEOFFSET()),
+            SET TimedOutAtUtc = SYSDATETIMEOFFSET(),
                 CancelRequested = 1,
                 CancelReason = COALESCE(@Reason, CancelReason, 'Run timed out.'),
                 CancelRequestedAtUtc = COALESCE(CancelRequestedAtUtc, SYSDATETIMEOFFSET())
             WHERE RunId = @RunId
+              AND TimedOutAtUtc IS NULL
             """,
             new { RunId = runId, Reason = reason });
 

--- a/src/FlowOrchestrator.SqlServer/SqlFlowRunStore.cs
+++ b/src/FlowOrchestrator.SqlServer/SqlFlowRunStore.cs
@@ -543,6 +543,28 @@ public sealed class SqlFlowRunStore :
         return affected > 0;
     }
 
+    /// <inheritdoc/>
+    public async Task<bool> ExtendDeadlineAsync(Guid runId, DateTimeOffset? newTimeoutAtUtc)
+    {
+        await using var conn = new SqlConnection(_connectionString);
+        // Every SET expression reads the pre-update row, so the CASEs evaluate the OLD TimedOutAtUtc:
+        // un-latch the cancel fields only when the termination was timeout-induced, preserving a
+        // genuine user cancellation. TimedOutAtUtc is cleared unconditionally.
+        var affected = await conn.ExecuteAsync(
+            """
+            UPDATE FlowRunControls
+            SET TimeoutAtUtc = @NewTimeoutAtUtc,
+                CancelRequested      = CASE WHEN TimedOutAtUtc IS NOT NULL THEN 0    ELSE CancelRequested END,
+                CancelReason         = CASE WHEN TimedOutAtUtc IS NOT NULL THEN NULL ELSE CancelReason END,
+                CancelRequestedAtUtc = CASE WHEN TimedOutAtUtc IS NOT NULL THEN NULL ELSE CancelRequestedAtUtc END,
+                TimedOutAtUtc        = NULL
+            WHERE RunId = @RunId
+            """,
+            new { RunId = runId, NewTimeoutAtUtc = newTimeoutAtUtc });
+
+        return affected > 0;
+    }
+
     public async Task<Guid?> FindRunIdByIdempotencyKeyAsync(Guid flowId, string triggerKey, string idempotencyKey)
     {
         await using var conn = new SqlConnection(_connectionString);

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/DashboardTestServer.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/DashboardTestServer.cs
@@ -67,10 +67,10 @@ public sealed class DashboardTestServer : IDisposable
         GlobalConfiguration.Configuration.UseInMemoryStorage();
 
         ScheduleStateStore.GetAllAsync().Returns(Array.Empty<FlowScheduleState>());
-        ScheduleStateStore.GetAsync(Arg.Any<string>()).Returns((FlowScheduleState?)null);
+        ScheduleStateStore.GetAsync(Arg.Any<string>()).Returns(default(FlowScheduleState?));
         EventReader.GetRunEventsAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<int>())
             .Returns(Array.Empty<FlowEventRecord>());
-        RunControlStore.GetRunControlAsync(Arg.Any<Guid>()).Returns((FlowRunControlRecord?)null);
+        RunControlStore.GetRunControlAsync(Arg.Any<Guid>()).Returns(default(FlowRunControlRecord?));
         TriggerInspector.GetJobsAsync().Returns(Array.Empty<RecurringTriggerInfo>());
         RuntimeStore.GetStepStatusesAsync(Arg.Any<Guid>())
             .Returns(new Dictionary<string, StepStatus>());

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/DashboardTestServer.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/DashboardTestServer.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using NSubstitute.ReturnsExtensions;
 
 namespace FlowOrchestrator.Dashboard.Tests;
 
@@ -68,10 +67,10 @@ public sealed class DashboardTestServer : IDisposable
         GlobalConfiguration.Configuration.UseInMemoryStorage();
 
         ScheduleStateStore.GetAllAsync().Returns(Array.Empty<FlowScheduleState>());
-        ScheduleStateStore.GetAsync(Arg.Any<string>()).ReturnsNull();
+        ScheduleStateStore.GetAsync(Arg.Any<string>()).Returns((FlowScheduleState?)null);
         EventReader.GetRunEventsAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<int>())
             .Returns(Array.Empty<FlowEventRecord>());
-        RunControlStore.GetRunControlAsync(Arg.Any<Guid>()).ReturnsNull();
+        RunControlStore.GetRunControlAsync(Arg.Any<Guid>()).Returns((FlowRunControlRecord?)null);
         TriggerInspector.GetJobsAsync().Returns(Array.Empty<RecurringTriggerInfo>());
         RuntimeStore.GetStepStatusesAsync(Arg.Any<Guid>())
             .Returns(new Dictionary<string, StepStatus>());

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/FlowCatalogEndpointTests.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/FlowCatalogEndpointTests.cs
@@ -50,7 +50,7 @@ public sealed class FlowCatalogEndpointTests : IDisposable
     public async Task GET_api_flows_by_id_returns_404_for_missing_flow()
     {
         // Arrange
-        _server.FlowStore.GetByIdAsync(Arg.Any<Guid>()).Returns((FlowDefinitionRecord?)null);
+        _server.FlowStore.GetByIdAsync(Arg.Any<Guid>()).Returns(default(FlowDefinitionRecord?));
 
         // Act
         var response = await _client.GetAsync($"/flows/api/flows/{Guid.NewGuid()}");

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/FlowCatalogEndpointTests.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/FlowCatalogEndpointTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using FlowOrchestrator.Core.Storage;
-using NSubstitute.ReturnsExtensions;
 
 namespace FlowOrchestrator.Dashboard.Tests;
 
@@ -51,7 +50,7 @@ public sealed class FlowCatalogEndpointTests : IDisposable
     public async Task GET_api_flows_by_id_returns_404_for_missing_flow()
     {
         // Arrange
-        _server.FlowStore.GetByIdAsync(Arg.Any<Guid>()).ReturnsNull();
+        _server.FlowStore.GetByIdAsync(Arg.Any<Guid>()).Returns((FlowDefinitionRecord?)null);
 
         // Act
         var response = await _client.GetAsync($"/flows/api/flows/{Guid.NewGuid()}");

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/RunEndpointTests.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/RunEndpointTests.cs
@@ -128,7 +128,7 @@ public sealed class RunEndpointTests : IDisposable
         var id = Guid.NewGuid();
         var run = new FlowRunRecord { Id = id, Status = "Succeeded", FlowName = "MyFlow" };
         _server.FlowRunStore.GetRunDetailAsync(id).Returns(run);
-        _server.OutputsRepository.GetTriggerHeadersAsync(id).Returns((IReadOnlyDictionary<string, string>?)null); // codeql[cs/useless-upcast] disambiguates NSubstitute overload
+        _server.OutputsRepository.GetTriggerHeadersAsync(id).Returns(default(IReadOnlyDictionary<string, string>?)); // codeql[cs/useless-upcast] disambiguates NSubstitute overload
 
         // Act
         var response = await _client.GetAsync($"/flows/api/runs/{id}");
@@ -143,7 +143,7 @@ public sealed class RunEndpointTests : IDisposable
     public async Task GET_api_runs_by_id_returns_404_for_missing_run()
     {
         // Arrange
-        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
+        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns(default(FlowRunRecord?));
 
         // Act
         var response = await _client.GetAsync($"/flows/api/runs/{Guid.NewGuid()}");
@@ -178,7 +178,7 @@ public sealed class RunEndpointTests : IDisposable
     public async Task GET_api_runs_steps_returns_404_for_missing_run()
     {
         // Arrange
-        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
+        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns(default(FlowRunRecord?));
 
         // Act
         var response = await _client.GetAsync($"/flows/api/runs/{Guid.NewGuid()}/steps");
@@ -240,7 +240,7 @@ public sealed class RunEndpointTests : IDisposable
     public async Task POST_retry_returns_404_when_run_not_found()
     {
         // Arrange
-        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
+        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns(default(FlowRunRecord?));
 
         // Act
         var response = await _client.PostAsync($"/flows/api/runs/{Guid.NewGuid()}/steps/step1/retry", null);
@@ -274,7 +274,7 @@ public sealed class RunEndpointTests : IDisposable
     public async Task POST_rerun_returns_404_when_run_missing()
     {
         // Arrange
-        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
+        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns(default(FlowRunRecord?));
 
         // Act
         var response = await _client.PostAsync($"/flows/api/runs/{Guid.NewGuid()}/rerun", null);

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/RunEndpointTests.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/RunEndpointTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Storage;
-using NSubstitute.ReturnsExtensions;
 
 namespace FlowOrchestrator.Dashboard.Tests;
 
@@ -144,7 +143,7 @@ public sealed class RunEndpointTests : IDisposable
     public async Task GET_api_runs_by_id_returns_404_for_missing_run()
     {
         // Arrange
-        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).ReturnsNull();
+        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
 
         // Act
         var response = await _client.GetAsync($"/flows/api/runs/{Guid.NewGuid()}");
@@ -179,7 +178,7 @@ public sealed class RunEndpointTests : IDisposable
     public async Task GET_api_runs_steps_returns_404_for_missing_run()
     {
         // Arrange
-        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).ReturnsNull();
+        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
 
         // Act
         var response = await _client.GetAsync($"/flows/api/runs/{Guid.NewGuid()}/steps");
@@ -241,7 +240,7 @@ public sealed class RunEndpointTests : IDisposable
     public async Task POST_retry_returns_404_when_run_not_found()
     {
         // Arrange
-        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).ReturnsNull();
+        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
 
         // Act
         var response = await _client.PostAsync($"/flows/api/runs/{Guid.NewGuid()}/steps/step1/retry", null);
@@ -275,7 +274,7 @@ public sealed class RunEndpointTests : IDisposable
     public async Task POST_rerun_returns_404_when_run_missing()
     {
         // Arrange
-        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).ReturnsNull();
+        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
 
         // Act
         var response = await _client.PostAsync($"/flows/api/runs/{Guid.NewGuid()}/rerun", null);
@@ -328,7 +327,7 @@ public sealed class RunEndpointTests : IDisposable
         Assert.Contains("runId", body);
         Assert.Contains("sourceRunId", body);
         await _server.FlowOrchestrator.Received(1).TriggerAsync(Arg.Is<ITriggerContext>(ctx =>
-            ctx.Flow.Id == flowId && ctx.Trigger.Key == "webhook"), Arg.Any<CancellationToken>());
+            ctx!.Flow.Id == flowId && ctx.Trigger.Key == "webhook"), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/RunLineageEndpointTests.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/RunLineageEndpointTests.cs
@@ -4,7 +4,6 @@ using System.Text.Json;
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Storage;
-using NSubstitute.ReturnsExtensions;
 
 namespace FlowOrchestrator.Dashboard.Tests;
 
@@ -53,7 +52,7 @@ public sealed class RunLineageEndpointTests : IDisposable
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         await _server.FlowOrchestrator.Received(1).TriggerAsync(
-            Arg.Is<ITriggerContext>(ctx => ctx.SourceRunId == sourceRunId),
+            Arg.Is<ITriggerContext>(ctx => ctx!.SourceRunId == sourceRunId),
             Arg.Any<CancellationToken>());
     }
 
@@ -61,7 +60,7 @@ public sealed class RunLineageEndpointTests : IDisposable
     public async Task GET_lineage_returns_404_when_run_missing()
     {
         // Arrange
-        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).ReturnsNull();
+        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
 
         // Act
         var response = await _client.GetAsync($"/flows/api/runs/{Guid.NewGuid()}/lineage");

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/RunLineageEndpointTests.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/RunLineageEndpointTests.cs
@@ -60,7 +60,7 @@ public sealed class RunLineageEndpointTests : IDisposable
     public async Task GET_lineage_returns_404_when_run_missing()
     {
         // Arrange
-        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
+        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns(default(FlowRunRecord?));
 
         // Act
         var response = await _client.GetAsync($"/flows/api/runs/{Guid.NewGuid()}/lineage");

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/ScheduleEndpointTests.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/ScheduleEndpointTests.cs
@@ -83,7 +83,7 @@ public sealed class ScheduleEndpointTests : IDisposable
         // Arrange
         var flowId = Guid.NewGuid();
         var jobId = JobId(flowId, "cron");
-        _server.ScheduleStateStore.GetAsync(jobId).Returns((FlowScheduleState?)null);
+        _server.ScheduleStateStore.GetAsync(jobId).Returns(default(FlowScheduleState?));
 
         // Act
         var response = await _client.PostAsync($"/flows/api/schedules/{jobId}/trigger", null);
@@ -131,7 +131,7 @@ public sealed class ScheduleEndpointTests : IDisposable
 
         _server.FlowStore.GetByIdAsync(flowId)
             .Returns(new FlowDefinitionRecord { Id = flowId, Name = "DailyFlow", IsEnabled = true });
-        _server.ScheduleStateStore.GetAsync(jobId).Returns((FlowScheduleState?)null);
+        _server.ScheduleStateStore.GetAsync(jobId).Returns(default(FlowScheduleState?));
 
         // Act
         var response = await _client.PostAsync($"/flows/api/schedules/{jobId}/pause", null);
@@ -197,8 +197,8 @@ public sealed class ScheduleEndpointTests : IDisposable
         // Arrange
         var flowId = Guid.NewGuid();
         var jobId = JobId(flowId, "cron");
-        _server.FlowStore.GetByIdAsync(flowId).Returns((FlowDefinitionRecord?)null);
-        _server.ScheduleStateStore.GetAsync(jobId).Returns((FlowScheduleState?)null);
+        _server.FlowStore.GetByIdAsync(flowId).Returns(default(FlowDefinitionRecord?));
+        _server.ScheduleStateStore.GetAsync(jobId).Returns(default(FlowScheduleState?));
 
         // Act
         var response = await _client.PostAsync($"/flows/api/schedules/{jobId}/resume", null);
@@ -226,7 +226,7 @@ public sealed class ScheduleEndpointTests : IDisposable
                 IsEnabled = true,
                 ManifestJson = manifestJson
             });
-        _server.ScheduleStateStore.GetAsync(jobId).Returns((FlowScheduleState?)null);
+        _server.ScheduleStateStore.GetAsync(jobId).Returns(default(FlowScheduleState?));
 
         // Act
         var response = await _client.PutAsync(
@@ -295,8 +295,8 @@ public sealed class ScheduleEndpointTests : IDisposable
         // Arrange
         var flowId = Guid.NewGuid();
         var jobId = JobId(flowId, "cron");
-        _server.FlowStore.GetByIdAsync(flowId).Returns((FlowDefinitionRecord?)null);
-        _server.ScheduleStateStore.GetAsync(jobId).Returns((FlowScheduleState?)null);
+        _server.FlowStore.GetByIdAsync(flowId).Returns(default(FlowDefinitionRecord?));
+        _server.ScheduleStateStore.GetAsync(jobId).Returns(default(FlowScheduleState?));
 
         // Act
         var response = await _client.PutAsync(

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/ScheduleEndpointTests.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/ScheduleEndpointTests.cs
@@ -5,7 +5,6 @@ using System.Text.Json;
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Storage;
-using NSubstitute.ReturnsExtensions;
 
 namespace FlowOrchestrator.Dashboard.Tests;
 
@@ -84,7 +83,7 @@ public sealed class ScheduleEndpointTests : IDisposable
         // Arrange
         var flowId = Guid.NewGuid();
         var jobId = JobId(flowId, "cron");
-        _server.ScheduleStateStore.GetAsync(jobId).ReturnsNull();
+        _server.ScheduleStateStore.GetAsync(jobId).Returns((FlowScheduleState?)null);
 
         // Act
         var response = await _client.PostAsync($"/flows/api/schedules/{jobId}/trigger", null);
@@ -132,7 +131,7 @@ public sealed class ScheduleEndpointTests : IDisposable
 
         _server.FlowStore.GetByIdAsync(flowId)
             .Returns(new FlowDefinitionRecord { Id = flowId, Name = "DailyFlow", IsEnabled = true });
-        _server.ScheduleStateStore.GetAsync(jobId).ReturnsNull();
+        _server.ScheduleStateStore.GetAsync(jobId).Returns((FlowScheduleState?)null);
 
         // Act
         var response = await _client.PostAsync($"/flows/api/schedules/{jobId}/pause", null);
@@ -141,7 +140,7 @@ public sealed class ScheduleEndpointTests : IDisposable
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         _server.TriggerDispatcher.Received(1).Remove(jobId);
         await _server.ScheduleStateStore.Received(1)
-            .SaveAsync(Arg.Is<FlowScheduleState>(s => s.JobId == jobId && s.IsPaused));
+            .SaveAsync(Arg.Is<FlowScheduleState>(s => s!.JobId == jobId && s.IsPaused));
     }
 
     [Fact]
@@ -198,8 +197,8 @@ public sealed class ScheduleEndpointTests : IDisposable
         // Arrange
         var flowId = Guid.NewGuid();
         var jobId = JobId(flowId, "cron");
-        _server.FlowStore.GetByIdAsync(flowId).ReturnsNull();
-        _server.ScheduleStateStore.GetAsync(jobId).ReturnsNull();
+        _server.FlowStore.GetByIdAsync(flowId).Returns((FlowDefinitionRecord?)null);
+        _server.ScheduleStateStore.GetAsync(jobId).Returns((FlowScheduleState?)null);
 
         // Act
         var response = await _client.PostAsync($"/flows/api/schedules/{jobId}/resume", null);
@@ -227,7 +226,7 @@ public sealed class ScheduleEndpointTests : IDisposable
                 IsEnabled = true,
                 ManifestJson = manifestJson
             });
-        _server.ScheduleStateStore.GetAsync(jobId).ReturnsNull();
+        _server.ScheduleStateStore.GetAsync(jobId).Returns((FlowScheduleState?)null);
 
         // Act
         var response = await _client.PutAsync(
@@ -238,7 +237,7 @@ public sealed class ScheduleEndpointTests : IDisposable
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         _server.TriggerDispatcher.Received(1).RegisterOrUpdate(jobId, flowId, "cron", newCron);
         await _server.ScheduleStateStore.Received(1)
-            .SaveAsync(Arg.Is<FlowScheduleState>(s => s.CronOverride == newCron));
+            .SaveAsync(Arg.Is<FlowScheduleState>(s => s!.CronOverride == newCron));
     }
 
     [Fact]
@@ -271,7 +270,7 @@ public sealed class ScheduleEndpointTests : IDisposable
         _server.TriggerDispatcher.DidNotReceive()
             .RegisterOrUpdate(Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>());
         await _server.ScheduleStateStore.Received(1)
-            .SaveAsync(Arg.Is<FlowScheduleState>(s => s.CronOverride == newCron));
+            .SaveAsync(Arg.Is<FlowScheduleState>(s => s!.CronOverride == newCron));
     }
 
     [Fact]
@@ -296,8 +295,8 @@ public sealed class ScheduleEndpointTests : IDisposable
         // Arrange
         var flowId = Guid.NewGuid();
         var jobId = JobId(flowId, "cron");
-        _server.FlowStore.GetByIdAsync(flowId).ReturnsNull();
-        _server.ScheduleStateStore.GetAsync(jobId).ReturnsNull();
+        _server.FlowStore.GetByIdAsync(flowId).Returns((FlowDefinitionRecord?)null);
+        _server.ScheduleStateStore.GetAsync(jobId).Returns((FlowScheduleState?)null);
 
         // Act
         var response = await _client.PutAsync(
@@ -324,7 +323,7 @@ public sealed class ScheduleEndpointTests : IDisposable
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         await _server.FlowOrchestrator.Received(1).TriggerAsync(
-            Arg.Is<ITriggerContext>(ctx => ctx.Flow.Id == flowId && ctx.Trigger.Key == "manual"),
+            Arg.Is<ITriggerContext>(ctx => ctx!.Flow.Id == flowId && ctx.Trigger.Key == "manual"),
             Arg.Any<CancellationToken>());
         var body = await response.Content.ReadAsStringAsync();
         Assert.Contains("runId", body);
@@ -380,7 +379,7 @@ public sealed class ScheduleEndpointTests : IDisposable
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         await _server.FlowOrchestrator.Received(1).TriggerAsync(
-            Arg.Is<ITriggerContext>(ctx => ctx.Trigger.Data != null),
+            Arg.Is<ITriggerContext>(ctx => ctx!.Trigger.Data != null),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/SignalEndpointTests.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/SignalEndpointTests.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Text;
 using FlowOrchestrator.Core.Storage;
-using NSubstitute.ReturnsExtensions;
 
 namespace FlowOrchestrator.Dashboard.Tests;
 
@@ -23,7 +22,7 @@ public sealed class SignalEndpointTests : IDisposable
     public async Task POST_signal_returns_404_when_run_missing()
     {
         // Arrange
-        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).ReturnsNull();
+        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
         using var content = new StringContent("{}", Encoding.UTF8, "application/json");
 
         // Act

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/SignalEndpointTests.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/SignalEndpointTests.cs
@@ -22,7 +22,7 @@ public sealed class SignalEndpointTests : IDisposable
     public async Task POST_signal_returns_404_when_run_missing()
     {
         // Arrange
-        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns((FlowRunRecord?)null);
+        _server.FlowRunStore.GetRunDetailAsync(Arg.Any<Guid>()).Returns(default(FlowRunRecord?));
         using var content = new StringContent("{}", Encoding.UTF8, "application/json");
 
         // Act

--- a/tests/integration/FlowOrchestrator.Hangfire.IntegrationTests/FlowSyncHostedServiceTests.cs
+++ b/tests/integration/FlowOrchestrator.Hangfire.IntegrationTests/FlowSyncHostedServiceTests.cs
@@ -42,7 +42,7 @@ public class FlowSyncHostedServiceTests
         repository.GetAllFlowsAsync().Returns(new List<IFlowDefinition> { flow });
 
         var store = Substitute.For<IFlowStore>();
-        store.GetByIdAsync(flow.Id).Returns((FlowDefinitionRecord?)null);
+        store.GetByIdAsync(flow.Id).Returns(default(FlowDefinitionRecord?));
         store.SaveAsync(Arg.Any<FlowDefinitionRecord>()).Returns(ci => ci.Arg<FlowDefinitionRecord>()!);
 
         var sut = CreateSut(repository, store);

--- a/tests/integration/FlowOrchestrator.Hangfire.IntegrationTests/FlowSyncHostedServiceTests.cs
+++ b/tests/integration/FlowOrchestrator.Hangfire.IntegrationTests/FlowSyncHostedServiceTests.cs
@@ -5,7 +5,6 @@ using FlowOrchestrator.Hangfire;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
-using NSubstitute.ReturnsExtensions;
 
 namespace FlowOrchestrator.Hangfire.Tests;
 
@@ -43,8 +42,8 @@ public class FlowSyncHostedServiceTests
         repository.GetAllFlowsAsync().Returns(new List<IFlowDefinition> { flow });
 
         var store = Substitute.For<IFlowStore>();
-        store.GetByIdAsync(flow.Id).ReturnsNull();
-        store.SaveAsync(Arg.Any<FlowDefinitionRecord>()).Returns(ci => ci.Arg<FlowDefinitionRecord>());
+        store.GetByIdAsync(flow.Id).Returns((FlowDefinitionRecord?)null);
+        store.SaveAsync(Arg.Any<FlowDefinitionRecord>()).Returns(ci => ci.Arg<FlowDefinitionRecord>()!);
 
         var sut = CreateSut(repository, store);
 
@@ -53,7 +52,7 @@ public class FlowSyncHostedServiceTests
 
         // Assert
         await store.Received(1).SaveAsync(Arg.Is<FlowDefinitionRecord>(r =>
-            r.Id == flow.Id && r.Version == "1.0" && r.ManifestJson != null));
+            r!.Id == flow.Id && r.Version == "1.0" && r.ManifestJson != null));
     }
 
     [Fact]
@@ -84,7 +83,7 @@ public class FlowSyncHostedServiceTests
 
         var store = Substitute.For<IFlowStore>();
         store.GetByIdAsync(flowId).Returns(existing);
-        store.SaveAsync(Arg.Any<FlowDefinitionRecord>()).Returns(ci => ci.Arg<FlowDefinitionRecord>());
+        store.SaveAsync(Arg.Any<FlowDefinitionRecord>()).Returns(ci => ci.Arg<FlowDefinitionRecord>()!);
 
         var sut = CreateSut(repository, store);
 
@@ -93,7 +92,7 @@ public class FlowSyncHostedServiceTests
 
         // Assert
         await store.Received(1).SaveAsync(Arg.Is<FlowDefinitionRecord>(r =>
-            r.Id == flowId && r.Version == "2.0"));
+            r!.Id == flowId && r.Version == "2.0"));
     }
 
     [Fact]
@@ -153,7 +152,7 @@ public class FlowSyncHostedServiceTests
 
         var store = Substitute.For<IFlowStore>();
         store.GetByIdAsync(flowId).Returns(new FlowDefinitionRecord { Id = flowId, IsEnabled = true });
-        store.SaveAsync(Arg.Any<FlowDefinitionRecord>()).Returns(ci => ci.Arg<FlowDefinitionRecord>());
+        store.SaveAsync(Arg.Any<FlowDefinitionRecord>()).Returns(ci => ci.Arg<FlowDefinitionRecord>()!);
 
         var sut = CreateSut(repository, store);
 
@@ -183,7 +182,7 @@ public class FlowSyncHostedServiceTests
 
         var store = Substitute.For<IFlowStore>();
         store.GetByIdAsync(flowId).Returns(new FlowDefinitionRecord { Id = flowId, IsEnabled = false });
-        store.SaveAsync(Arg.Any<FlowDefinitionRecord>()).Returns(ci => ci.Arg<FlowDefinitionRecord>());
+        store.SaveAsync(Arg.Any<FlowDefinitionRecord>()).Returns(ci => ci.Arg<FlowDefinitionRecord>()!);
 
         var sut = CreateSut(repository, store);
 

--- a/tests/integration/FlowOrchestrator.Hangfire.IntegrationTests/HangfireFlowOrchestratorTests.cs
+++ b/tests/integration/FlowOrchestrator.Hangfire.IntegrationTests/HangfireFlowOrchestratorTests.cs
@@ -171,7 +171,7 @@ public class HangfireFlowOrchestratorTests
 
         var stepResult = new StepResult { Key = "step1", Status = StepStatus.Succeeded, Result = "ok" };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
-        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns((IStepInstance?)null);
+        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns(default(IStepInstance?));
 
         // Act
         await sut.RunStepAsync(ctx, flow.Id, step);
@@ -217,7 +217,7 @@ public class HangfireFlowOrchestratorTests
 
         var stepResult = new StepResult { Key = "step1", Status = StepStatus.Succeeded };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
-        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns((IStepInstance?)null);
+        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns(default(IStepInstance?));
 
         // Act
         await sut.RunStepAsync(ctx, flow.Id, step);
@@ -237,7 +237,7 @@ public class HangfireFlowOrchestratorTests
 
         var stepResult = new StepResult { Key = "step1", Status = StepStatus.Failed, ReThrow = true, FailedReason = "critical" };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
-        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns((IStepInstance?)null);
+        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns(default(IStepInstance?));
 
         // Act
         var act = () => sut.RunStepAsync(ctx, flow.Id, step).AsTask();
@@ -374,7 +374,7 @@ public class HangfireFlowOrchestratorTests
         // v1.22+: claim is at execute-time; the current step must claim true to actually execute.
         // Downstream-blocking is controlled by the statuses dict above, not by the claim.
         runtimeStore.TryClaimStepAsync(runId, Arg.Any<string>()).Returns(true);
-        runtimeStore.GetRunStatusAsync(runId).Returns((string?)null);
+        runtimeStore.GetRunStatusAsync(runId).Returns(default(string?));
 
         // Act
         await sut.RunStepAsync(ctx, flow.Id, step);
@@ -424,7 +424,7 @@ public class HangfireFlowOrchestratorTests
 
         var succeededResult = new StepResult { Key = "step_c", Status = StepStatus.Succeeded };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(succeededResult);
-        _flowExecutor.GetNextStep(ctx, flow, step, succeededResult).Returns((IStepInstance?)null);
+        _flowExecutor.GetNextStep(ctx, flow, step, succeededResult).Returns(default(IStepInstance?));
 
         IReadOnlyDictionary<string, StepStatus> statuses = new Dictionary<string, StepStatus>
         {
@@ -438,7 +438,7 @@ public class HangfireFlowOrchestratorTests
         // v1.22+: claim is at execute-time; the current step must claim true to actually execute.
         // Downstream-blocking is controlled by the statuses dict above, not by the claim.
         runtimeStore.TryClaimStepAsync(runId, Arg.Any<string>()).Returns(true);
-        runtimeStore.GetRunStatusAsync(runId).Returns((string?)null);
+        runtimeStore.GetRunStatusAsync(runId).Returns(default(string?));
 
         // Act
         await sut.RunStepAsync(ctx, flow.Id, step);
@@ -483,7 +483,7 @@ public class HangfireFlowOrchestratorTests
 
         var succeededResult = new StepResult { Key = "happy_path", Status = StepStatus.Succeeded };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(succeededResult);
-        _flowExecutor.GetNextStep(ctx, flow, step, succeededResult).Returns((IStepInstance?)null);
+        _flowExecutor.GetNextStep(ctx, flow, step, succeededResult).Returns(default(IStepInstance?));
 
         IReadOnlyDictionary<string, StepStatus> statuses = new Dictionary<string, StepStatus>
         {
@@ -496,7 +496,7 @@ public class HangfireFlowOrchestratorTests
         // v1.22+: claim is at execute-time; the current step must claim true to actually execute.
         // Downstream-blocking is controlled by the statuses dict above, not by the claim.
         runtimeStore.TryClaimStepAsync(runId, Arg.Any<string>()).Returns(true);
-        runtimeStore.GetRunStatusAsync(runId).Returns((string?)null);
+        runtimeStore.GetRunStatusAsync(runId).Returns(default(string?));
 
         // Act
         await sut.RunStepAsync(ctx, flow.Id, step);
@@ -522,7 +522,7 @@ public class HangfireFlowOrchestratorTests
 
         var stepResult = new StepResult { Key = "loop1", Status = StepStatus.Succeeded, DispatchHint = hint };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
-        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns((IStepInstance?)null);
+        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns(default(IStepInstance?));
 
         await sut.RunStepAsync(ctx, flow.Id, step);
 

--- a/tests/integration/FlowOrchestrator.Hangfire.IntegrationTests/HangfireFlowOrchestratorTests.cs
+++ b/tests/integration/FlowOrchestrator.Hangfire.IntegrationTests/HangfireFlowOrchestratorTests.cs
@@ -8,7 +8,6 @@ using Hangfire;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
-using NSubstitute.ReturnsExtensions;
 
 namespace FlowOrchestrator.Hangfire.Tests;
 
@@ -172,7 +171,7 @@ public class HangfireFlowOrchestratorTests
 
         var stepResult = new StepResult { Key = "step1", Status = StepStatus.Succeeded, Result = "ok" };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
-        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).ReturnsNull();
+        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns((IStepInstance?)null);
 
         // Act
         await sut.RunStepAsync(ctx, flow.Id, step);
@@ -218,7 +217,7 @@ public class HangfireFlowOrchestratorTests
 
         var stepResult = new StepResult { Key = "step1", Status = StepStatus.Succeeded };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
-        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).ReturnsNull();
+        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns((IStepInstance?)null);
 
         // Act
         await sut.RunStepAsync(ctx, flow.Id, step);
@@ -238,7 +237,7 @@ public class HangfireFlowOrchestratorTests
 
         var stepResult = new StepResult { Key = "step1", Status = StepStatus.Failed, ReThrow = true, FailedReason = "critical" };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
-        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).ReturnsNull();
+        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns((IStepInstance?)null);
 
         // Act
         var act = () => sut.RunStepAsync(ctx, flow.Id, step).AsTask();
@@ -375,7 +374,7 @@ public class HangfireFlowOrchestratorTests
         // v1.22+: claim is at execute-time; the current step must claim true to actually execute.
         // Downstream-blocking is controlled by the statuses dict above, not by the claim.
         runtimeStore.TryClaimStepAsync(runId, Arg.Any<string>()).Returns(true);
-        runtimeStore.GetRunStatusAsync(runId).ReturnsNull();
+        runtimeStore.GetRunStatusAsync(runId).Returns((string?)null);
 
         // Act
         await sut.RunStepAsync(ctx, flow.Id, step);
@@ -425,7 +424,7 @@ public class HangfireFlowOrchestratorTests
 
         var succeededResult = new StepResult { Key = "step_c", Status = StepStatus.Succeeded };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(succeededResult);
-        _flowExecutor.GetNextStep(ctx, flow, step, succeededResult).ReturnsNull();
+        _flowExecutor.GetNextStep(ctx, flow, step, succeededResult).Returns((IStepInstance?)null);
 
         IReadOnlyDictionary<string, StepStatus> statuses = new Dictionary<string, StepStatus>
         {
@@ -439,7 +438,7 @@ public class HangfireFlowOrchestratorTests
         // v1.22+: claim is at execute-time; the current step must claim true to actually execute.
         // Downstream-blocking is controlled by the statuses dict above, not by the claim.
         runtimeStore.TryClaimStepAsync(runId, Arg.Any<string>()).Returns(true);
-        runtimeStore.GetRunStatusAsync(runId).ReturnsNull();
+        runtimeStore.GetRunStatusAsync(runId).Returns((string?)null);
 
         // Act
         await sut.RunStepAsync(ctx, flow.Id, step);
@@ -484,7 +483,7 @@ public class HangfireFlowOrchestratorTests
 
         var succeededResult = new StepResult { Key = "happy_path", Status = StepStatus.Succeeded };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(succeededResult);
-        _flowExecutor.GetNextStep(ctx, flow, step, succeededResult).ReturnsNull();
+        _flowExecutor.GetNextStep(ctx, flow, step, succeededResult).Returns((IStepInstance?)null);
 
         IReadOnlyDictionary<string, StepStatus> statuses = new Dictionary<string, StepStatus>
         {
@@ -497,7 +496,7 @@ public class HangfireFlowOrchestratorTests
         // v1.22+: claim is at execute-time; the current step must claim true to actually execute.
         // Downstream-blocking is controlled by the statuses dict above, not by the claim.
         runtimeStore.TryClaimStepAsync(runId, Arg.Any<string>()).Returns(true);
-        runtimeStore.GetRunStatusAsync(runId).ReturnsNull();
+        runtimeStore.GetRunStatusAsync(runId).Returns((string?)null);
 
         // Act
         await sut.RunStepAsync(ctx, flow.Id, step);
@@ -523,7 +522,7 @@ public class HangfireFlowOrchestratorTests
 
         var stepResult = new StepResult { Key = "loop1", Status = StepStatus.Succeeded, DispatchHint = hint };
         _stepExecutor.ExecuteAsync(ctx, flow, step).Returns(stepResult);
-        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).ReturnsNull();
+        _flowExecutor.GetNextStep(ctx, flow, step, stepResult).Returns((IStepInstance?)null);
 
         await sut.RunStepAsync(ctx, flow.Id, step);
 

--- a/tests/integration/FlowOrchestrator.Hangfire.IntegrationTests/HangfireFlowOrchestratorTests.cs
+++ b/tests/integration/FlowOrchestrator.Hangfire.IntegrationTests/HangfireFlowOrchestratorTests.cs
@@ -328,7 +328,7 @@ public class HangfireFlowOrchestratorTests
         await sut.RunStepAsync(ctx, flow.Id, step);
 
         // Assert
-        await _runStore.Received(1).CompleteRunAsync(ctx.RunId, "Cancelled");
+        await _runStore.Received(1).CompleteRunIfActiveAsync(ctx.RunId, "Cancelled");
     }
 
     [Fact]
@@ -380,7 +380,7 @@ public class HangfireFlowOrchestratorTests
         await sut.RunStepAsync(ctx, flow.Id, step);
 
         // Assert: run must complete as Failed, not Skipped
-        await _runStore.Received(1).CompleteRunAsync(runId, "Failed");
+        await _runStore.Received(1).CompleteRunIfActiveAsync(runId, "Failed");
     }
 
     [Fact]
@@ -444,7 +444,7 @@ public class HangfireFlowOrchestratorTests
         await sut.RunStepAsync(ctx, flow.Id, step);
 
         // Assert: all leaves Skipped → run = Skipped, not Succeeded
-        await _runStore.Received(1).CompleteRunAsync(runId, "Skipped");
+        await _runStore.Received(1).CompleteRunIfActiveAsync(runId, "Skipped");
     }
 
     [Fact]
@@ -502,7 +502,7 @@ public class HangfireFlowOrchestratorTests
         await sut.RunStepAsync(ctx, flow.Id, step);
 
         // Assert: mixed leaves (one Succeeded, one Skipped) → run = Succeeded
-        await _runStore.Received(1).CompleteRunAsync(runId, "Succeeded");
+        await _runStore.Received(1).CompleteRunIfActiveAsync(runId, "Succeeded");
     }
 
     [Fact]

--- a/tests/integration/FlowOrchestrator.InMemory.IntegrationTests/InMemoryRuntimeTests.cs
+++ b/tests/integration/FlowOrchestrator.InMemory.IntegrationTests/InMemoryRuntimeTests.cs
@@ -145,9 +145,9 @@ public sealed class InMemoryRuntimeTests
 
         // Assert
         await engine.Received(1).RunStepAsync(
-            Arg.Is<IExecutionContext>(c => c.RunId == ctx.RunId),
+            Arg.Is<IExecutionContext>(c => c!.RunId == ctx.RunId),
             Arg.Any<IFlowDefinition>(),
-            Arg.Is<IStepInstance>(s => s.Key == step.Key),
+            Arg.Is<IStepInstance>(s => s!.Key == step.Key),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/integration/FlowOrchestrator.PostgreSQL.IntegrationTests/PostgreSqlFlowRunStoreTests.cs
+++ b/tests/integration/FlowOrchestrator.PostgreSQL.IntegrationTests/PostgreSqlFlowRunStoreTests.cs
@@ -434,4 +434,38 @@ public sealed class PostgreSqlFlowRunStoreTests : IClassFixture<PostgreSqlFixtur
         Assert.NotNull(control);
         Assert.Null(control!.TimeoutAtUtc);
     }
+
+    [Fact]
+    public async Task CompleteRunIfActiveAsync_TransitionsRunningOnce_ThenReturnsFalse()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        await _store.StartRunAsync(Guid.NewGuid(), "F", runId, "manual", null, null);
+
+        // Act
+        var first = await _store.CompleteRunIfActiveAsync(runId, "Succeeded");
+        var second = await _store.CompleteRunIfActiveAsync(runId, "TimedOut");
+
+        // Assert — guarded UPDATE transitions exactly once; the first writer's status stands.
+        Assert.True(first);
+        Assert.False(second);
+        var detail = await _store.GetRunDetailAsync(runId);
+        Assert.Equal("Succeeded", detail!.Status);
+    }
+
+    [Fact]
+    public async Task MarkTimedOutAsync_AlreadyTimedOut_ReturnsFalse()
+    {
+        // Arrange — align the contract with the InMemory backend (Finding 3): a repeat is a no-op.
+        var runId = Guid.NewGuid();
+        await _store.ConfigureRunAsync(runId, Guid.NewGuid(), "manual", null, DateTimeOffset.UtcNow.AddMinutes(-1));
+        var first = await _store.MarkTimedOutAsync(runId, "deadline exceeded");
+
+        // Act
+        var second = await _store.MarkTimedOutAsync(runId, "again");
+
+        // Assert
+        Assert.True(first);
+        Assert.False(second);
+    }
 }

--- a/tests/integration/FlowOrchestrator.PostgreSQL.IntegrationTests/PostgreSqlFlowRunStoreTests.cs
+++ b/tests/integration/FlowOrchestrator.PostgreSQL.IntegrationTests/PostgreSqlFlowRunStoreTests.cs
@@ -361,4 +361,77 @@ public sealed class PostgreSqlFlowRunStoreTests : IClassFixture<PostgreSqlFixtur
         var attemptNumbers = step.Attempts!.Select(a => a.Attempt).OrderBy(n => n).ToArray();
         Assert.Equal(Enumerable.Range(1, concurrency).ToArray(), attemptNumbers);
     }
+
+    [Fact]
+    public async Task ExtendDeadlineAsync_NoControlRecord_ReturnsFalse()
+    {
+        // Arrange — no ConfigureRunAsync, so no control record exists.
+        var runId = Guid.NewGuid();
+
+        // Act
+        var result = await _store.ExtendDeadlineAsync(runId, DateTimeOffset.UtcNow.AddMinutes(10));
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ExtendDeadlineAsync_AfterTimeout_ClearsTimeoutLatchAndRefreshesDeadline()
+    {
+        // Arrange — a run latched TimedOut (also sets the cancel fields).
+        var runId = Guid.NewGuid();
+        await _store.ConfigureRunAsync(runId, Guid.NewGuid(), "manual", null, DateTimeOffset.UtcNow.AddMinutes(-5));
+        await _store.MarkTimedOutAsync(runId, "deadline exceeded");
+        var newDeadline = DateTimeOffset.UtcNow.AddMinutes(10);
+
+        // Act
+        var result = await _store.ExtendDeadlineAsync(runId, newDeadline);
+
+        // Assert — the timeout-induced termination is fully un-latched and the deadline refreshed.
+        Assert.True(result);
+        var control = await _store.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.Null(control!.TimedOutAtUtc);
+        Assert.False(control.CancelRequested);
+        Assert.Null(control.CancelReason);
+        Assert.Null(control.CancelRequestedAtUtc);
+        Assert.NotNull(control.TimeoutAtUtc);
+    }
+
+    [Fact]
+    public async Task ExtendDeadlineAsync_PreservesGenuineUserCancellation()
+    {
+        // Arrange — a user-cancelled run (TimedOutAtUtc stays null).
+        var runId = Guid.NewGuid();
+        await _store.ConfigureRunAsync(runId, Guid.NewGuid(), "manual", null, null);
+        await _store.RequestCancelAsync(runId, "user requested");
+
+        // Act
+        var result = await _store.ExtendDeadlineAsync(runId, DateTimeOffset.UtcNow.AddMinutes(10));
+
+        // Assert — only timeout-induced state is cleared; the user cancellation survives.
+        Assert.True(result);
+        var control = await _store.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.True(control!.CancelRequested);
+        Assert.Equal("user requested", control.CancelReason);
+        Assert.Null(control.TimedOutAtUtc);
+    }
+
+    [Fact]
+    public async Task ExtendDeadlineAsync_NullDeadline_ClearsTimeoutBound()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        await _store.ConfigureRunAsync(runId, Guid.NewGuid(), "manual", null, DateTimeOffset.UtcNow.AddMinutes(5));
+
+        // Act
+        var result = await _store.ExtendDeadlineAsync(runId, null);
+
+        // Assert
+        Assert.True(result);
+        var control = await _store.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.Null(control!.TimeoutAtUtc);
+    }
 }

--- a/tests/integration/FlowOrchestrator.PostgreSQL.IntegrationTests/PostgreSqlOutputsRepositoryTests.cs
+++ b/tests/integration/FlowOrchestrator.PostgreSQL.IntegrationTests/PostgreSqlOutputsRepositoryTests.cs
@@ -3,7 +3,6 @@ using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Storage;
 using NSubstitute;
-using NSubstitute.ReturnsExtensions;
 
 namespace FlowOrchestrator.PostgreSQL.Tests;
 
@@ -25,7 +24,7 @@ public sealed class PostgreSqlOutputsRepositoryTests : IClassFixture<PostgreSqlF
         var flow = Substitute.For<IFlowDefinition>();
         var trigger = Substitute.For<ITrigger>();
         trigger.Data.Returns(new { OrderId = 42, Customer = "Test" });
-        trigger.Headers.ReturnsNull();
+        trigger.Headers.Returns((IReadOnlyDictionary<string, string>?)null);
 
         // Act
         await _repo.SaveTriggerDataAsync(ctx, flow, trigger);
@@ -58,7 +57,7 @@ public sealed class PostgreSqlOutputsRepositoryTests : IClassFixture<PostgreSqlF
         var ctx = MakeTriggerContext(runId);
         var flow = Substitute.For<IFlowDefinition>();
         var trigger = Substitute.For<ITrigger>();
-        trigger.Data.ReturnsNull();
+        trigger.Data.Returns((object?)null);
         var headers = new Dictionary<string, string> { ["X-Request-Id"] = "abc123" };
         trigger.Headers.Returns(headers);
 

--- a/tests/integration/FlowOrchestrator.PostgreSQL.IntegrationTests/PostgreSqlOutputsRepositoryTests.cs
+++ b/tests/integration/FlowOrchestrator.PostgreSQL.IntegrationTests/PostgreSqlOutputsRepositoryTests.cs
@@ -24,7 +24,7 @@ public sealed class PostgreSqlOutputsRepositoryTests : IClassFixture<PostgreSqlF
         var flow = Substitute.For<IFlowDefinition>();
         var trigger = Substitute.For<ITrigger>();
         trigger.Data.Returns(new { OrderId = 42, Customer = "Test" });
-        trigger.Headers.Returns((IReadOnlyDictionary<string, string>?)null);
+        trigger.Headers.Returns(default(IReadOnlyDictionary<string, string>?));
 
         // Act
         await _repo.SaveTriggerDataAsync(ctx, flow, trigger);
@@ -57,7 +57,7 @@ public sealed class PostgreSqlOutputsRepositoryTests : IClassFixture<PostgreSqlF
         var ctx = MakeTriggerContext(runId);
         var flow = Substitute.For<IFlowDefinition>();
         var trigger = Substitute.For<ITrigger>();
-        trigger.Data.Returns((object?)null);
+        trigger.Data.Returns(default(object?));
         var headers = new Dictionary<string, string> { ["X-Request-Id"] = "abc123" };
         trigger.Headers.Returns(headers);
 

--- a/tests/integration/FlowOrchestrator.SqlServer.IntegrationTests/SqlFlowRunStoreTests.cs
+++ b/tests/integration/FlowOrchestrator.SqlServer.IntegrationTests/SqlFlowRunStoreTests.cs
@@ -367,4 +367,38 @@ public sealed class SqlFlowRunStoreTests : IClassFixture<SqlServerFixture>
         Assert.NotNull(control);
         Assert.Null(control!.TimeoutAtUtc);
     }
+
+    [Fact]
+    public async Task CompleteRunIfActiveAsync_TransitionsRunningOnce_ThenReturnsFalse()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        await _store.StartRunAsync(Guid.NewGuid(), "F", runId, "manual", null, null);
+
+        // Act
+        var first = await _store.CompleteRunIfActiveAsync(runId, "Succeeded");
+        var second = await _store.CompleteRunIfActiveAsync(runId, "TimedOut");
+
+        // Assert — guarded UPDATE transitions exactly once; the first writer's status stands.
+        Assert.True(first);
+        Assert.False(second);
+        var detail = await _store.GetRunDetailAsync(runId);
+        Assert.Equal("Succeeded", detail!.Status);
+    }
+
+    [Fact]
+    public async Task MarkTimedOutAsync_AlreadyTimedOut_ReturnsFalse()
+    {
+        // Arrange — align the contract with the InMemory backend (Finding 3): a repeat is a no-op.
+        var runId = Guid.NewGuid();
+        await _store.ConfigureRunAsync(runId, Guid.NewGuid(), "manual", null, DateTimeOffset.UtcNow.AddMinutes(-1));
+        var first = await _store.MarkTimedOutAsync(runId, "deadline exceeded");
+
+        // Act
+        var second = await _store.MarkTimedOutAsync(runId, "again");
+
+        // Assert
+        Assert.True(first);
+        Assert.False(second);
+    }
 }

--- a/tests/integration/FlowOrchestrator.SqlServer.IntegrationTests/SqlFlowRunStoreTests.cs
+++ b/tests/integration/FlowOrchestrator.SqlServer.IntegrationTests/SqlFlowRunStoreTests.cs
@@ -294,4 +294,77 @@ public sealed class SqlFlowRunStoreTests : IClassFixture<SqlServerFixture>
         Assert.Empty(runs);
         Assert.Equal(3, total);
     }
+
+    [Fact]
+    public async Task ExtendDeadlineAsync_NoControlRecord_ReturnsFalse()
+    {
+        // Arrange — no ConfigureRunAsync, so no control record exists.
+        var runId = Guid.NewGuid();
+
+        // Act
+        var result = await _store.ExtendDeadlineAsync(runId, DateTimeOffset.UtcNow.AddMinutes(10));
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ExtendDeadlineAsync_AfterTimeout_ClearsTimeoutLatchAndRefreshesDeadline()
+    {
+        // Arrange — a run latched TimedOut (also sets the cancel fields).
+        var runId = Guid.NewGuid();
+        await _store.ConfigureRunAsync(runId, Guid.NewGuid(), "manual", null, DateTimeOffset.UtcNow.AddMinutes(-5));
+        await _store.MarkTimedOutAsync(runId, "deadline exceeded");
+        var newDeadline = DateTimeOffset.UtcNow.AddMinutes(10);
+
+        // Act
+        var result = await _store.ExtendDeadlineAsync(runId, newDeadline);
+
+        // Assert — the timeout-induced termination is fully un-latched and the deadline refreshed.
+        Assert.True(result);
+        var control = await _store.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.Null(control!.TimedOutAtUtc);
+        Assert.False(control.CancelRequested);
+        Assert.Null(control.CancelReason);
+        Assert.Null(control.CancelRequestedAtUtc);
+        Assert.NotNull(control.TimeoutAtUtc);
+    }
+
+    [Fact]
+    public async Task ExtendDeadlineAsync_PreservesGenuineUserCancellation()
+    {
+        // Arrange — a user-cancelled run (TimedOutAtUtc stays null).
+        var runId = Guid.NewGuid();
+        await _store.ConfigureRunAsync(runId, Guid.NewGuid(), "manual", null, null);
+        await _store.RequestCancelAsync(runId, "user requested");
+
+        // Act
+        var result = await _store.ExtendDeadlineAsync(runId, DateTimeOffset.UtcNow.AddMinutes(10));
+
+        // Assert — only timeout-induced state is cleared; the user cancellation survives.
+        Assert.True(result);
+        var control = await _store.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.True(control!.CancelRequested);
+        Assert.Equal("user requested", control.CancelReason);
+        Assert.Null(control.TimedOutAtUtc);
+    }
+
+    [Fact]
+    public async Task ExtendDeadlineAsync_NullDeadline_ClearsTimeoutBound()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        await _store.ConfigureRunAsync(runId, Guid.NewGuid(), "manual", null, DateTimeOffset.UtcNow.AddMinutes(5));
+
+        // Act
+        var result = await _store.ExtendDeadlineAsync(runId, null);
+
+        // Assert
+        Assert.True(result);
+        var control = await _store.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.Null(control!.TimeoutAtUtc);
+    }
 }

--- a/tests/integration/FlowOrchestrator.SqlServer.IntegrationTests/SqlOutputsRepositoryTests.cs
+++ b/tests/integration/FlowOrchestrator.SqlServer.IntegrationTests/SqlOutputsRepositoryTests.cs
@@ -3,7 +3,6 @@ using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
 using FlowOrchestrator.Core.Storage;
 using NSubstitute;
-using NSubstitute.ReturnsExtensions;
 
 namespace FlowOrchestrator.SqlServer.Tests;
 
@@ -25,7 +24,7 @@ public sealed class SqlOutputsRepositoryTests : IClassFixture<SqlServerFixture>
         var flow = Substitute.For<IFlowDefinition>();
         var trigger = Substitute.For<ITrigger>();
         trigger.Data.Returns(new { OrderId = 42, Customer = "Test" });
-        trigger.Headers.ReturnsNull();
+        trigger.Headers.Returns((IReadOnlyDictionary<string, string>?)null);
 
         // Act
         await _repo.SaveTriggerDataAsync(ctx, flow, trigger);
@@ -57,7 +56,7 @@ public sealed class SqlOutputsRepositoryTests : IClassFixture<SqlServerFixture>
         var ctx = MakeTriggerContext(runId);
         var flow = Substitute.For<IFlowDefinition>();
         var trigger = Substitute.For<ITrigger>();
-        trigger.Data.ReturnsNull();
+        trigger.Data.Returns((object?)null);
         var headers = new Dictionary<string, string> { ["X-Request-Id"] = "abc123" };
         trigger.Headers.Returns(headers);
 

--- a/tests/integration/FlowOrchestrator.SqlServer.IntegrationTests/SqlOutputsRepositoryTests.cs
+++ b/tests/integration/FlowOrchestrator.SqlServer.IntegrationTests/SqlOutputsRepositoryTests.cs
@@ -24,7 +24,7 @@ public sealed class SqlOutputsRepositoryTests : IClassFixture<SqlServerFixture>
         var flow = Substitute.For<IFlowDefinition>();
         var trigger = Substitute.For<ITrigger>();
         trigger.Data.Returns(new { OrderId = 42, Customer = "Test" });
-        trigger.Headers.Returns((IReadOnlyDictionary<string, string>?)null);
+        trigger.Headers.Returns(default(IReadOnlyDictionary<string, string>?));
 
         // Act
         await _repo.SaveTriggerDataAsync(ctx, flow, trigger);
@@ -56,7 +56,7 @@ public sealed class SqlOutputsRepositoryTests : IClassFixture<SqlServerFixture>
         var ctx = MakeTriggerContext(runId);
         var flow = Substitute.For<IFlowDefinition>();
         var trigger = Substitute.For<ITrigger>();
-        trigger.Data.Returns((object?)null);
+        trigger.Data.Returns(default(object?));
         var headers = new Dictionary<string, string> { ["X-Request-Id"] = "abc123" };
         trigger.Headers.Returns(headers);
 

--- a/tests/regression/FlowOrchestrator.RegressionTests/Hangfire/HangfireStepDispatcherConcurrencyTests.cs
+++ b/tests/regression/FlowOrchestrator.RegressionTests/Hangfire/HangfireStepDispatcherConcurrencyTests.cs
@@ -68,7 +68,7 @@ public sealed class HangfireStepDispatcherConcurrencyTests
             .Create(Arg.Any<Job>(), Arg.Any<IState>())
             .Returns(callInfo =>
             {
-                capturedStates.Add(callInfo.Arg<IState>());
+                capturedStates.Add(callInfo.Arg<IState>()!);
                 return Guid.NewGuid().ToString();
             });
 

--- a/tests/regression/FlowOrchestrator.RegressionTests/Hosting/FlowRunRecoveryConcurrencyTests.cs
+++ b/tests/regression/FlowOrchestrator.RegressionTests/Hosting/FlowRunRecoveryConcurrencyTests.cs
@@ -64,7 +64,7 @@ public sealed class FlowRunRecoveryConcurrencyTests
         await dispatcher.Received(1).EnqueueStepAsync(
             Arg.Any<IExecutionContext>(),
             flow,
-            Arg.Is<IStepInstance>(s => s.Key == "step1"),
+            Arg.Is<IStepInstance>(s => s!.Key == "step1"),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/regression/FlowOrchestrator.RegressionTests/Testing/PeriodicTimeoutEnforcementTests.cs
+++ b/tests/regression/FlowOrchestrator.RegressionTests/Testing/PeriodicTimeoutEnforcementTests.cs
@@ -1,0 +1,44 @@
+using FlowOrchestrator.Core.Storage;
+using FlowOrchestrator.Testing.Tests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FlowOrchestrator.Testing.Tests;
+
+/// <summary>
+/// Regression for the missing timeout-enforcement service: a run stuck <c>Running</c> with a lapsed
+/// deadline and nothing scheduled must be marked <see cref="RunStatus.TimedOut"/> by the periodic
+/// <c>FlowTimeoutEnforcementHostedService</c> — without any manual retry or further step dispatch.
+/// Before the fix such a run sat <c>Running</c> indefinitely.
+/// </summary>
+public sealed class PeriodicTimeoutEnforcementTests
+{
+    [Fact]
+    public async Task PeriodicSweep_MarksStuckRunningRunAsTimedOut()
+    {
+        // Arrange — host with a fast enforcement interval. We seed a stuck Running run directly in the
+        // store (a run whose worker died leaving nothing scheduled), which is the exact production
+        // scenario the lazy dispatch-time gate can never resolve.
+        await using var host = await FlowTestHost.For<HandlerThrowsFlow>()
+            .WithService(new FlakyHandlerProbe())
+            .WithHandler<FlakyStepHandler>("Flaky")
+            .WithCustomConfiguration(b => b.RunControl.TimeoutEnforcementInterval = TimeSpan.FromSeconds(1))
+            .BuildAsync();
+
+        var runStore = host.Services.GetRequiredService<IFlowRunStore>();
+        var controlStore = host.Services.GetRequiredService<IFlowRunControlStore>();
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+
+        await runStore.StartRunAsync(flowId, "StuckFlow", runId, "manual", null, null);
+        await controlStore.ConfigureRunAsync(runId, flowId, "manual", null, DateTimeOffset.UtcNow.AddSeconds(-1));
+
+        // Act — no trigger, no retry: wait for the periodic sweep to enforce the deadline.
+        var snapshot = await host.WaitForRunAsync(runId, TimeSpan.FromSeconds(30));
+
+        // Assert — the run was proactively timed out by the hosted service.
+        Assert.Equal(RunStatus.TimedOut, snapshot.Status);
+        var control = await controlStore.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.NotNull(control!.TimedOutAtUtc);
+    }
+}

--- a/tests/regression/FlowOrchestrator.RegressionTests/Testing/RetryAfterTimeoutTests.cs
+++ b/tests/regression/FlowOrchestrator.RegressionTests/Testing/RetryAfterTimeoutTests.cs
@@ -1,0 +1,53 @@
+using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Storage;
+using FlowOrchestrator.Testing.Tests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FlowOrchestrator.Testing.Tests;
+
+/// <summary>
+/// Regression for the "dashboard Retry is a permanent no-op past the timeout deadline" defect.
+/// A run whose <c>DefaultRunTimeout</c> lapsed while it sat <see cref="RunStatus.Failed"/> must, on
+/// retry, get a fresh execution window so the handler actually re-runs and the run can reach
+/// <see cref="RunStatus.Succeeded"/> — instead of being skipped by the termination gate forever.
+/// </summary>
+public sealed class RetryAfterTimeoutTests
+{
+    [Fact]
+    public async Task RetryStepAsync_AfterRunDeadlineLapsed_ReExecutesHandlerAndSucceeds()
+    {
+        // Arrange — short run timeout; handler fails on attempt 1, succeeds afterwards. The periodic
+        // enforcer is disabled here so this test isolates the retry path (a Failed run is not active
+        // and would not be swept anyway).
+        var probe = new FlakyHandlerProbe { FailUntilAttempt = 1 };
+        await using var host = await FlowTestHost.For<HandlerThrowsFlow>()
+            .WithService(probe)
+            .WithHandler<FlakyStepHandler>("Flaky")
+            .WithCustomConfiguration(b =>
+            {
+                b.RunControl.DefaultRunTimeout = TimeSpan.FromSeconds(2);
+                b.RunControl.TimeoutEnforcementInterval = null;
+            })
+            .BuildAsync();
+
+        // Act 1 — initial trigger fails fast and lands in Failed.
+        var initial = await host.TriggerAsync(timeout: TimeSpan.FromSeconds(30));
+        Assert.Equal(RunStatus.Failed, initial.Status);
+        Assert.Equal(1, probe.Attempt);
+
+        // Let the run's 2s deadline lapse while it sits Failed — this is the state that used to make
+        // the run permanently unrecoverable.
+        await Task.Delay(TimeSpan.FromSeconds(2.5));
+
+        var orchestrator = host.Services.GetRequiredService<IFlowOrchestrator>();
+        var flow = new HandlerThrowsFlow();
+
+        // Act 2 — dashboard Retry after the deadline lapsed.
+        await orchestrator.RetryStepAsync(flow.Id, initial.RunId, "flaky");
+        var snapshot = await host.WaitForRunAsync(initial.RunId, TimeSpan.FromSeconds(30));
+
+        // Assert — the handler ran again (attempt 2) and the run recovered to Succeeded.
+        Assert.Equal(RunStatus.Succeeded, snapshot.Status);
+        Assert.Equal(2, probe.Attempt);
+    }
+}

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/FlowOrchestratorEngineInvariantTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/FlowOrchestratorEngineInvariantTests.cs
@@ -194,7 +194,7 @@ public sealed class FlowOrchestratorEngineInvariantTests
         await _dispatcher.Received(1).ScheduleStepAsync(
             Arg.Any<IExecutionContext>(),
             flow,
-            Arg.Is<IStepInstance>(s => s.Key == "step1"),
+            Arg.Is<IStepInstance>(s => s!.Key == "step1"),
             Arg.Is<TimeSpan>(d => d == TimeSpan.FromSeconds(5)),
             Arg.Any<CancellationToken>());
         Assert.True(scheduleObservedReleaseFirst);

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/ForEachStepHandlerTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/ForEachStepHandlerTests.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Execution;
 using NSubstitute;
-using NSubstitute.ReturnsExtensions;
 
 namespace FlowOrchestrator.Core.Tests.Execution;
 
@@ -17,7 +16,7 @@ public class ForEachStepHandlerTests
         var ctx = Substitute.For<IExecutionContext>();
         ctx.RunId.Returns(Guid.NewGuid());
         ctx.TriggerData.Returns(triggerData);
-        ctx.TriggerHeaders.ReturnsNull();
+        ctx.TriggerHeaders.Returns((IReadOnlyDictionary<string, string>?)null);
         return ctx;
     }
 

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/ForEachStepHandlerTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/ForEachStepHandlerTests.cs
@@ -16,7 +16,7 @@ public class ForEachStepHandlerTests
         var ctx = Substitute.For<IExecutionContext>();
         ctx.RunId.Returns(Guid.NewGuid());
         ctx.TriggerData.Returns(triggerData);
-        ctx.TriggerHeaders.Returns((IReadOnlyDictionary<string, string>?)null);
+        ctx.TriggerHeaders.Returns(default(IReadOnlyDictionary<string, string>?));
         return ctx;
     }
 

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RetryExtendsRunDeadlineTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RetryExtendsRunDeadlineTests.cs
@@ -40,7 +40,7 @@ public sealed class RetryExtendsRunDeadlineTests
                 Arg.Any<IExecutionContext>(),
                 Arg.Any<IFlowDefinition>(),
                 Arg.Any<IStepInstance>())
-            .Returns(call => new ValueTask<IStepResult>(resultForStep(call.Arg<IStepInstance>().Key)));
+            .Returns(call => new ValueTask<IStepResult>(resultForStep(call.Arg<IStepInstance>()!.Key)));
 
         _flowRepo.GetAllFlowsAsync().Returns(new ValueTask<IReadOnlyList<IFlowDefinition>>(new[] { flow }));
 

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RetryExtendsRunDeadlineTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RetryExtendsRunDeadlineTests.cs
@@ -1,0 +1,177 @@
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Configuration;
+using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Observability;
+using FlowOrchestrator.Core.Storage;
+using FlowOrchestrator.InMemory;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using CoreExecutionContext = FlowOrchestrator.Core.Execution.ExecutionContext;
+
+namespace FlowOrchestrator.Core.Tests.Execution;
+
+/// <summary>
+/// Regression for the "dashboard Retry is a permanent no-op past the timeout deadline" defect:
+/// <see cref="FlowOrchestratorEngine.RetryStepAsync"/> must grant the run a fresh execution window
+/// (via <see cref="IFlowRunControlStore.ExtendDeadlineAsync"/>) before re-dispatch, otherwise the
+/// re-dispatched step is skipped by the termination gate before the handler runs.
+/// </summary>
+public sealed class RetryExtendsRunDeadlineTests
+{
+    private readonly IFlowExecutor _flowExecutor = Substitute.For<IFlowExecutor>();
+    private readonly IFlowGraphPlanner _graphPlanner = new FlowGraphPlanner();
+    private readonly IStepExecutor _stepExecutor = Substitute.For<IStepExecutor>();
+    private readonly IFlowStore _flowStore = Substitute.For<IFlowStore>();
+    private readonly IOutputsRepository _outputsRepo = Substitute.For<IOutputsRepository>();
+    private readonly IExecutionContextAccessor _ctxAccessor = Substitute.For<IExecutionContextAccessor>();
+    private readonly IFlowRepository _flowRepo = Substitute.For<IFlowRepository>();
+    private readonly ILogger<FlowOrchestratorEngine> _logger =
+        Substitute.For<ILogger<FlowOrchestratorEngine>>();
+
+    private FlowOrchestratorEngine CreateEngine(
+        InMemoryFlowRunStore store,
+        IFlowDefinition flow,
+        FlowRunControlOptions options,
+        Func<string, IStepResult> resultForStep)
+    {
+        var dispatcher = Substitute.For<IStepDispatcher>();
+
+        _stepExecutor.ExecuteAsync(
+                Arg.Any<IExecutionContext>(),
+                Arg.Any<IFlowDefinition>(),
+                Arg.Any<IStepInstance>())
+            .Returns(call => new ValueTask<IStepResult>(resultForStep(call.Arg<IStepInstance>().Key)));
+
+        _flowRepo.GetAllFlowsAsync().Returns(new ValueTask<IReadOnlyList<IFlowDefinition>>(new[] { flow }));
+
+        return new FlowOrchestratorEngine(
+            dispatcher,
+            _flowExecutor,
+            _graphPlanner,
+            _stepExecutor,
+            _flowStore,
+            store,
+            _outputsRepo,
+            _ctxAccessor,
+            _flowRepo,
+            [store],
+            [store],
+            options,
+            new FlowObservabilityOptions { EnableEventPersistence = false, EnableOpenTelemetry = false },
+            new FlowOrchestratorTelemetry(),
+            _logger);
+    }
+
+    private static IFlowDefinition MakeSingleStepFlow(Guid flowId)
+    {
+        var flow = Substitute.For<IFlowDefinition>();
+        flow.Id.Returns(flowId);
+        flow.Manifest.Returns(new FlowManifest
+        {
+            Steps = new StepCollection
+            {
+                ["step1"] = new StepMetadata { Type = "Work" }
+            }
+        });
+        return flow;
+    }
+
+    [Fact]
+    public async Task RetryStepAsync_OnTimedOutRun_ReExecutesHandler_AndRefreshesDeadlineIntoTheFuture()
+    {
+        // Arrange — step fails on attempt 1 (before deadline), succeeds on retry.
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        var flow = MakeSingleStepFlow(flowId);
+        var attempt = 0;
+        var options = new FlowRunControlOptions { DefaultRunTimeout = TimeSpan.FromMinutes(5) };
+        var store = new InMemoryFlowRunStore();
+        var engine = CreateEngine(store, flow, options, _ => ++attempt == 1
+            ? new StepResult { Key = "step1", Status = StepStatus.Failed, FailedReason = "upstream 404" }
+            : new StepResult { Key = "step1", Status = StepStatus.Succeeded });
+
+        await store.StartRunAsync(flowId, "TestFlow", runId, "manual", null, null);
+        await store.ConfigureRunAsync(runId, flowId, "manual", null, DateTimeOffset.UtcNow.AddMinutes(5));
+
+        // Attempt 1 → Failed, run terminates Failed.
+        await engine.RunStepAsync(
+            new CoreExecutionContext { RunId = runId }, flow, new StepInstance("step1", "Work") { RunId = runId });
+        Assert.Equal("Failed", await store.GetRunStatusAsync(runId));
+
+        // Deadline lapses while the run sits Failed, latching it TimedOut.
+        await store.MarkTimedOutAsync(runId, "Deadline exceeded");
+
+        // Act — dashboard Retry.
+        await engine.RetryStepAsync(flowId, runId, "step1");
+
+        // Assert — the handler actually ran on retry; the run reaches Succeeded.
+        Assert.Equal(2, attempt);
+        Assert.Equal(StepStatus.Succeeded, (await store.GetStepStatusesAsync(runId))["step1"]);
+        Assert.Equal("Succeeded", await store.GetRunStatusAsync(runId));
+
+        // Assert — the timeout latch is cleared and the deadline is refreshed into the future.
+        var control = await store.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.Null(control!.TimedOutAtUtc);
+        Assert.False(control.CancelRequested);
+        Assert.NotNull(control.TimeoutAtUtc);
+        Assert.True(control.TimeoutAtUtc > DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public async Task RetryStepAsync_OnTimedOutRun_WithTimeoutDisabled_StillReExecutesHandler()
+    {
+        // Arrange — DefaultRunTimeout null (timeout globally disabled), no per-run override.
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        var flow = MakeSingleStepFlow(flowId);
+        var attempt = 0;
+        var store = new InMemoryFlowRunStore();
+        var engine = CreateEngine(store, flow, new FlowRunControlOptions(), _ => ++attempt == 1
+            ? new StepResult { Key = "step1", Status = StepStatus.Failed, FailedReason = "boom" }
+            : new StepResult { Key = "step1", Status = StepStatus.Succeeded });
+
+        await store.StartRunAsync(flowId, "TestFlow", runId, "manual", null, null);
+        await store.ConfigureRunAsync(runId, flowId, "manual", null, null);
+
+        await engine.RunStepAsync(
+            new CoreExecutionContext { RunId = runId }, flow, new StepInstance("step1", "Work") { RunId = runId });
+        await store.MarkTimedOutAsync(runId, "Deadline exceeded");
+
+        // Act
+        await engine.RetryStepAsync(flowId, runId, "step1");
+
+        // Assert — handler ran; run Succeeded; no timeout bound restored.
+        Assert.Equal("Succeeded", await store.GetRunStatusAsync(runId));
+        var control = await store.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.Null(control!.TimedOutAtUtc);
+        Assert.Null(control.TimeoutAtUtc);
+    }
+
+    [Fact]
+    public async Task RefreshedDeadline_StillBoundsARunawayLoop()
+    {
+        // Arrange — a refreshed execution window that has itself already lapsed (a genuinely
+        // runaway retry loop). The termination gate must still time the run out — the refresh
+        // must never disable the protection the timeout exists for.
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        var flow = MakeSingleStepFlow(flowId);
+        var store = new InMemoryFlowRunStore();
+        var engine = CreateEngine(store, flow, new FlowRunControlOptions(),
+            _ => new StepResult { Key = "step1", Status = StepStatus.Succeeded });
+
+        await store.StartRunAsync(flowId, "TestFlow", runId, "manual", null, null);
+        await store.ConfigureRunAsync(runId, flowId, "manual", null, null);
+        await store.ExtendDeadlineAsync(runId, DateTimeOffset.UtcNow.AddMinutes(-1));
+
+        // Act — dispatch the step against the lapsed refreshed deadline.
+        await engine.RunStepAsync(
+            new CoreExecutionContext { RunId = runId }, flow, new StepInstance("step1", "Work") { RunId = runId });
+
+        // Assert — the handler never ran; the run is timed out again.
+        await _stepExecutor.DidNotReceiveWithAnyArgs().ExecuteAsync(default!, default!, default!);
+        Assert.Equal("TimedOut", await store.GetRunStatusAsync(runId));
+    }
+}

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RetryStepCascadeAdvanceTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RetryStepCascadeAdvanceTests.cs
@@ -84,7 +84,7 @@ public sealed class RetryStepCascadeAdvanceTests
 
         ValueTask<string?> Capture(NSubstitute.Core.CallInfo call)
         {
-            var step = call.Arg<IStepInstance>();
+            var step = call.Arg<IStepInstance>()!;
             enqueued.Add(step.Key);
             pending.Enqueue(step);
             return new ValueTask<string?>("job-" + step.Key);
@@ -111,7 +111,7 @@ public sealed class RetryStepCascadeAdvanceTests
                 Arg.Any<IStepInstance>())
             .Returns(call =>
             {
-                var step = call.Arg<IStepInstance>();
+                var step = call.Arg<IStepInstance>()!;
                 return new ValueTask<IStepResult>(resultForStep(step.Key));
             });
 

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RunControlTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RunControlTests.cs
@@ -165,4 +165,36 @@ public sealed class RunControlTests
         var status = await store.GetRunStatusAsync(runId);
         Assert.Equal("TimedOut", status);
     }
+
+    [Fact]
+    public async Task RunStepAsync_UserCancelledAndDeadlineLapsed_CompletesAsCancelled_NotTimedOut()
+    {
+        // Arrange — a run cancelled by the user whose deadline ALSO lapsed. Cancel intent must win:
+        // the termination gate resolves Cancelled (not TimedOut), and the timeout latch is never set —
+        // otherwise a later retry would clear the cancellation.
+        var store = new InMemoryFlowRunStore();
+        var engine = CreateEngine(store);
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        var flow = MakeSingleStepFlow(flowId);
+
+        await store.StartRunAsync(flowId, "TestFlow", runId, "manual", null, null);
+        // Deadline already in the past AND a user cancellation on record.
+        await store.ConfigureRunAsync(runId, flowId, "manual", null, DateTimeOffset.UtcNow.AddMinutes(-1));
+        await store.RequestCancelAsync(runId, "user requested");
+
+        // Act
+        await engine.RunStepAsync(
+            new CoreExecutionContext { RunId = runId },
+            flow,
+            new StepInstance("step1", "Work") { RunId = runId });
+
+        // Assert
+        await _stepExecutor.DidNotReceiveWithAnyArgs()
+            .ExecuteAsync(default!, default!, default!);
+        Assert.Equal("Cancelled", await store.GetRunStatusAsync(runId));
+        var control = await store.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.Null(control!.TimedOutAtUtc);
+    }
 }

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RunTimeoutEnforcementTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RunTimeoutEnforcementTests.cs
@@ -46,15 +46,18 @@ public sealed class RunTimeoutEnforcementTests
             _logger);
 
     [Fact]
-    public async Task EnforceDueTimeoutsAsync_LapsedActiveRun_MarksTimedOutAndCompletesRun()
+    public async Task EnforceDueTimeoutsAsync_StuckRunningRunWithFailedStep_MarksTimedOutAndCompletesRun()
     {
-        // Arrange — active run whose deadline has already passed, nothing in flight.
+        // Arrange — the production scenario: a step failed and left nothing scheduled, so the run sat
+        // Running past its deadline. No in-flight work remains → the sweep must complete it TimedOut.
         var store = new InMemoryFlowRunStore();
         var engine = CreateEngine(store);
         var flowId = Guid.NewGuid();
         var runId = Guid.NewGuid();
         await store.StartRunAsync(flowId, "TestFlow", runId, "manual", null, null);
         await store.ConfigureRunAsync(runId, flowId, "manual", null, DateTimeOffset.UtcNow.AddMinutes(-1));
+        await store.RecordStepStartAsync(runId, "step1", "Work", "{}", "job1");
+        await store.RecordStepCompleteAsync(runId, "step1", "Failed", null, "upstream 404");
 
         // Act
         await engine.EnforceDueTimeoutsAsync();
@@ -110,10 +113,12 @@ public sealed class RunTimeoutEnforcementTests
     }
 
     [Fact]
-    public async Task EnforceDueTimeoutsAsync_RunWithInFlightStep_LatchesTimeoutButDoesNotComplete()
+    public async Task EnforceDueTimeoutsAsync_RunWithInFlightStep_IsLeftUntouched()
     {
-        // Arrange — lapsed deadline but a step is still Running: the in-flight guard must prevent
-        // force-completion. The run stays Running (converges to TimedOut once the step finishes).
+        // Arrange — lapsed deadline but a step is still Running: the run is NOT stuck. The periodic
+        // sweep must leave it entirely alone (no latch, no completion) so the dispatch-time gate can
+        // enforce the deadline on the step's next dispatch. Latching here would risk an inconsistent
+        // TimedOut(control)/Succeeded(run) state if the final in-flight step then completed.
         var store = new InMemoryFlowRunStore();
         var engine = CreateEngine(store);
         var flowId = Guid.NewGuid();
@@ -125,10 +130,10 @@ public sealed class RunTimeoutEnforcementTests
         // Act
         await engine.EnforceDueTimeoutsAsync();
 
-        // Assert
+        // Assert — untouched: still Running, deadline not latched.
         Assert.Equal("Running", await store.GetRunStatusAsync(runId));
         var control = await store.GetRunControlAsync(runId);
         Assert.NotNull(control);
-        Assert.NotNull(control!.TimedOutAtUtc);
+        Assert.Null(control!.TimedOutAtUtc);
     }
 }

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RunTimeoutEnforcementTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RunTimeoutEnforcementTests.cs
@@ -1,6 +1,7 @@
 using FlowOrchestrator.Core.Abstractions;
 using FlowOrchestrator.Core.Configuration;
 using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Notifications;
 using FlowOrchestrator.Core.Observability;
 using FlowOrchestrator.Core.Storage;
 using FlowOrchestrator.InMemory;
@@ -27,7 +28,7 @@ public sealed class RunTimeoutEnforcementTests
     private readonly ILogger<FlowOrchestratorEngine> _logger =
         Substitute.For<ILogger<FlowOrchestratorEngine>>();
 
-    private FlowOrchestratorEngine CreateEngine(InMemoryFlowRunStore store) =>
+    private FlowOrchestratorEngine CreateEngine(InMemoryFlowRunStore store, IFlowEventNotifier? notifier = null) =>
         new FlowOrchestratorEngine(
             _dispatcher,
             _flowExecutor,
@@ -43,7 +44,24 @@ public sealed class RunTimeoutEnforcementTests
             new FlowRunControlOptions(),
             new FlowObservabilityOptions { EnableEventPersistence = false, EnableOpenTelemetry = false },
             new FlowOrchestratorTelemetry(),
-            _logger);
+            _logger,
+            notifier);
+
+    /// <summary>Counts published <see cref="RunCompletedEvent"/>s so tests can assert exactly-once completion.</summary>
+    private sealed class CountingNotifier : IFlowEventNotifier
+    {
+        private int _runCompleted;
+        public int RunCompletedCount => _runCompleted;
+
+        public ValueTask PublishAsync(FlowLifecycleEvent evt, CancellationToken ct = default)
+        {
+            if (evt is RunCompletedEvent)
+            {
+                Interlocked.Increment(ref _runCompleted);
+            }
+            return ValueTask.CompletedTask;
+        }
+    }
 
     [Fact]
     public async Task EnforceDueTimeoutsAsync_StuckRunningRunWithFailedStep_MarksTimedOutAndCompletesRun()
@@ -135,5 +153,53 @@ public sealed class RunTimeoutEnforcementTests
         var control = await store.GetRunControlAsync(runId);
         Assert.NotNull(control);
         Assert.Null(control!.TimedOutAtUtc);
+    }
+
+    [Fact]
+    public async Task EnforceDueTimeoutsAsync_StuckLapsedUserCancelledRun_CompletesAsCancelled_PreservingCancel()
+    {
+        // Arrange — a user cancelled a run that then got stuck past its deadline. The sweep must
+        // finalise it as Cancelled (honouring intent), NOT mislabel it TimedOut, and must NOT latch
+        // the timeout — otherwise a later retry would clear the cancel.
+        var store = new InMemoryFlowRunStore();
+        var engine = CreateEngine(store);
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        await store.StartRunAsync(flowId, "TestFlow", runId, "manual", null, null);
+        await store.ConfigureRunAsync(runId, flowId, "manual", null, DateTimeOffset.UtcNow.AddMinutes(-1));
+        await store.RequestCancelAsync(runId, "user requested");
+
+        // Act
+        await engine.EnforceDueTimeoutsAsync();
+
+        // Assert
+        Assert.Equal("Cancelled", await store.GetRunStatusAsync(runId));
+        var control = await store.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.Null(control!.TimedOutAtUtc);
+        Assert.True(control.CancelRequested);
+        Assert.Equal("user requested", control.CancelReason);
+    }
+
+    [Fact]
+    public async Task EnforceDueTimeoutsAsync_CalledTwiceOnStuckRun_PublishesExactlyOneRunCompletedEvent()
+    {
+        // Arrange — a stuck, lapsed run. Two sweeps (mimicking a second replica / a re-entrant tick)
+        // must complete the run exactly once, thanks to the guarded CompleteRunIfActiveAsync.
+        var notifier = new CountingNotifier();
+        var store = new InMemoryFlowRunStore();
+        var engine = CreateEngine(store, notifier);
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        await store.StartRunAsync(flowId, "TestFlow", runId, "manual", null, null);
+        await store.ConfigureRunAsync(runId, flowId, "manual", null, DateTimeOffset.UtcNow.AddMinutes(-1));
+
+        // Act
+        await engine.EnforceDueTimeoutsAsync();
+        await engine.EnforceDueTimeoutsAsync();
+
+        // Assert
+        Assert.Equal("TimedOut", await store.GetRunStatusAsync(runId));
+        Assert.Equal(1, notifier.RunCompletedCount);
     }
 }

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RunTimeoutEnforcementTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/RunTimeoutEnforcementTests.cs
@@ -1,0 +1,134 @@
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Configuration;
+using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Observability;
+using FlowOrchestrator.Core.Storage;
+using FlowOrchestrator.InMemory;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace FlowOrchestrator.Core.Tests.Execution;
+
+/// <summary>
+/// Tests for the periodic timeout enforcer (<see cref="FlowOrchestratorEngine.EnforceDueTimeoutsAsync"/>),
+/// which proactively marks active runs whose deadline has passed as <c>TimedOut</c> so a stuck run does
+/// not sit <c>Running</c> indefinitely.
+/// </summary>
+public sealed class RunTimeoutEnforcementTests
+{
+    private readonly IStepDispatcher _dispatcher = Substitute.For<IStepDispatcher>();
+    private readonly IFlowExecutor _flowExecutor = Substitute.For<IFlowExecutor>();
+    private readonly IFlowGraphPlanner _graphPlanner = new FlowGraphPlanner();
+    private readonly IStepExecutor _stepExecutor = Substitute.For<IStepExecutor>();
+    private readonly IFlowStore _flowStore = Substitute.For<IFlowStore>();
+    private readonly IOutputsRepository _outputsRepo = Substitute.For<IOutputsRepository>();
+    private readonly IExecutionContextAccessor _ctxAccessor = Substitute.For<IExecutionContextAccessor>();
+    private readonly IFlowRepository _flowRepo = Substitute.For<IFlowRepository>();
+    private readonly ILogger<FlowOrchestratorEngine> _logger =
+        Substitute.For<ILogger<FlowOrchestratorEngine>>();
+
+    private FlowOrchestratorEngine CreateEngine(InMemoryFlowRunStore store) =>
+        new FlowOrchestratorEngine(
+            _dispatcher,
+            _flowExecutor,
+            _graphPlanner,
+            _stepExecutor,
+            _flowStore,
+            store,
+            _outputsRepo,
+            _ctxAccessor,
+            _flowRepo,
+            [store],
+            [store],
+            new FlowRunControlOptions(),
+            new FlowObservabilityOptions { EnableEventPersistence = false, EnableOpenTelemetry = false },
+            new FlowOrchestratorTelemetry(),
+            _logger);
+
+    [Fact]
+    public async Task EnforceDueTimeoutsAsync_LapsedActiveRun_MarksTimedOutAndCompletesRun()
+    {
+        // Arrange — active run whose deadline has already passed, nothing in flight.
+        var store = new InMemoryFlowRunStore();
+        var engine = CreateEngine(store);
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        await store.StartRunAsync(flowId, "TestFlow", runId, "manual", null, null);
+        await store.ConfigureRunAsync(runId, flowId, "manual", null, DateTimeOffset.UtcNow.AddMinutes(-1));
+
+        // Act
+        await engine.EnforceDueTimeoutsAsync();
+
+        // Assert
+        Assert.Equal("TimedOut", await store.GetRunStatusAsync(runId));
+        var control = await store.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.NotNull(control!.TimedOutAtUtc);
+    }
+
+    [Fact]
+    public async Task EnforceDueTimeoutsAsync_DeadlineNotYetPassed_LeavesRunRunning()
+    {
+        // Arrange
+        var store = new InMemoryFlowRunStore();
+        var engine = CreateEngine(store);
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        await store.StartRunAsync(flowId, "TestFlow", runId, "manual", null, null);
+        await store.ConfigureRunAsync(runId, flowId, "manual", null, DateTimeOffset.UtcNow.AddMinutes(30));
+
+        // Act
+        await engine.EnforceDueTimeoutsAsync();
+
+        // Assert
+        Assert.Equal("Running", await store.GetRunStatusAsync(runId));
+        var control = await store.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.Null(control!.TimedOutAtUtc);
+    }
+
+    [Fact]
+    public async Task EnforceDueTimeoutsAsync_CompletedRun_IsNotTimedOut()
+    {
+        // Arrange — a Succeeded run whose (irrelevant) deadline has lapsed. Not active → untouched.
+        var store = new InMemoryFlowRunStore();
+        var engine = CreateEngine(store);
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        await store.StartRunAsync(flowId, "TestFlow", runId, "manual", null, null);
+        await store.ConfigureRunAsync(runId, flowId, "manual", null, DateTimeOffset.UtcNow.AddMinutes(-1));
+        await store.CompleteRunAsync(runId, "Succeeded");
+
+        // Act
+        await engine.EnforceDueTimeoutsAsync();
+
+        // Assert
+        Assert.Equal("Succeeded", await store.GetRunStatusAsync(runId));
+        var control = await store.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.Null(control!.TimedOutAtUtc);
+    }
+
+    [Fact]
+    public async Task EnforceDueTimeoutsAsync_RunWithInFlightStep_LatchesTimeoutButDoesNotComplete()
+    {
+        // Arrange — lapsed deadline but a step is still Running: the in-flight guard must prevent
+        // force-completion. The run stays Running (converges to TimedOut once the step finishes).
+        var store = new InMemoryFlowRunStore();
+        var engine = CreateEngine(store);
+        var flowId = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        await store.StartRunAsync(flowId, "TestFlow", runId, "manual", null, null);
+        await store.ConfigureRunAsync(runId, flowId, "manual", null, DateTimeOffset.UtcNow.AddMinutes(-1));
+        await store.RecordStepStartAsync(runId, "step1", "Work", "{}", "job1");
+
+        // Act
+        await engine.EnforceDueTimeoutsAsync();
+
+        // Assert
+        Assert.Equal("Running", await store.GetRunStatusAsync(runId));
+        var control = await store.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.NotNull(control!.TimedOutAtUtc);
+    }
+}

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Hosting/FlowRunRecoveryHostedServiceTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Hosting/FlowRunRecoveryHostedServiceTests.cs
@@ -97,9 +97,9 @@ public class FlowRunRecoveryHostedServiceTests
 
         // Assert
         await _dispatcher.Received(1).EnqueueStepAsync(
-            Arg.Is<IExecutionContext>(c => c.RunId == runId),
+            Arg.Is<IExecutionContext>(c => c!.RunId == runId),
             flow,
-            Arg.Is<IStepInstance>(s => s.Key == "step1"),
+            Arg.Is<IStepInstance>(s => s!.Key == "step1"),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Notifications/EngineNotifierIsolationTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Notifications/EngineNotifierIsolationTests.cs
@@ -98,9 +98,9 @@ public sealed class EngineNotifierIsolationTests
         // Assert
         await notifier.Received(1).PublishAsync(
             Arg.Is<FlowLifecycleEvent>(e =>
-                ((RunStartedEvent)e).RunId == ctx.RunId &&
-                ((RunStartedEvent)e).FlowId == flow.Id &&
-                ((RunStartedEvent)e).TriggerKey == "manual"),
+                ((RunStartedEvent)e!).RunId == ctx.RunId &&
+                ((RunStartedEvent)e!).FlowId == flow.Id &&
+                ((RunStartedEvent)e!).TriggerKey == "manual"),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Storage/FlowRunControlStoreDefaultMethodTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Storage/FlowRunControlStoreDefaultMethodTests.cs
@@ -1,0 +1,48 @@
+using FlowOrchestrator.Core.Storage;
+
+namespace FlowOrchestrator.Core.Tests.Storage;
+
+/// <summary>
+/// Guards the source-compatibility contract for <see cref="IFlowRunControlStore.ExtendDeadlineAsync"/>:
+/// it ships as a default interface method so existing custom control-store implementations that predate
+/// it continue to compile, degrading retry to its previous no-op behaviour rather than failing to build.
+/// </summary>
+public sealed class FlowRunControlStoreDefaultMethodTests
+{
+    /// <summary>
+    /// A minimal custom control store that implements every required member but deliberately does NOT
+    /// override <see cref="IFlowRunControlStore.ExtendDeadlineAsync"/>. That it compiles at all is half
+    /// the assertion; the test verifies the inherited default returns <see langword="false"/>.
+    /// </summary>
+    private sealed class LegacyControlStore : IFlowRunControlStore
+    {
+        public Task ConfigureRunAsync(Guid runId, Guid flowId, string triggerKey, string? idempotencyKey, DateTimeOffset? timeoutAtUtc)
+            => Task.CompletedTask;
+
+        public Task<FlowRunControlRecord?> GetRunControlAsync(Guid runId)
+            => Task.FromResult<FlowRunControlRecord?>(null);
+
+        public Task<bool> RequestCancelAsync(Guid runId, string? reason) => Task.FromResult(false);
+
+        public Task<bool> MarkTimedOutAsync(Guid runId, string? reason) => Task.FromResult(false);
+
+        public Task<Guid?> FindRunIdByIdempotencyKeyAsync(Guid flowId, string triggerKey, string idempotencyKey)
+            => Task.FromResult<Guid?>(null);
+
+        public Task<bool> TryRegisterIdempotencyKeyAsync(Guid flowId, string triggerKey, string idempotencyKey, Guid runId)
+            => Task.FromResult(true);
+    }
+
+    [Fact]
+    public async Task ExtendDeadlineAsync_DefaultInterfaceMethod_ReturnsFalse()
+    {
+        // Arrange
+        IFlowRunControlStore store = new LegacyControlStore();
+
+        // Act
+        var result = await store.ExtendDeadlineAsync(Guid.NewGuid(), DateTimeOffset.UtcNow.AddMinutes(5));
+
+        // Assert
+        Assert.False(result);
+    }
+}

--- a/tests/unit/FlowOrchestrator.Hangfire.UnitTests/HangfireAdapterTests.cs
+++ b/tests/unit/FlowOrchestrator.Hangfire.UnitTests/HangfireAdapterTests.cs
@@ -93,7 +93,7 @@ public sealed class HangfireAdapterTests
 
         // Assert
         _jobClient.Received(1).Create(
-            Arg.Is<Job>(j => j.Type == typeof(IHangfireStepRunner)),
+            Arg.Is<Job>(j => j!.Type == typeof(IHangfireStepRunner)),
             Arg.Any<IState>());
     }
 
@@ -112,7 +112,7 @@ public sealed class HangfireAdapterTests
 
         // Assert
         _jobClient.Received(1).Create(
-            Arg.Is<Job>(j => j.Type == typeof(IHangfireStepRunner)),
+            Arg.Is<Job>(j => j!.Type == typeof(IHangfireStepRunner)),
             Arg.Any<IState>());
     }
 
@@ -166,7 +166,7 @@ public sealed class HangfireAdapterTests
         // Assert
         _recurringManager.Received(1).AddOrUpdate(
             Arg.Any<string>(),
-            Arg.Is<Job>(j => j.Type == typeof(IHangfireFlowTrigger)),
+            Arg.Is<Job>(j => j!.Type == typeof(IHangfireFlowTrigger)),
             Arg.Any<string>(),
             Arg.Any<RecurringJobOptions>());
     }
@@ -212,7 +212,7 @@ public sealed class HangfireAdapterTests
 
         // Assert
         _jobClient.Received(1).Create(
-            Arg.Is<Job>(j => j.Type == typeof(IHangfireFlowTrigger)),
+            Arg.Is<Job>(j => j!.Type == typeof(IHangfireFlowTrigger)),
             Arg.Is<IState>(s => s is EnqueuedState));
     }
 

--- a/tests/unit/FlowOrchestrator.InMemory.UnitTests/InMemoryFlowRunStoreTests.cs
+++ b/tests/unit/FlowOrchestrator.InMemory.UnitTests/InMemoryFlowRunStoreTests.cs
@@ -748,6 +748,35 @@ public class InMemoryFlowRunStoreTests
     }
 
     [Fact]
+    public async Task CompleteRunIfActiveAsync_TransitionsRunningOnce_ThenReturnsFalse()
+    {
+        // Arrange — a running run; two concurrent completers race to finish it.
+        var runId = Guid.NewGuid();
+        await _sut.StartRunAsync(Guid.NewGuid(), "F", runId, "manual", null, null);
+
+        // Act — first call wins the transition, second finds it already terminal.
+        var first = await _sut.CompleteRunIfActiveAsync(runId, "Succeeded");
+        var second = await _sut.CompleteRunIfActiveAsync(runId, "TimedOut");
+
+        // Assert — exactly one transition; the first writer's status stands.
+        Assert.True(first);
+        Assert.False(second);
+        Assert.Equal("Succeeded", await _sut.GetRunStatusAsync(runId));
+    }
+
+    [Fact]
+    public async Task CompleteRunIfActiveAsync_UnknownRun_ReturnsFalse()
+    {
+        // Arrange
+
+        // Act
+        var result = await _sut.CompleteRunIfActiveAsync(Guid.NewGuid(), "Succeeded");
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
     public async Task CleanupAsync_RetainsRunCompletedExactlyAtCutoff()
     {
         // Arrange — strict less-than semantics: a run completed AT the cutoff is retained,

--- a/tests/unit/FlowOrchestrator.InMemory.UnitTests/InMemoryFlowRunStoreTests.cs
+++ b/tests/unit/FlowOrchestrator.InMemory.UnitTests/InMemoryFlowRunStoreTests.cs
@@ -674,6 +674,80 @@ public class InMemoryFlowRunStoreTests
     }
 
     [Fact]
+    public async Task ExtendDeadlineAsync_NoControlRecord_ReturnsFalse()
+    {
+        // Arrange — no ConfigureRunAsync call, so no control record exists for this run.
+        var runId = Guid.NewGuid();
+
+        // Act
+        var result = await _sut.ExtendDeadlineAsync(runId, DateTimeOffset.UtcNow.AddMinutes(10));
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(await _sut.GetRunControlAsync(runId));
+    }
+
+    [Fact]
+    public async Task ExtendDeadlineAsync_AfterTimeout_ClearsTimeoutLatchAndRefreshesDeadline()
+    {
+        // Arrange — a run that has been latched TimedOut (which also sets the cancel fields).
+        var runId = Guid.NewGuid();
+        await _sut.ConfigureRunAsync(runId, Guid.NewGuid(), "manual", null, DateTimeOffset.UtcNow.AddMinutes(-5));
+        await _sut.MarkTimedOutAsync(runId, "deadline exceeded");
+        var newDeadline = DateTimeOffset.UtcNow.AddMinutes(10);
+
+        // Act
+        var result = await _sut.ExtendDeadlineAsync(runId, newDeadline);
+
+        // Assert — timeout-induced termination is fully un-latched and the deadline is refreshed.
+        Assert.True(result);
+        var control = await _sut.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.Equal(newDeadline, control!.TimeoutAtUtc);
+        Assert.Null(control.TimedOutAtUtc);
+        Assert.False(control.CancelRequested);
+        Assert.Null(control.CancelReason);
+        Assert.Null(control.CancelRequestedAtUtc);
+    }
+
+    [Fact]
+    public async Task ExtendDeadlineAsync_PreservesGenuineUserCancellation()
+    {
+        // Arrange — a run cancelled by the user (TimedOutAtUtc stays null).
+        var runId = Guid.NewGuid();
+        await _sut.ConfigureRunAsync(runId, Guid.NewGuid(), "manual", null, null);
+        await _sut.RequestCancelAsync(runId, "user requested");
+
+        // Act
+        var result = await _sut.ExtendDeadlineAsync(runId, DateTimeOffset.UtcNow.AddMinutes(10));
+
+        // Assert — the user cancellation survives; only timeout-induced state is cleared.
+        Assert.True(result);
+        var control = await _sut.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.True(control!.CancelRequested);
+        Assert.Equal("user requested", control.CancelReason);
+        Assert.Null(control.TimedOutAtUtc);
+    }
+
+    [Fact]
+    public async Task ExtendDeadlineAsync_NullDeadline_ClearsTimeoutBound()
+    {
+        // Arrange
+        var runId = Guid.NewGuid();
+        await _sut.ConfigureRunAsync(runId, Guid.NewGuid(), "manual", null, DateTimeOffset.UtcNow.AddMinutes(5));
+
+        // Act
+        var result = await _sut.ExtendDeadlineAsync(runId, null);
+
+        // Assert
+        Assert.True(result);
+        var control = await _sut.GetRunControlAsync(runId);
+        Assert.NotNull(control);
+        Assert.Null(control!.TimeoutAtUtc);
+    }
+
+    [Fact]
     public async Task CleanupAsync_RetainsRunCompletedExactlyAtCutoff()
     {
         // Arrange — strict less-than semantics: a run completed AT the cutoff is retained,


### PR DESCRIPTION
## Summary

Fixes the production defect where the dashboard **Retry** button is a permanent no-op once a run's timeout deadline has passed, plus the missing timeout-enforcement service. Also **bundles all 9 open Dependabot PRs** into this single PR (see below).

### Defect 1 — Retry never refreshed the run's execution window
`RetryStepAsync` reset only the `FlowRuns`/`FlowSteps` rows, never the `FlowRunControls` record. Once `TimeoutAtUtc` lapsed (or the run was latched `TimedOut`), the re-dispatched step hit the termination gate and was skipped as `"Run is TimedOut."` before the handler ran — the run was permanently unrecoverable (observed: a run retried ~18h after its upstream recovered; the handler never ran).

**Fix:** new `IFlowRunControlStore.ExtendDeadlineAsync` (default interface method → existing custom stores compile unchanged), implemented in InMemory/SqlServer/PostgreSQL. `RetryStepAsync` refreshes the deadline via the existing `ResolveTimeoutAtUtc` before re-dispatch, un-latching **only timeout-induced** termination while preserving a genuine user cancel. The refresh reuses trigger-time resolution so the runaway-loop bound survives.

### Defect 2 — no timeout-enforcement service existed
`MarkTimedOutAsync` documented a "timeout-enforcement background service" that did not exist; a run whose step threw and left nothing scheduled sat `Running` forever.

**Fix:** new `IRunTimeoutEnforcer` + `FlowOrchestratorEngine.EnforceDueTimeoutsAsync`, driven by a new `FlowTimeoutEnforcementHostedService` on a configurable `FlowRunControlOptions.TimeoutEnforcementInterval` (default 30s). The sweep **only completes genuinely stuck runs** (no in-flight/claimed/dispatched work) — in-flight/polling runs stay with the lazy dispatch-time gate. This avoids an inconsistent `TimedOut`(control)/`Succeeded`(run) state that would arise if a latched run's final in-flight step then succeeded (the graph continuation classifies terminal status from step statuses, not the control record).

### Behaviour decisions
- Retry refreshes the deadline (`now + timeout`) rather than clearing it, keeping the runaway-loop protection.
- `TimedOut → Running` on retry is already handled by `_runStore.RetryStepAsync`; same path covers `Failed` runs whose deadline lapsed.
- Retrying a genuinely **user-cancelled** run stays a no-op by design (only timeout-induced latch is cleared).

## Tests
- **Store contract** (InMemory unit + SqlServer/PostgreSQL integration via Testcontainers): `ExtendDeadlineAsync` sets/clears the deadline, un-latches timeout-induced cancel, preserves user cancel, returns false when absent.
- **Engine unit**: retry re-executes the handler, deadline refreshed into the future, runaway bound survives refresh; enforcer completes a stuck failed-step run, ignores not-yet-lapsed / completed / in-flight runs; default-method source compatibility.
- **Regression full-host**: `RetryAfterTimeoutTests` (retry after the deadline lapsed → run reaches Succeeded), `PeriodicTimeoutEnforcementTests` (stuck run swept to TimedOut with no manual retry).

### Verification (with all 9 bumps applied)
- `dotnet build` (full solution): 0 warnings, 0 errors.
- Unit: **1707 passed, 0 failed** (all TFMs).
- Integration: **1158 passed, 0 failed** (real SQL Server + PostgreSQL + Service Bus emulator).
- Regression: **168 passed, 0 failed** (all TFMs).
- e2e smoke (Aspire, 4 instances): dashboard / cron / manual-trigger / ForEach / When-skip / webhook / WaitForSignal / Hangfire presence / SQL-only OrderFulfillment all verified functional across `flow-sqlserver`, `flow-postgresql`, `flow-inmemory`, `flow-servicebus`. (The timeout job itself isn't exercised by the sample app — it has no `DefaultRunTimeout`; it's covered by the regression tests above.)

## Bundled dependency updates (combined into this one PR)
All 9 open Dependabot PRs, cherry-picked:

| PR | Bump |
|----|------|
| #118 | Microsoft.Extensions.Logging 10.0.8 → 10.0.9 |
| #119 | OpenTelemetry 1.15.3 → 1.16.0 |
| #120 | OpenTelemetry.Instrumentation.AspNetCore 1.15.2 → 1.16.0 |
| #121 | System.Text.Json 10.0.8 → 10.0.9 |
| #122 | Testcontainers 4.12.0 → 4.13.0 |
| #123 | actions/setup-node 6 → 7 |
| #124 | Azure.Messaging.ServiceBus 7.20.1 → 7.20.2 |
| #125 | Microsoft.NET.Test.Sdk 18.7.0 → 18.8.0 |
| #126 | **NSubstitute 5.3.0 → 6.0.0** (major — includes the test-suite migration below) |

**NSubstitute 6.0 migration:** 6.0 adds nullable annotations to `Arg<T>()`, `CallInfo.Arg<T>()`, `Arg.Is<T>()` predicates, and `ReturnsNull<T>`, which broke ~59 call sites under `TreatWarningsAsErrors`. Migrated mechanically (`Arg.Is<T>(x => x.P)` → `x!.P`; callback `Arg<T>()` → `Arg<T>()!`; `.ReturnsNull()` → typed `.Returns((T?)null)`). Same pass counts as 5.3.0 → no behavioural regression.

Known limitation: in a multi-replica deployment each replica runs the sweep, so a stuck run may emit a duplicate `RunCompletedEvent` (idempotent status, no corruption) — future hardening could add a leader/lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
