### PR TITLE
chore(deps): batch Dependabot bumps + SSH.NET security pin, release 1.29.2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,7 +62,7 @@ jobs:
           node-version: 22
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.4
+        uses: github/codeql-action/init@v4.37.7
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -80,6 +80,6 @@ jobs:
         run: dotnet build FlowOrchestrator.slnx --configuration Release --no-restore
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.4
+        uses: github/codeql-action/analyze@v4.37.7
         with:
           category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.29.2] - 2026-08-22
+
+### Security
+
+- **SSH.NET pinned to 2026.0.0** to clear GHSA-q939-rpr3-3284 (high severity —
+  `ScpClient` recursive download allows arbitrary file write via server-controlled
+  SCP filenames; affects all versions `<= 2025.1.0`). SSH.NET is a transitive
+  dependency of Testcontainers, so it is pinned centrally in `Directory.Packages.props`
+  (relying on `CentralPackageTransitivePinningEnabled`); the fix reaches the
+  SqlServer / PostgreSQL / ServiceBus integration-test projects and closes all three
+  Dependabot alerts.
+
+### Dependencies
+
+- Runtime: Microsoft.Extensions.Logging 10.0.9 → 10.0.10;
+  Microsoft.Extensions.DependencyInjection.Abstractions and
+  Microsoft.Extensions.Logging.Abstractions 10.0.10 → 10.0.11;
+  System.Text.Json 10.0.9 → 10.0.11.
+- Test infrastructure: Testcontainers 4.13.0 → 4.14.0; Testcontainers.MsSql and
+  Testcontainers.PostgreSql 4.12.0 → 4.13.0; NSubstitute 6.0.0 → 6.2.0;
+  Microsoft.NET.Test.Sdk 18.8.1 → 18.9.0;
+  Microsoft.Extensions.TimeProvider.Testing 10.8.0 → 10.9.0;
+  Microsoft.AspNetCore.TestHost 8.0.29 → 8.0.30.
+- CI: github/codeql-action 4.37.4 → 4.37.7.
+
 ## [1.29.1] - 2026-08-09
 
 ### Dependencies

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <RepositoryUrl>https://github.com/hoangsnowy/FlowOrchestrator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/hoangsnowy/FlowOrchestrator</PackageProjectUrl>
-    <VersionPrefix>1.29.1</VersionPrefix>
+    <VersionPrefix>1.29.2</VersionPrefix>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,15 +41,15 @@
     <PackageVersion Include="Hangfire.SqlServer" Version="1.8.24" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Npgsql" Version="10.0.3" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.11" />
   </ItemGroup>
 
   <!-- Observability — keep all OpenTelemetry packages on the same release line. -->
@@ -64,13 +64,22 @@
 
   <!-- Test infrastructure -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.29" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageVersion Include="NSubstitute" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.12.0" />
-    <PackageVersion Include="Testcontainers" Version="4.13.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.30" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="NSubstitute" Version="6.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers" Version="4.14.0" />
+    <!--
+      SSH.NET is pinned (not referenced directly): Testcontainers pulls it in
+      transitively, and every version <= 2025.1.0 carries GHSA-q939-rpr3-3284
+      (high-severity ScpClient arbitrary-file-write on recursive download).
+      CentralPackageTransitivePinningEnabled=true propagates this fixed version
+      to the SqlServer / PostgreSQL / ServiceBus integration-test projects,
+      clearing all three Dependabot alerts.
+    -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Summary

Consolidates the **12 open Dependabot PRs** (#143–#157) into one release and fixes the outstanding **high-severity security alert**.

### Security
- **SSH.NET pinned to `2026.0.0`** — clears [GHSA-q939-rpr3-3284](https://github.com/advisories/GHSA-q939-rpr3-3284) (high: `ScpClient` recursive download → arbitrary file write, affects `<= 2025.1.0`). SSH.NET is transitive via Testcontainers; pinned centrally in `Directory.Packages.props` so `CentralPackageTransitivePinningEnabled` propagates the fix to the SqlServer / PostgreSQL / ServiceBus integration-test projects. Closes all 3 Dependabot alerts.

### Dependencies
| Package | From → To | PR |
|---|---|---|
| Microsoft.Extensions.Logging | 10.0.9 → 10.0.10 | #143 |
| Microsoft.Extensions.DependencyInjection.Abstractions | 10.0.10 → 10.0.11 | #152 |
| Microsoft.Extensions.Logging.Abstractions | 10.0.10 → 10.0.11 | #152 |
| System.Text.Json | 10.0.9 → 10.0.11 | #156 |
| Testcontainers | 4.13.0 → 4.14.0 | #157 |
| Testcontainers.MsSql | 4.12.0 → 4.13.0 | #146 |
| Testcontainers.PostgreSql | 4.12.0 → 4.13.0 | #147 |
| NSubstitute | 6.0.0 → 6.2.0 | #155 |
| Microsoft.NET.Test.Sdk | 18.8.1 → 18.9.0 | #154 |
| Microsoft.Extensions.TimeProvider.Testing | 10.8.0 → 10.9.0 | #153 |
| Microsoft.AspNetCore.TestHost | 8.0.29 → 8.0.30 | #150 |
| SSH.NET (new pin) | → 2026.0.0 | #148 |
| github/codeql-action | 4.37.4 → 4.37.7 | #149 |

### Version
`1.29.1` → `1.29.2` (patch — dep bumps + transitive security fix, no public API change). CHANGELOG updated.

### Verification
- `dotnet build -c Release`: **0 warnings, 0 errors**
- Unit suite: green (~1300 tests, 0 failed)
- Integration suite (Docker): green — incl. the 3 SSH.NET-affected projects
- Regression suite: green (56 × 3 TFMs)
- **e2e skill: 40/40** across all 4 storage/runtime instances

Supersedes #143, #146, #147, #148, #149, #150, #152, #153, #154, #155, #156, #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)