### PR TITLE
batch: dependabot bumps (#159–#165) + ForEach sibling @steps() fix (#166) + runs-search loading UI

### DIFF
--- a/.claude/skills/e2e/SKILL.md
+++ b/.claude/skills/e2e/SKILL.md
@@ -151,7 +151,9 @@ runId=$(curl -fsS -u admin:admin -X POST "http://localhost:$port/flows/api/flows
         -H 'Content-Type: application/json' \
         -d '{"orderIds":[1,2,3],"items":[{"id":1},{"id":2},{"id":3}]}' | jq -r '.runId')
 # Poll-to-Succeeded as in 5.3, then assert step count >= 4 (forEach + 3 children).
-# A healthy run reports 6 steps.
+# A healthy run reports 9 steps: prepare_batch + process_orders + 3×(validate_order +
+# archive_order) + finalize_batch. archive_order reads its sibling validate_order's output
+# via "@steps('validate_order').output.note" (scope-relative resolution, issue #166).
 ```
 
 #### 5.5 Skip semantics (ConditionalSkipDemoFlow + AmountThresholdFlow)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,7 +62,7 @@ jobs:
           node-version: 22
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.7
+        uses: github/codeql-action/init@v4.37.8
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -80,6 +80,6 @@ jobs:
         run: dotnet build FlowOrchestrator.slnx --configuration Release --no-restore
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.7
+        uses: github/codeql-action/analyze@v4.37.8
         with:
           category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.30.0] - 2026-08-30
+
+### Added
+
+- **Scope-relative `@steps()` references inside a ForEach loop** (issue #166). A nested
+  loop child step can now read a sibling child's output with the bare key it is declared
+  under — `@steps('validate_order').output.note` — and the resolver rewrites it to the
+  current iteration's runtime scope (`process_orders.{index}.validate_order`). Previously
+  a bare sibling key threw *"Step 'validate_order' is not defined in the flow manifest"*
+  because `@steps()` only resolved against the static manifest. A bare key that is a
+  top-level step is left unchanged, so upstream references from inside a loop keep working;
+  `.status` and `.error` follow the same rule. This brings `@steps()` in line with the
+  sibling-key handling `RunAfter` already applies within a loop scope. The `OrderBatchFlow`
+  sample gains an `archive_order` child that demonstrates the pattern end-to-end.
+
 ### Dependencies
 
 - Runtime: Microsoft.Extensions.DependencyInjection and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Dependencies
+
+- Runtime: Microsoft.Extensions.DependencyInjection and
+  Microsoft.Extensions.Hosting.Abstractions 10.0.10 → 10.0.11.
+- Observability: OpenTelemetry **1.17.0 → 1.18.0 across the whole family**
+  (`OpenTelemetry`, `.Api`, `.Exporter.Console`, `.Exporter.OpenTelemetryProtocol`,
+  `.Extensions.Hosting`, `.Instrumentation.AspNetCore`). Dependabot bumps `.Api`
+  alone; the rest are moved with it because these packages ship as one release line
+  and mixing lines risks `TracerProvider`/`MeterProvider` binding mismatches.
+- Test infrastructure: Testcontainers.MsSql and Testcontainers.PostgreSql
+  4.13.0 → 4.14.0; xunit.runner.visualstudio 3.1.5 → 4.0.0.
+- CI: github/codeql-action 4.37.7 → 4.37.8.
+
 ## [1.29.2] - 2026-08-22
 
 ### Security

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <RepositoryUrl>https://github.com/hoangsnowy/FlowOrchestrator</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/hoangsnowy/FlowOrchestrator</PackageProjectUrl>
-    <VersionPrefix>1.29.2</VersionPrefix>
+    <VersionPrefix>1.30.0</VersionPrefix>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,12 +40,12 @@
     <PackageVersion Include="Hangfire.InMemory" Version="1.0.0" />
     <PackageVersion Include="Hangfire.SqlServer" Version="1.8.24" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Npgsql" Version="10.0.3" />
@@ -54,12 +54,12 @@
 
   <!-- Observability — keep all OpenTelemetry packages on the same release line. -->
   <ItemGroup>
-    <PackageVersion Include="OpenTelemetry" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
   </ItemGroup>
 
   <!-- Test infrastructure -->
@@ -68,8 +68,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.14.0" />
     <PackageVersion Include="Testcontainers" Version="4.14.0" />
     <!--
       SSH.NET is pinned (not referenced directly): Testcontainers pulls it in
@@ -82,7 +82,7 @@
     <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
   </ItemGroup>
 
   <!-- Benchmark infrastructure (tests/benchmarks/ only) -->

--- a/docs/articles/expressions.md
+++ b/docs/articles/expressions.md
@@ -34,6 +34,23 @@ Reference the output of a prior step directly in a downstream step's inputs:
 
 Both single and double quotes are accepted for the step key: `@steps('key')` and `@steps("key")` are equivalent.
 
+### Sibling references inside a ForEach
+
+When a `@steps('key')` expression is evaluated from a step running **inside a ForEach
+loop**, a bare (dot-free) key that is not a top-level step is resolved against the
+current iteration's scope. A child running as `process_orders.2.archive_order` reads
+`@steps('validate_order').output.note` from `process_orders.2.validate_order` — its own
+iteration, not iteration 0:
+
+```csharp
+["message"] = "@steps('validate_order').output.note"
+```
+
+A bare key that *is* a top-level step (e.g. `@steps('prepare_batch')`) is left unchanged,
+so upstream references from inside a loop still work. To read a specific iteration from
+outside its scope, write the fully-qualified runtime key: `@steps('process_orders.0.validate_order')`.
+See [ForEach Loops → Referencing a Sibling Step's Output](foreach.md) for the full rules.
+
 ## Null-Safe Access
 
 The `?.` operator means: if any segment in the path is `null` or missing, the whole expression evaluates to `null` rather than throwing. This matches the C# null-conditional operator semantics.

--- a/docs/articles/foreach.md
+++ b/docs/articles/foreach.md
@@ -101,6 +101,54 @@ for (int i = 0; i < itemCount; i++)
 }
 ```
 
+## Referencing a Sibling Step's Output
+
+A child step can read the output of another child in the **same iteration** using a
+plain `@steps('siblingKey')` expression — the bare key, exactly as it is written in the
+manifest. At runtime the resolver rewrites it to the current iteration's scope, so a
+step running as `process_orders.2.archive_order` resolves `@steps('validate_order')` to
+`process_orders.2.validate_order` — never iteration 0's:
+
+```csharp
+Steps = new StepCollection
+{
+    ["validate_order"] = new StepMetadata
+    {
+        Type = "ProcessOrderItem",
+        Inputs = new Dictionary<string, object?> { ["maxOrderValue"] = 10000 }
+    },
+
+    ["archive_order"] = new StepMetadata
+    {
+        Type = "LogMessage",
+        RunAfter = new RunAfterCollection { ["validate_order"] = [StepStatus.Succeeded] },
+        Inputs = new Dictionary<string, object?>
+        {
+            // Bare sibling key — resolves to THIS iteration's validate_order output.
+            ["message"] = "@steps('validate_order').output.note"
+        }
+    }
+}
+```
+
+Resolution rules for `@steps('key')` evaluated from inside a loop:
+
+| Key written in the expression | Resolves to |
+|---|---|
+| A bare sibling key (`validate_order`) | The current iteration's scope: `{loop}.{index}.validate_order` |
+| A bare key that is a **top-level** step (`prepare_batch`) | The top-level step, unchanged — the loop scope is *not* prepended |
+| An explicitly-qualified key (`process_orders.0.validate_order`) | Used verbatim (hard-codes iteration 0) |
+
+The bare-key rewrite only applies when the key is not a top-level manifest step, so
+upstream references made from inside a loop keep working. The same rule governs
+`.status` and `.error` access, and it mirrors the sibling-key handling that `RunAfter`
+already applies within a loop scope.
+
+> [!NOTE]
+> The rewrite walks *enclosing* loop scopes nearest-first, so a deeply nested child can
+> reference a sibling declared in the same loop. It does not reach *into* a different
+> iteration — use the explicit `{loop}.{index}.{child}` key for cross-iteration reads.
+
 ## How Dispatch Works
 
 `ForEachStepHandler` does not enqueue jobs directly. Instead it returns a `StepResult` that carries a `DispatchHint` with `Spawn` entries — one per iteration. `FlowOrchestratorEngine` receives the hint, validates that the spawned step keys are not already present in the static DAG, and dispatches each one via `IStepDispatcher`. This keeps runtime dispatch logic in the engine and makes `ForEachStepHandler` portable across all runtime adapters (Hangfire, InMemory, or any future adapter).
@@ -183,6 +231,17 @@ public sealed class OrderBatchFlow : IFlowDefinition
                         Inputs = new Dictionary<string, object?>
                         {
                             ["maxOrderValue"] = 10000  // same for every iteration
+                        }
+                    },
+
+                    // Reads the sibling validate_order output for THIS iteration.
+                    ["archive_order"] = new StepMetadata
+                    {
+                        Type = "LogMessage",
+                        RunAfter = new RunAfterCollection { ["validate_order"] = [StepStatus.Succeeded] },
+                        Inputs = new Dictionary<string, object?>
+                        {
+                            ["message"] = "@steps('validate_order').output.note"
                         }
                     }
                 }

--- a/samples/FlowOrchestrator.SampleApp/Flows/OrderBatchFlow.cs
+++ b/samples/FlowOrchestrator.SampleApp/Flows/OrderBatchFlow.cs
@@ -49,7 +49,9 @@ namespace FlowOrchestrator.SampleApp.Flows;
 ///
 ///   prepare_batch    → LogMessage         — Logs the incoming batch ID from trigger data
 ///   process_orders   → ForEach            — Iterates over orderIds (ConcurrencyLimit = 2)
-///     └ validate_order → ProcessOrderItem — Validates and logs each order (per iteration)
+///     ├ validate_order → ProcessOrderItem — Validates and logs each order (per iteration)
+///     └ archive_order  → LogMessage       — Reads the SIBLING validate_order output via
+///                                            "@steps('validate_order').output.note" (issue #166)
 ///   finalize_batch   → LogMessage         — Logs completion after all iterations finish
 ///
 /// ── Runtime step key layout ──────────────────────────────────────────────────
@@ -57,9 +59,11 @@ namespace FlowOrchestrator.SampleApp.Flows;
 ///   prepare_batch
 ///   process_orders
 ///     process_orders.0.validate_order    ← iteration 0 (parallel)
+///     process_orders.0.archive_order     ← iteration 0, reads process_orders.0.validate_order
 ///     process_orders.1.validate_order    ← iteration 1 (parallel, ConcurrencyLimit = 2)
+///     process_orders.1.archive_order     ← iteration 1, reads process_orders.1.validate_order
 ///     process_orders.2.validate_order    ← iteration 2 (waits for a slot)
-///     process_orders.3.validate_order    ← iteration 3 (waits for a slot)
+///     process_orders.2.archive_order     ← iteration 2, reads process_orders.2.validate_order
 ///   finalize_batch
 /// </summary>
 public sealed class OrderBatchFlow : IFlowDefinition
@@ -151,6 +155,26 @@ public sealed class OrderBatchFlow : IFlowDefinition
                             // Static manifest input — merged with __loopItem / __loopIndex
                             // before the handler receives them. Optional: omit to use defaults.
                             ["maxOrderValue"] = 10000
+                        }
+                    },
+
+                    // Second child step — demonstrates a SIBLING output reference inside a loop.
+                    // "@steps('validate_order')" is a bare key: at runtime the engine rewrites it
+                    // to the CURRENT iteration's scope (e.g. "process_orders.2.validate_order"),
+                    // so archive_order always reads its own iteration's validation note — never
+                    // iteration 0's. This is the scope-relative @steps() resolution added for
+                    // GitHub issue #166; before it, the bare key threw
+                    // "Step 'validate_order' is not defined in the flow manifest".
+                    ["archive_order"] = new StepMetadata
+                    {
+                        Type = "LogMessage",
+                        RunAfter = new RunAfterCollection
+                        {
+                            ["validate_order"] = [StepStatus.Succeeded]
+                        },
+                        Inputs = new Dictionary<string, object?>
+                        {
+                            ["message"] = "@steps('validate_order').output.note"
                         }
                     }
                 }

--- a/src/FlowOrchestrator.Core/Execution/DefaultStepExecutor.cs
+++ b/src/FlowOrchestrator.Core/Execution/DefaultStepExecutor.cs
@@ -60,7 +60,9 @@ public sealed class DefaultStepExecutor : IStepExecutor
         step.Inputs = InputResolutionPipeline.Resolve(step.Inputs, context.TriggerData, context.TriggerHeaders);
 
         // Pass 2 (async): resolve @steps('key').output|status|error expressions.
-        var resolver = new StepOutputResolver(_outputsRepository, _runStore, context.RunId, flow.Manifest.Steps);
+        // step.Key is the runtime key, so the resolver can rewrite a bare sibling reference
+        // (e.g. @steps('wait_signal')) to the current loop scope when this step runs inside a ForEach.
+        var resolver = new StepOutputResolver(_outputsRepository, _runStore, context.RunId, flow.Manifest.Steps, step.Key);
         step.Inputs = await StepExpressionResolutionPipeline.ResolveAsync(step.Inputs, resolver).ConfigureAwait(false);
 
         await _outputsRepository.SaveStepInputAsync(context, flow, step).ConfigureAwait(false);

--- a/src/FlowOrchestrator.Core/Expressions/StepOutputResolver.cs
+++ b/src/FlowOrchestrator.Core/Expressions/StepOutputResolver.cs
@@ -211,14 +211,12 @@ public sealed class StepOutputResolver
         if (exprKey.Contains('.', StringComparison.Ordinal))
             return null;
 
-        foreach (var scope in EnumerateRuntimeScopes(_currentStepKey))
-        {
-            var candidate = $"{scope}.{exprKey}";
-            if (_steps.FindStep(candidate) is not null)
-                return candidate;
-        }
-
-        return null;
+        // Try each enclosing loop scope, nearest-first, as "{scope}.{exprKey}" and take the
+        // first that exists in the manifest. Only reached for a bare key that is not a
+        // top-level step, i.e. the case that previously threw.
+        return EnumerateRuntimeScopes(_currentStepKey)
+            .Select(scope => $"{scope}.{exprKey}")
+            .FirstOrDefault(candidate => _steps.FindStep(candidate) is not null);
     }
 
     /// <summary>

--- a/src/FlowOrchestrator.Core/Expressions/StepOutputResolver.cs
+++ b/src/FlowOrchestrator.Core/Expressions/StepOutputResolver.cs
@@ -74,6 +74,7 @@ public sealed class StepOutputResolver
     private readonly IFlowRunStore _runStore;
     private readonly Guid _runId;
     private readonly StepCollection _steps;
+    private readonly string? _currentStepKey;
 
     // Per-execution output cache — avoids duplicate GetStepOutputAsync calls for the same step key.
     private readonly Dictionary<string, object?> _outputCache = new(StringComparer.Ordinal);
@@ -92,16 +93,26 @@ public sealed class StepOutputResolver
     /// <param name="steps">
     /// The flow's step collection, used to validate that any referenced step key exists in the manifest.
     /// </param>
+    /// <param name="currentStepKey">
+    /// The runtime key of the step whose inputs are being resolved (e.g. <c>"scan.0.open_camera"</c>).
+    /// When supplied and a bare <c>@steps('sibling')</c> key does not exist at the manifest's top level,
+    /// the resolver rewrites it to the enclosing loop scope (<c>"scan.0.sibling"</c>) so that a nested
+    /// ForEach child step can reference the output of a sibling child in the same iteration — mirroring
+    /// the sibling-key rewriting the DAG planner already applies to <c>RunAfter</c>. Pass
+    /// <see langword="null"/> (the default) to disable scope-relative resolution.
+    /// </param>
     public StepOutputResolver(
         IOutputsRepository outputsRepository,
         IFlowRunStore runStore,
         Guid runId,
-        StepCollection steps)
+        StepCollection steps,
+        string? currentStepKey = null)
     {
         _outputsRepository = outputsRepository;
         _runStore = runStore;
         _runId = runId;
         _steps = steps;
+        _currentStepKey = currentStepKey;
     }
 
     /// <summary>
@@ -155,13 +166,14 @@ public sealed class StepOutputResolver
         if (parsed is null)
             return expression; // passthrough — not a @steps() expression
 
-        var (stepKey, property, trail) = parsed.Value;
+        var (exprKey, property, trail) = parsed.Value;
 
-        if (_steps.FindStep(stepKey) is null)
+        var stepKey = ResolveEffectiveKey(exprKey);
+        if (stepKey is null)
             throw new FlowExpressionException(
                 expression,
-                stepKey,
-                $"Step '{stepKey}' is not defined in the flow manifest. Expression: '{expression}'");
+                exprKey,
+                $"Step '{exprKey}' is not defined in the flow manifest. Expression: '{expression}'");
 
         return property switch
         {
@@ -170,6 +182,63 @@ public sealed class StepOutputResolver
             "error" => await ResolveErrorAsync(stepKey).ConfigureAwait(false),
             _ => null
         };
+    }
+
+    /// <summary>
+    /// Maps the step key written in the expression to the effective runtime key used for
+    /// output / status / error lookup, or <see langword="null"/> when it cannot be resolved.
+    /// </summary>
+    /// <remarks>
+    /// Resolution order:
+    /// <list type="number">
+    /// <item>If the key already resolves against the manifest (a top-level step, or an
+    /// explicitly-qualified <c>"loop.0.child"</c> path), it is used verbatim — preserving
+    /// upstream references made from inside a loop.</item>
+    /// <item>Otherwise, for a bare (dot-free) key, each enclosing loop scope of
+    /// <c>_currentStepKey</c> is tried nearest-first as <c>"{scope}.{key}"</c>, so a nested
+    /// ForEach child can reference a sibling child's output in the same iteration.</item>
+    /// </list>
+    /// This fallback only fires for keys that previously threw, so it never changes the
+    /// meaning of an expression that already resolved.
+    /// </remarks>
+    private string? ResolveEffectiveKey(string exprKey)
+    {
+        if (_steps.FindStep(exprKey) is not null)
+            return exprKey;
+
+        // An explicitly-qualified key that does not exist is a genuine error — do not
+        // attempt to graft it onto the current scope.
+        if (exprKey.Contains('.', StringComparison.Ordinal))
+            return null;
+
+        foreach (var scope in EnumerateRuntimeScopes(_currentStepKey))
+        {
+            var candidate = $"{scope}.{exprKey}";
+            if (_steps.FindStep(candidate) is not null)
+                return candidate;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Yields the enclosing loop-scope prefixes of a runtime step key, nearest (innermost) first.
+    /// For <c>"outer.0.inner.1.child"</c> this yields <c>"outer.0.inner.1"</c> then <c>"outer.0"</c>.
+    /// </summary>
+    private static IEnumerable<string> EnumerateRuntimeScopes(string? runtimeStepKey)
+    {
+        if (string.IsNullOrEmpty(runtimeStepKey))
+            yield break;
+
+        var segments = runtimeStepKey.Split(
+            '.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        // A scope prefix is any path that ends at a numeric loop-iteration segment.
+        for (var i = segments.Length - 1; i >= 1; i--)
+        {
+            if (int.TryParse(segments[i], out _))
+                yield return string.Join('.', segments.Take(i + 1));
+        }
     }
 
     private async ValueTask<object?> ResolveOutputAsync(string stepKey, string trail)

--- a/src/FlowOrchestrator.Core/Expressions/StepOutputResolver.cs
+++ b/src/FlowOrchestrator.Core/Expressions/StepOutputResolver.cs
@@ -235,7 +235,7 @@ public sealed class StepOutputResolver
         for (var i = segments.Length - 1; i >= 1; i--)
         {
             if (int.TryParse(segments[i], out _))
-                yield return string.Join('.', segments.Take(i + 1));
+                yield return string.Join('.', segments, 0, i + 1); // array-range overload — no LINQ Take iterator
         }
     }
 

--- a/src/FlowOrchestrator.Dashboard/Assets/dashboard.css
+++ b/src/FlowOrchestrator.Dashboard/Assets/dashboard.css
@@ -525,6 +525,22 @@ input:focus-visible,select:focus-visible,textarea:focus-visible{outline:2px soli
 .skeleton-card{display:flex;flex-direction:column;gap:0;pointer-events:none}
 @keyframes skeleton-shine{0%{background-position:200% 0}100%{background-position:-200% 0}}
 
+/* Indeterminate loading bar — shown while a user-initiated run search / filter fetch is
+   in flight (JS adds .is-loading for non-silent loadRuns calls only, so the 5 s auto-refresh
+   tick never flashes it). The ::before is generated content on the persistent #runs-list
+   element, so it survives the innerHTML swap that renders the rows, and position:sticky keeps
+   it pinned to the top of the scroll viewport. margin-bottom:-3px overlays it on the rows
+   instead of pushing them down, so the layout does not jump. */
+@keyframes runs-loading-slide{0%{background-position:200% 0}100%{background-position:-200% 0}}
+.runs-list.is-loading::before{
+  content:"";position:sticky;top:0;left:0;z-index:5;display:block;height:3px;margin-bottom:-3px;
+  background:linear-gradient(90deg,transparent 0%,var(--fo-terracotta) 50%,transparent 100%);
+  background-size:50% 100%;background-repeat:no-repeat;
+  animation:runs-loading-slide 1.1s linear infinite;
+}
+/* Dim the stale rows while the fresh page loads so it reads as "refreshing", not "done". */
+.runs-list.is-loading > table{opacity:.55;transition:opacity .15s ease}
+
 /* Inline error message + retry button */
 .empty-msg--error{color:var(--fo-danger-text);background:var(--fo-danger-bg);border:1px solid var(--fo-danger-border);border-radius:var(--r-comfy);margin:14px;padding:18px;display:flex;flex-direction:column;align-items:center;gap:10px}
 

--- a/src/FlowOrchestrator.Dashboard/Assets/dashboard.js
+++ b/src/FlowOrchestrator.Dashboard/Assets/dashboard.js
@@ -2184,7 +2184,12 @@ function renderRuns(preserveScroll) {
 
 async function loadRuns(preserveScroll) {
   const listEl = $('runs-list');
-  if (listEl) listEl.setAttribute('aria-busy', 'true');
+  if (listEl) {
+    listEl.setAttribute('aria-busy', 'true');
+    // Loading bar for user-initiated loads (search / filter / pagination). Silent
+    // auto-refresh passes preserveScroll=true, so its 5 s tick never flashes the bar.
+    if (!preserveScroll) listEl.classList.add('is-loading');
+  }
   // Render skeleton on first paint (empty list and not preserving scroll position).
   if (listEl && !preserveScroll && !listEl.innerHTML.trim()) {
     listEl.innerHTML = '<table class="runs-table" aria-hidden="true"><thead><tr><th>Status</th><th>Run ID</th><th>Flow</th><th>Trigger</th><th>Started</th><th>Duration</th></tr></thead><tbody>'
@@ -2221,12 +2226,13 @@ async function loadRuns(preserveScroll) {
     }
 
     renderRuns(preserveScroll);
-    if (listEl) listEl.setAttribute('aria-busy', 'false');
+    if (listEl) { listEl.setAttribute('aria-busy', 'false'); listEl.classList.remove('is-loading'); }
   } catch(e) {
     if (isAbortError(e)) return;
     console.error('Runs load error', e);
     if (listEl) {
       listEl.setAttribute('aria-busy', 'false');
+      listEl.classList.remove('is-loading');
       if (!preserveScroll) {
         listEl.innerHTML = '<div class="empty-msg empty-msg--error">Failed to load runs. <button class="btn-retry" onclick="loadRuns()">Retry</button></div>';
         showError('Failed to load runs', e.message);

--- a/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/DashboardJsContractTests.cs
+++ b/tests/integration/FlowOrchestrator.Dashboard.IntegrationTests/DashboardJsContractTests.cs
@@ -141,6 +141,24 @@ public sealed class DashboardJsContractTests : IDisposable
         Assert.Contains("@keyframes skeleton-shine", html);
     }
 
+    // ── Run search / filter loading indicator ─────────────────────────────────
+
+    [Fact]
+    public async Task GET_root_inlines_runs_loading_bar_for_user_initiated_loads()
+    {
+        // Arrange — a slow run search / filter fetch shows an indeterminate loading
+        // bar; the silent 5 s auto-refresh (preserveScroll=true) must not trigger it.
+
+        // Act
+        var html = await _body.Value;
+
+        // Assert — CSS bar + keyframe, and the JS gate that only arms it for
+        // user-initiated (non-preserveScroll) loadRuns calls.
+        Assert.Contains(".runs-list.is-loading::before", html, StringComparison.Ordinal);
+        Assert.Contains("@keyframes runs-loading-slide", html, StringComparison.Ordinal);
+        Assert.Contains("if (!preserveScroll) listEl.classList.add('is-loading');", html, StringComparison.Ordinal);
+    }
+
     // ── URL-persistent filter state ───────────────────────────────────────────
 
     [Fact]

--- a/tests/integration/FlowOrchestrator.Testing.IntegrationTests/Fixtures/ForEachSiblingReferenceFlow.cs
+++ b/tests/integration/FlowOrchestrator.Testing.IntegrationTests/Fixtures/ForEachSiblingReferenceFlow.cs
@@ -1,0 +1,91 @@
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Execution;
+
+namespace FlowOrchestrator.Testing.Tests.Fixtures;
+
+/// <summary>
+/// ForEach flow whose loop body has two sibling child steps where the second reads the
+/// first's output by <b>bare key</b>: <c>emit</c> → <c>consume</c>, and
+/// <c>consume.label = @steps('emit').output.marker</c>.
+/// </summary>
+/// <remarks>
+/// Regression fixture for issue #166: a nested ForEach child referencing a sibling child's
+/// output via <c>@steps('sibling')</c> must resolve to the current iteration's runtime key
+/// (<c>process_items.{index}.emit</c>) instead of throwing
+/// "Step 'emit' is not defined in the flow manifest".
+/// </remarks>
+public sealed class ForEachSiblingReferenceFlow : IFlowDefinition
+{
+    /// <summary>Stable flow identifier.</summary>
+    public Guid Id { get; } = new("33333333-3333-3333-3333-333333333333");
+
+    /// <summary>Schema version.</summary>
+    public string Version => "1.0";
+
+    /// <summary>Trigger + step manifest with a two-step ForEach body using a sibling output reference.</summary>
+    public FlowManifest Manifest { get; set; } = new()
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            ["process_items"] = new LoopStepMetadata
+            {
+                Type = "ForEach",
+                ForEach = "@triggerBody()?.items",
+                ConcurrencyLimit = 2,
+                Steps = new StepCollection
+                {
+                    ["emit"] = new StepMetadata
+                    {
+                        Type = "EmitIndex",
+                        Inputs = new Dictionary<string, object?>()
+                    },
+                    ["consume"] = new StepMetadata
+                    {
+                        Type = "Echo",
+                        RunAfter = new RunAfterCollection { ["emit"] = [StepStatus.Succeeded] },
+                        Inputs = new Dictionary<string, object?>
+                        {
+                            // Bare sibling reference — must resolve to process_items.{index}.emit.
+                            ["label"] = "@steps('emit').output.marker"
+                        }
+                    }
+                }
+            },
+            ["finalize"] = new StepMetadata
+            {
+                Type = "Echo",
+                RunAfter = new RunAfterCollection { ["process_items"] = [StepStatus.Succeeded] },
+                Inputs = new Dictionary<string, object?> { ["label"] = "done" }
+            }
+        }
+    };
+}
+
+/// <summary>Output of <see cref="EmitIndexStepHandler"/>: a per-iteration marker.</summary>
+public sealed class EmitIndexOutput
+{
+    /// <summary>A stable, iteration-specific marker of the form <c>iter-{index}</c>.</summary>
+    public string? Marker { get; set; }
+}
+
+/// <summary>
+/// Test handler that emits a marker derived from the injected <c>__loopIndex</c>, giving each
+/// loop iteration a distinct output so a sibling reference can be proven to read the correct one.
+/// </summary>
+public sealed class EmitIndexStepHandler : IStepHandler
+{
+    /// <inheritdoc/>
+    public ValueTask<object?> ExecuteAsync(IExecutionContext context, IFlowDefinition flow, IStepInstance step)
+    {
+        var index = step.Inputs.TryGetValue("__loopIndex", out var raw) ? Convert.ToInt32(raw) : -1;
+        return ValueTask.FromResult<object?>(new StepResult<EmitIndexOutput>
+        {
+            Key = step.Key,
+            Value = new EmitIndexOutput { Marker = $"iter-{index}" }
+        });
+    }
+}

--- a/tests/integration/FlowOrchestrator.Testing.IntegrationTests/ForEachSiblingReferenceTests.cs
+++ b/tests/integration/FlowOrchestrator.Testing.IntegrationTests/ForEachSiblingReferenceTests.cs
@@ -1,0 +1,42 @@
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Testing.Tests.Fixtures;
+
+namespace FlowOrchestrator.Testing.Tests;
+
+/// <summary>
+/// End-to-end coverage for issue #166: a nested ForEach child step referencing a sibling
+/// child's output by bare key (<c>@steps('emit')</c>) must resolve to the current iteration's
+/// runtime key through the real engine + InMemory runtime + outputs repository.
+/// </summary>
+public sealed class ForEachSiblingReferenceTests
+{
+    [Fact]
+    public async Task ForEachChild_resolvesSiblingOutputByBareKey_perIteration()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<ForEachSiblingReferenceFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithHandler<EmitIndexStepHandler>("EmitIndex")
+            .WithHandler<ForEachStepHandler>("ForEach")
+            .BuildAsync();
+
+        // Act
+        var result = await host.TriggerAsync(
+            body: new { items = new[] { "a", "b", "c" } },
+            timeout: TimeSpan.FromSeconds(15));
+
+        // Assert
+        Assert.False(result.TimedOut);
+        Assert.Equal(RunStatus.Succeeded, result.Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["finalize"].Status);
+        for (var index = 0; index < 3; index++)
+        {
+            // Each consume step read its own iteration's emit output, not iteration 0's.
+            var consume = result.Steps[$"process_items.{index}.consume"];
+            Assert.Equal(StepStatus.Succeeded, consume.Status);
+            var echoed = consume.Output.GetProperty("Echoed").GetString();
+            Assert.Equal($"iter-{index}", echoed);
+        }
+    }
+}

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Expressions/StepOutputResolverTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Expressions/StepOutputResolverTests.cs
@@ -18,8 +18,32 @@ public class StepOutputResolverTests
         ["submit"] = new StepMetadata { Type = "Submit" }
     };
 
+    // A flow whose ForEach loop "scan" wraps two sibling child steps. The child steps
+    // reference each other's output by bare key, exactly as reported in issue #166.
+    private static readonly StepCollection _loopSteps = new()
+    {
+        ["fetch_orders"] = new StepMetadata { Type = "Fetch" },
+        ["scan"] = new LoopStepMetadata
+        {
+            Type = "ForEach",
+            ForEach = "@triggerBody()?.items",
+            Steps = new StepCollection
+            {
+                ["wait_robot_goto"] = new StepMetadata { Type = "WaitForSignal" },
+                ["open_camera"] = new StepMetadata
+                {
+                    Type = "OpenCamera",
+                    RunAfter = new RunAfterCollection { { "wait_robot_goto", [StepStatus.Succeeded] } }
+                }
+            }
+        }
+    };
+
     private StepOutputResolver CreateResolver(StepCollection? steps = null) =>
         new(_outputs, _runStore, _runId, steps ?? _defaultSteps);
+
+    private StepOutputResolver CreateResolver(StepCollection steps, string currentStepKey) =>
+        new(_outputs, _runStore, _runId, steps, currentStepKey);
 
     private static JsonElement Json(string raw) =>
         JsonSerializer.Deserialize<JsonElement>(raw);
@@ -139,6 +163,115 @@ public class StepOutputResolverTests
         Assert.Equal("ghost_step", ex.StepKey);
         Assert.Contains("ghost_step", ex.Message);
         Assert.Contains("ghost_step", ex.Expression);
+    }
+
+    // ── Scope-relative sibling resolution inside a ForEach (issue #166) ─────────
+
+    [Fact]
+    public async Task ResolvesSiblingOutputByBareKeyInsideLoopScope()
+    {
+        // Arrange — open_camera (running as scan.0.open_camera) references its sibling
+        // wait_robot_goto by bare key; the output is persisted under the runtime key.
+        var output = Json("{\"Location\":\"BAY-7\"}");
+        _outputs.GetStepOutputAsync(_runId, "scan.0.wait_robot_goto")
+            .Returns(new ValueTask<object?>(output));
+        var resolver = CreateResolver(_loopSteps, "scan.0.open_camera");
+
+        // Act
+        var result = await resolver.ResolveAsync("@steps('wait_robot_goto').output.Location");
+
+        // Assert
+        var element = Assert.IsType<JsonElement>(result);
+        Assert.Equal("BAY-7", element.GetString());
+    }
+
+    [Fact]
+    public async Task ResolvesSiblingByBareKeyUsingIterationOfCurrentStep()
+    {
+        // Arrange — the current step is in iteration 3, so the sibling must resolve to
+        // scan.3.wait_robot_goto (not scan.0.*), proving the loop index is honored.
+        var output = Json("{\"Location\":\"BAY-3\"}");
+        _outputs.GetStepOutputAsync(_runId, "scan.3.wait_robot_goto")
+            .Returns(new ValueTask<object?>(output));
+        var resolver = CreateResolver(_loopSteps, "scan.3.open_camera");
+
+        // Act
+        var result = await resolver.ResolveAsync("@steps('wait_robot_goto').output.Location");
+
+        // Assert
+        var element = Assert.IsType<JsonElement>(result);
+        Assert.Equal("BAY-3", element.GetString());
+    }
+
+    [Fact]
+    public async Task TopLevelReferenceFromInsideLoopStillResolvesByBareKey()
+    {
+        // Arrange — a bare key that IS a top-level manifest step must not be rewritten
+        // into the loop scope; it resolves against the top-level runtime key.
+        var output = Json("{\"orderId\":\"ORD-9\"}");
+        _outputs.GetStepOutputAsync(_runId, "fetch_orders")
+            .Returns(new ValueTask<object?>(output));
+        var resolver = CreateResolver(_loopSteps, "scan.0.open_camera");
+
+        // Act
+        var result = await resolver.ResolveAsync("@steps('fetch_orders').output.orderId");
+
+        // Assert
+        var element = Assert.IsType<JsonElement>(result);
+        Assert.Equal("ORD-9", element.GetString());
+    }
+
+    [Fact]
+    public async Task ExplicitlyQualifiedRuntimeKeyResolvesDirectly()
+    {
+        // Arrange
+        var output = Json("{\"Location\":\"BAY-1\"}");
+        _outputs.GetStepOutputAsync(_runId, "scan.1.wait_robot_goto")
+            .Returns(new ValueTask<object?>(output));
+        var resolver = CreateResolver(_loopSteps, "scan.1.open_camera");
+
+        // Act
+        var result = await resolver.ResolveAsync("@steps('scan.1.wait_robot_goto').output.Location");
+
+        // Assert
+        var element = Assert.IsType<JsonElement>(result);
+        Assert.Equal("BAY-1", element.GetString());
+    }
+
+    [Fact]
+    public async Task SiblingStatusResolvesByBareKeyInsideLoopScope()
+    {
+        // Arrange
+        var detail = new FlowRunRecord
+        {
+            Id = _runId,
+            Status = "Running",
+            Steps =
+            [
+                new FlowStepRecord { StepKey = "scan.2.wait_robot_goto", Status = "Succeeded" }
+            ]
+        };
+        _runStore.GetRunDetailAsync(_runId).Returns(Task.FromResult<FlowRunRecord?>(detail));
+        var resolver = CreateResolver(_loopSteps, "scan.2.open_camera");
+
+        // Act
+        var result = await resolver.ResolveAsync("@steps('wait_robot_goto').status");
+
+        // Assert
+        Assert.Equal("Succeeded", result);
+    }
+
+    [Fact]
+    public async Task BareSiblingKeyStillThrowsWhenNoCurrentStepScopeIsSupplied()
+    {
+        // Arrange — without the current step key (the legacy 4-arg constructor), a bare
+        // loop-child key cannot be scope-resolved and must still throw, unchanged.
+        var resolver = CreateResolver(_loopSteps);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<FlowExpressionException>(
+            async () => await resolver.ResolveAsync("@steps('wait_robot_goto').output.Location"));
+        Assert.Equal("wait_robot_goto", ex.StepKey);
     }
 
     // ── Status and error ──────────────────────────────────────────────────────


### PR DESCRIPTION
This branch bundles three things the team asked to ship together. Release **1.30.0**.

## 1. Dependabot batch (#159–#165)

| PR | Package | From → To |
|---|---|---|
| #160 | Microsoft.Extensions.DependencyInjection | 10.0.10 → 10.0.11 |
| #161 | Microsoft.Extensions.Hosting.Abstractions | 10.0.10 → 10.0.11 |
| #162 | OpenTelemetry family | 1.17.0 → 1.18.0 |
| #163 | Testcontainers.MsSql | 4.13.0 → 4.14.0 |
| #164 | Testcontainers.PostgreSql | 4.13.0 → 4.14.0 |
| #165 | xunit.runner.visualstudio | 3.1.5 → 4.0.0 |
| #159 | github/codeql-action | 4.37.7 → 4.37.8 |

OpenTelemetry: Dependabot (#162) bumps `.Api` alone; the **whole family** is moved to `1.18.0` to honor the "same release line" invariant in `Directory.Packages.props`. xunit.runner.visualstudio 3→4 is a major bump — test discovery verified locally.

## 2. Fix: scope-relative `@steps()` inside ForEach (#166)

A nested ForEach child can now read a sibling child's output with the bare key it is declared under — `@steps('validate_order').output.note` — and the resolver rewrites it to the current iteration's runtime scope (`process_orders.{index}.validate_order`). Before, a bare sibling key threw *"Step 'X' is not defined in the flow manifest"* because `@steps()` only resolved against the static manifest, while `RunAfter` already scope-rewrote sibling keys. A bare key that IS a top-level step is left unchanged, so upstream refs from inside a loop keep working; `.status`/`.error` follow the same rule.

- `StepOutputResolver`: new optional `currentStepKey`; `ResolveEffectiveKey` falls back to enclosing loop scopes (nearest-first) only when a bare key is not a top-level step.
- `DefaultStepExecutor` passes `step.Key` (runtime key) into the resolver.
- `OrderBatchFlow` sample gains an `archive_order` child demonstrating the pattern.
- Docs: `foreach.md` "Referencing a Sibling Step's Output", `expressions.md` note.

## 3. Feature: loading indicator for slow run search (dashboard)

The runs list only rendered a skeleton on first paint; a re-search over existing rows showed no feedback while the fetch was in flight. Added an indeterminate loading bar on `#runs-list` for **user-initiated** loads only (`loadRuns` toggles `.is-loading` when `preserveScroll` is falsy), so the silent 5 s auto-refresh never flashes it. All colors via `--fo-*` tokens (DESIGN.md).

## Verification

- `dotnet build -c Release` — **0 warnings, 0 errors**.
- Unit / Integration / Regression suites — **green** across net8.0/9.0/10.0 (Core +6 resolver tests, +1 end-to-end ForEach sibling integration test, +1 dashboard JS contract test).
- **e2e smoke (Aspire, 4 runtimes)** — `RESULT: 37/37 passed, 3 skipped`. Issue #166 sibling resolution (`archive_order`) verified `Succeeded` on SQL Server, PostgreSQL, InMemory **and** ServiceBus (`steps=9 archiveOK=3 archiveFail=0` each).
- CodeQL `cs/linq/missed-select` on the diff — fixed.

Closes #159, #160, #161, #162, #163, #164, #165, #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)