### PR TITLE
fix(core): harden the loop barrier — When-skip settle, loop-step retry, live Running row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [1.30.1] - 2026-08-31
 
+### Added
+
+- **`WarehouseRobotFlow` sample (…0013)** — the issue #169 manifest as a realistic,
+  self-playing demo: a webhook/manual-triggered warehouse scan whose ForEach parks each
+  iteration on a `robot_goto` signal, reads the arriving robot's payload via a
+  scope-relative `@steps()` expression, and fires `robot_callback_success` only after the
+  last location — with `RobotSimulatorHostedService` playing the robot end-to-end through
+  the same public surfaces (`IFlowRunStore`, `IFlowSignalDispatcher`) a real controller
+  integration would use (disable with `ROBOT_SIMULATOR=false`). `samples/README.md` now
+  maps every sample flow to the core surface it demonstrates.
+
 ### Fixed
 
 - **A step declaring `RunAfter` on a ForEach loop now runs after the loop body, not
@@ -22,6 +33,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   immediately. A failing iteration still settles the loop as `Succeeded`, preserving the
   existing "downstream runs even when an iteration failed" semantics; only the timing
   changed. Nested loops settle innermost-first in a single pass.
+- **A `When`-skip that finishes a loop's last iteration now settles the barrier in the same
+  continuation pass.** The skip is recorded after the barrier check, with no later step
+  completion to re-trigger it — without the second settle pass the loop (and the run)
+  parked forever on an already-finished body.
+- **Re-running a settled loop step (dashboard retry) no longer strands the run.** Retry
+  clears the dispatch ledger for the retried key only, so the re-executed ForEach re-armed
+  its barrier while every child was suppressed as already-dispatched; the loop step is now
+  its own settle candidate and completes immediately from its own continuation.
+- **A loop step no longer carries a `CompletedAt` timestamp while it is `Running`.** The
+  fan-out result is no longer written through `RecordStepCompleteAsync`; the row keeps the
+  `Running` stamp from step start and receives its completion (status, output, timestamp)
+  only when the barrier settles — so the dashboard shows a live loop, not a finished one.
 - **Run recovery no longer dispatches steps whose dependencies are unsatisfied.** On
   startup, `FlowRunRecoveryHostedService` re-scheduled every step the planner classified as
   *waiting* — i.e. every step still blocked on a `RunAfter` dependency — which executed it

--- a/FlowOrchestrator.AppHost/Program.cs
+++ b/FlowOrchestrator.AppHost/Program.cs
@@ -108,6 +108,7 @@ internal static class SampleFlowIds
         new("00000000-0000-0000-0000-000000000010"), // DeadEndSkipDemoFlow
         new("00000000-0000-0000-0000-000000000011"), // FinalStepSkipDemoFlow
         new("00000000-0000-0000-0000-000000000012"), // AmountThresholdFlow
+        new("00000000-0000-0000-0000-000000000013"), // WarehouseRobotFlow (issue #169 barrier demo)
         new("d1f8a000-0000-0000-0000-000000000125"), // WebhookEnterpriseSampleFlow (v1.25)
     ];
 }

--- a/samples/FlowOrchestrator.SampleApp.Tests/WarehouseRobotFlowTests.cs
+++ b/samples/FlowOrchestrator.SampleApp.Tests/WarehouseRobotFlowTests.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics;
+using System.Text.Json;
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Storage;
+using FlowOrchestrator.SampleApp.Flows;
+using FlowOrchestrator.SampleApp.Steps;
+using FlowOrchestrator.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FlowOrchestrator.SampleApp.Tests;
+
+/// <summary>
+/// Integration test for <see cref="WarehouseRobotFlow"/> — the issue #169 loop-barrier demo.
+/// Plays the robot manually (two signals) and asserts the callback step ran strictly after
+/// every location was scanned.
+/// </summary>
+public sealed class WarehouseRobotFlowTests
+{
+    private static readonly TimeSpan TerminalTimeout = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    public async Task WarehouseRobotFlow_scansEveryLocation_beforeTheRobotCallbackFires()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<WarehouseRobotFlow>()
+            .WithHandler<LogMessageStepHandler>("LogMessage")
+            .WithHandler<OpenCameraStep>("OpenCamera")
+            .WithHandler<RobotCallbackStep>("RobotCallback")
+            .WithHandler<ForEachStepHandler>("ForEach")
+            .WithFastPolling()
+            .BuildAsync();
+
+        var body = new Dictionary<string, object?>
+        {
+            ["OrderNo"] = "WH-1042",
+            ["Locations"] = new[] { "A-01-03", "B-11-01" }
+        };
+
+        using var scope = host.Services.CreateScope();
+        var orchestrator = scope.ServiceProvider.GetRequiredService<IFlowOrchestrator>();
+        var flow = scope.ServiceProvider.GetServices<IFlowDefinition>().OfType<WarehouseRobotFlow>().First();
+        var ctx = new TriggerContext
+        {
+            Flow = flow,
+            Trigger = new Trigger("manual", "Manual", body),
+            RunId = Guid.Empty,
+            TriggerData = body
+        };
+
+        // Act — trigger, then play the robot: deliver both arrivals once their waiters park.
+        await orchestrator.TriggerAsync(ctx);
+        var signals = host.Services.GetRequiredService<IFlowSignalDispatcher>();
+        var signalStore = host.Services.GetRequiredService<IFlowSignalStore>();
+        foreach (var (index, location) in new[] { (0, "A-01-03"), (1, "B-11-01") })
+        {
+            var stepKey = $"scan_process.{index}.wait_robot_goto";
+            var sw = Stopwatch.StartNew();
+            while (sw.Elapsed < TimeSpan.FromSeconds(15)
+                   && await signalStore.GetWaiterAsync(ctx.RunId, stepKey) is null)
+            {
+                await Task.Delay(25);
+            }
+
+            await signals.DispatchAsync(
+                ctx.RunId, "robot_goto", JsonSerializer.Serialize(new { Location = location }));
+        }
+
+        var result = await host.WaitForRunAsync(ctx.RunId, TerminalTimeout);
+
+        // Assert — full success, per-iteration capture of the right location, callback last.
+        Assert.False(result.TimedOut);
+        Assert.Equal(RunStatus.Succeeded, result.Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["scan_process"].Status);
+
+        var callback = result.Steps["robot_callback_success"];
+        Assert.Equal(StepStatus.Succeeded, callback.Status);
+        Assert.Equal(2, callback.Output.GetProperty("ScannedCount").GetInt32());
+        Assert.NotNull(callback.StartedAt);
+
+        foreach (var index in new[] { 0, 1 })
+        {
+            var camera = result.Steps[$"scan_process.{index}.open_camera"];
+            Assert.Equal(StepStatus.Succeeded, camera.Status);
+            Assert.NotNull(camera.CompletedAt);
+            Assert.True(
+                callback.StartedAt >= camera.CompletedAt,
+                $"robot_callback_success started at {callback.StartedAt:O} — before iteration {index}'s capture at {camera.CompletedAt:O}.");
+        }
+
+        // Each camera photographed the location ITS OWN waiter reported (scope-relative @steps()).
+        var captured = new[] { 0, 1 }
+            .Select(i => result.Steps[$"scan_process.{i}.open_camera"].Output.GetProperty("Location").GetString() ?? "")
+            .OrderBy(l => l, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(new[] { "A-01-03", "B-11-01" }, captured);
+    }
+}

--- a/samples/FlowOrchestrator.SampleApp/Flows/WarehouseRobotFlow.cs
+++ b/samples/FlowOrchestrator.SampleApp/Flows/WarehouseRobotFlow.cs
@@ -1,0 +1,136 @@
+using FlowOrchestrator.Core.Abstractions;
+
+namespace FlowOrchestrator.SampleApp.Flows;
+
+/// <summary>
+/// WarehouseRobotFlow — a warehouse scanning job driven by a real (simulated) robot.
+///
+/// This is the exact production shape reported in issue #169, promoted to a first-class
+/// sample: a <c>ForEach</c> over storage locations whose body <b>parks mid-iteration</b> on a
+/// <c>WaitForSignal</c> until the robot reports it has arrived, then reads that robot's
+/// payload via a scope-relative <c>@steps()</c> expression — and a callback step that must
+/// run only after <b>every</b> location has been scanned.
+///
+/// What it demonstrates, per step:
+///
+///   scan_start              — @triggerBody() expression on a webhook/manual trigger.
+///   scan_process            — ForEach fan-out over @triggerBody()?.Locations with
+///                             ConcurrencyLimit = 1 (one location at a time, like one robot).
+///     wait_robot_goto       — WaitForSignal ("robot_goto"): the iteration parks until the
+///                             robot arrives. The loop step stays Running on the dashboard
+///                             the whole time — the v1.30.1 loop completion barrier.
+///     open_camera           — reads THIS iteration's robot payload by bare sibling key:
+///                             @steps('wait_robot_goto').output.Location (v1.30.0, issue #166).
+///   robot_callback_success  — RunAfter = { scan_process: [Succeeded] }: dispatched only when
+///                             the barrier settles, i.e. after the last location is scanned
+///                             (v1.30.1, issue #169). Reads the loop's own output
+///                             (@steps('scan_process').output.iterations) for the summary.
+///
+/// How to run it "like production":
+///   The RobotSimulatorHostedService plays the robot — it notices each parked
+///   wait_robot_goto waiter and delivers the "robot_goto" signal a few seconds later with a
+///   realistic payload, so a single trigger plays the whole job out on the dashboard with no
+///   manual signalling. Watch the run detail: iterations light up one by one while
+///   scan_process stays Running, and robot_callback_success only appears at the very end.
+///
+/// Trigger it:
+///   Manual — dashboard "Trigger" button, body:
+///     { "OrderNo": "WH-1042", "Locations": ["A-01-03", "A-02-07", "B-11-01"] }
+///   Webhook —
+///     POST /flows/api/webhook/warehouse-scan
+///     Content-Type: application/json
+///     { "OrderNo": "WH-1042", "Locations": ["A-01-03", "A-02-07", "B-11-01"] }
+///
+/// To drive the robot yourself instead, set ROBOT_SIMULATOR=false and POST the signals:
+///   POST /flows/api/runs/{runId}/signals/robot_goto   body: { "Location": "A-01-03" }
+/// </summary>
+public sealed class WarehouseRobotFlow : IFlowDefinition
+{
+    /// <summary>Stable flow identifier (…0013).</summary>
+    public Guid Id { get; } = new Guid("00000000-0000-0000-0000-000000000013");
+
+    /// <summary>Schema version.</summary>
+    public string Version => "1.0";
+
+    /// <summary>Trigger + step manifest — see the type-level remarks for the walkthrough.</summary>
+    public FlowManifest Manifest { get; set; } = new FlowManifest
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual },
+            ["scan_location"] = new TriggerMetadata
+            {
+                Type = TriggerType.Webhook,
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["webhookSlug"] = "warehouse-scan"
+                }
+            }
+        },
+        Steps = new StepCollection
+        {
+            // Entry: acknowledge the scan job. Nothing depends on its output — it exists so
+            // the run timeline shows when the job was accepted.
+            ["scan_start"] = new StepMetadata
+            {
+                Type = "LogMessage",
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["message"] = "@triggerBody()?.OrderNo"
+                }
+            },
+
+            // One iteration per storage location. ConcurrencyLimit = 1 models a single robot:
+            // dispatch is staggered, and each iteration parks until ITS robot_goto arrives.
+            ["scan_process"] = new LoopStepMetadata
+            {
+                Type = "ForEach",
+                RunAfter = new RunAfterCollection { ["scan_start"] = [StepStatus.Succeeded] },
+                ForEach = "@triggerBody()?.Locations",
+                ConcurrencyLimit = 1,
+                Steps = new StepCollection
+                {
+                    // Parks in Pending until the robot reports arrival. All iterations share the
+                    // signal name — per-iteration routing comes from the runtime step key
+                    // (scan_process.{index}.wait_robot_goto). Times out after 5 minutes so an
+                    // abandoned job fails loudly instead of parking forever.
+                    ["wait_robot_goto"] = new StepMetadata
+                    {
+                        Type = "WaitForSignal",
+                        Inputs = new Dictionary<string, object?>
+                        {
+                            ["signalName"] = "robot_goto",
+                            ["timeoutSeconds"] = 300
+                        }
+                    },
+
+                    // Captures the location the robot ACTUALLY reached — read from this
+                    // iteration's own waiter output by bare sibling key.
+                    ["open_camera"] = new StepMetadata
+                    {
+                        Type = "OpenCamera",
+                        RunAfter = new RunAfterCollection { ["wait_robot_goto"] = [StepStatus.Succeeded] },
+                        Inputs = new Dictionary<string, object?>
+                        {
+                            ["OrderNo"] = "@triggerBody()?.OrderNo",
+                            ["Location"] = "@steps('wait_robot_goto').output.Location"
+                        }
+                    }
+                }
+            },
+
+            // Runs after ALL iterations complete — the loop completion barrier guarantees it.
+            // Reads the loop step's own output for the iteration count.
+            ["robot_callback_success"] = new StepMetadata
+            {
+                Type = "RobotCallback",
+                RunAfter = new RunAfterCollection { ["scan_process"] = [StepStatus.Succeeded] },
+                Inputs = new Dictionary<string, object?>
+                {
+                    ["OrderNo"] = "@triggerBody()?.OrderNo",
+                    ["ScannedCount"] = "@steps('scan_process').output.iterations"
+                }
+            }
+        }
+    };
+}

--- a/samples/FlowOrchestrator.SampleApp/Program.cs
+++ b/samples/FlowOrchestrator.SampleApp/Program.cs
@@ -202,6 +202,12 @@ builder.Services.AddFlowOrchestrator(options =>
     // /flows/api/runs/{runId}/signals/approval with a JSON body like {"approver":"manager"}.
     options.AddFlow<ApprovalWorkflowFlow>();
 
+    // Issue #169 / v1.30.1 loop-completion-barrier demo — a robot-driven warehouse scan whose
+    // ForEach parks mid-iteration on WaitForSignal and whose callback step may only run after
+    // the LAST location is scanned. RobotSimulatorHostedService plays the robot, so a single
+    // trigger plays the whole job out on the dashboard with no manual signalling.
+    options.AddFlow<WarehouseRobotFlow>();
+
     if (storageBackend == "sqlserver")
         options.AddFlow<OrderFulfillmentFlow>();
 });
@@ -217,6 +223,19 @@ builder.Services.AddStepHandler<SimulatedFailureStep>("SimulatedFailure");
 // Reads __loopItem (order ID) and __loopIndex injected by ForEachStepHandler at runtime.
 // Used by OrderBatchFlow → process_orders scope → validate_order step.
 builder.Services.AddStepHandler<ProcessOrderItemStep>("ProcessOrderItem");
+
+// WarehouseRobotFlow handlers — camera capture inside the ForEach scope, robot-controller
+// callback after the loop's completion barrier settles.
+builder.Services.AddStepHandler<OpenCameraStep>("OpenCamera");
+builder.Services.AddStepHandler<RobotCallbackStep>("RobotCallback");
+
+// The simulated robot that drives WarehouseRobotFlow end-to-end. Reads only public storage
+// abstractions and signals via IFlowSignalDispatcher — the same surface a real robot-controller
+// integration would use. Set ROBOT_SIMULATOR=false to drive signals manually instead.
+if (builder.Configuration.GetValue("ROBOT_SIMULATOR", true))
+{
+    builder.Services.AddHostedService<RobotSimulatorHostedService>();
+}
 
 // QueryDatabaseStep / SaveResultStep / SampleDataMigrator depend on the Orders
 // business table which only exists in the SQL Server instance.

--- a/samples/FlowOrchestrator.SampleApp/RobotSimulatorHostedService.cs
+++ b/samples/FlowOrchestrator.SampleApp/RobotSimulatorHostedService.cs
@@ -1,0 +1,213 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text.Json;
+using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Storage;
+using FlowOrchestrator.SampleApp.Flows;
+
+namespace FlowOrchestrator.SampleApp;
+
+/// <summary>
+/// Plays the warehouse robot for <see cref="WarehouseRobotFlow"/>: watches active runs for a
+/// parked <c>wait_robot_goto</c> iteration, "drives" for a few seconds, then delivers the
+/// <c>robot_goto</c> signal with the location it reached — so a single trigger plays the whole
+/// scan job out on the dashboard with no manual signalling.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The simulator reads only public storage abstractions (<see cref="IFlowRunStore"/>,
+/// <see cref="IOutputsRepository"/>) and signals through <see cref="IFlowSignalDispatcher"/> —
+/// exactly what a real robot-controller integration would call, which is what makes the sample
+/// behave like production: the flow itself has no idea a simulator exists.
+/// </para>
+/// <para>
+/// One signal is delivered per run per sweep, in iteration order, mirroring a single robot
+/// visiting locations sequentially (the flow's <c>ConcurrencyLimit = 1</c>). The dispatcher
+/// routes a shared signal name to the earliest undelivered waiter, which registers in
+/// iteration order under that concurrency limit — the delivery log records the actual
+/// runtime step key the signal landed on.
+/// </para>
+/// <para>
+/// Disable with <c>ROBOT_SIMULATOR=false</c> to drive the robot yourself:
+/// <c>POST /flows/api/runs/{runId}/signals/robot_goto</c> with <c>{"Location":"A-01-03"}</c>.
+/// </para>
+/// </remarks>
+public sealed class RobotSimulatorHostedService : BackgroundService
+{
+    private static readonly TimeSpan SweepInterval = TimeSpan.FromSeconds(1);
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<RobotSimulatorHostedService> _logger;
+
+    // (runId, runtimeStepKey) → when the "robot" arrives. Entries for finished runs are pruned
+    // each sweep; the whole map is tiny (one entry per parked iteration).
+    private readonly ConcurrentDictionary<(Guid RunId, string StepKey), DateTimeOffset> _travelling = new();
+    private readonly ConcurrentDictionary<(Guid RunId, string StepKey), bool> _delivered = new();
+
+    /// <summary>Initialises the simulator with the root service provider for per-sweep scopes.</summary>
+    public RobotSimulatorHostedService(IServiceProvider serviceProvider, ILogger<RobotSimulatorHostedService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("[RobotSimulator] online — watching WarehouseRobotFlow runs (set ROBOT_SIMULATOR=false to drive the robot manually).");
+
+        using var timer = new PeriodicTimer(SweepInterval);
+        while (await WaitForNextSweepAsync(timer, stoppingToken).ConfigureAwait(false))
+        {
+            try
+            {
+                await SweepOnceAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                // The simulator must never take the sample host down — log and try again next second.
+                _logger.LogWarning(ex, "[RobotSimulator] sweep failed — retrying next interval.");
+            }
+        }
+    }
+
+    private static async Task<bool> WaitForNextSweepAsync(PeriodicTimer timer, CancellationToken ct)
+    {
+        try
+        {
+            return await timer.WaitForNextTickAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+    }
+
+    private async Task SweepOnceAsync(CancellationToken ct)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var runStore = scope.ServiceProvider.GetRequiredService<IFlowRunStore>();
+        var outputs = scope.ServiceProvider.GetRequiredService<IOutputsRepository>();
+        var signals = scope.ServiceProvider.GetRequiredService<IFlowSignalDispatcher>();
+        var flowId = new WarehouseRobotFlow().Id;
+
+        var activeRuns = await runStore.GetActiveRunsAsync().ConfigureAwait(false);
+        var activeIds = new HashSet<Guid>();
+
+        foreach (var run in activeRuns)
+        {
+            if (run.FlowId != flowId)
+            {
+                continue;
+            }
+
+            activeIds.Add(run.Id);
+            var detail = await runStore.GetRunDetailAsync(run.Id).ConfigureAwait(false);
+            if (detail?.Steps is null)
+            {
+                continue;
+            }
+
+            // Parked waiters, in iteration order — the robot visits one location at a time.
+            var parked = detail.Steps
+                .Where(step => step.Status == "Pending"
+                               && step.StepKey.StartsWith("scan_process.", StringComparison.Ordinal)
+                               && step.StepKey.EndsWith(".wait_robot_goto", StringComparison.Ordinal)
+                               && !_delivered.ContainsKey((run.Id, step.StepKey)))
+                .OrderBy(step => step.StepKey, StringComparer.Ordinal)
+                .ToList();
+
+            if (parked.Count == 0)
+            {
+                continue;
+            }
+
+            var next = parked[0];
+            var key = (run.Id, next.StepKey);
+
+            // First sighting: start "driving" — arrive 2–4.5 s later.
+            if (!_travelling.TryGetValue(key, out var arriveAt))
+            {
+                arriveAt = DateTimeOffset.UtcNow + TimeSpan.FromMilliseconds(RandomNumberGenerator.GetInt32(2_000, 4_500));
+                _travelling[key] = arriveAt;
+                _logger.LogInformation(
+                    "[RobotSimulator] RunId={RunId} robot driving to the location for {StepKey} (ETA {EtaSeconds:F1}s)",
+                    run.Id, next.StepKey, (arriveAt - DateTimeOffset.UtcNow).TotalSeconds);
+                continue;
+            }
+
+            if (DateTimeOffset.UtcNow < arriveAt)
+            {
+                continue;
+            }
+
+            var location = await ResolveLocationAsync(outputs, run.Id, next.StepKey).ConfigureAwait(false);
+            var payload = JsonSerializer.Serialize(new { Location = location, ReachedAt = DateTimeOffset.UtcNow });
+            var result = await signals.DispatchAsync(run.Id, "robot_goto", payload, ct).ConfigureAwait(false);
+
+            _delivered[key] = true;
+            _travelling.TryRemove(key, out _);
+            _logger.LogInformation(
+                "[RobotSimulator] RunId={RunId} robot arrived at {Location} — signal delivered to {StepKey} ({Status})",
+                run.Id, location, result.StepKey ?? next.StepKey, result.Status);
+        }
+
+        PruneFinishedRuns(activeIds);
+    }
+
+    /// <summary>
+    /// Reads the trigger body's <c>Locations</c> array and picks the entry matching the parked
+    /// iteration's index, falling back to a synthetic aisle code when absent.
+    /// </summary>
+    private static async Task<string> ResolveLocationAsync(IOutputsRepository outputs, Guid runId, string stepKey)
+    {
+        // "scan_process.{index}.wait_robot_goto" → {index}
+        var segments = stepKey.Split('.');
+        var index = segments.Length >= 2 && int.TryParse(segments[1], out var parsed) ? parsed : 0;
+
+        try
+        {
+            var trigger = await outputs.GetTriggerDataAsync(runId).ConfigureAwait(false);
+            if (trigger is JsonElement { ValueKind: JsonValueKind.Object } body
+                && body.TryGetProperty("Locations", out var locations)
+                && locations.ValueKind == JsonValueKind.Array
+                && index < locations.GetArrayLength())
+            {
+                var value = locations[index];
+                if (value.ValueKind == JsonValueKind.String && value.GetString() is { Length: > 0 } text)
+                {
+                    return text;
+                }
+            }
+        }
+        catch (Exception)
+        {
+            // Trigger data unavailable or oddly shaped — fall through to the synthetic code.
+        }
+
+        return $"AISLE-{index + 1:00}";
+    }
+
+    private void PruneFinishedRuns(HashSet<Guid> activeIds)
+    {
+        foreach (var key in _travelling.Keys)
+        {
+            if (!activeIds.Contains(key.RunId))
+            {
+                _travelling.TryRemove(key, out _);
+            }
+        }
+
+        foreach (var key in _delivered.Keys)
+        {
+            if (!activeIds.Contains(key.RunId))
+            {
+                _delivered.TryRemove(key, out _);
+            }
+        }
+    }
+}

--- a/samples/FlowOrchestrator.SampleApp/Steps/OpenCameraStep.cs
+++ b/samples/FlowOrchestrator.SampleApp/Steps/OpenCameraStep.cs
@@ -1,0 +1,90 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text.Json;
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Execution;
+
+namespace FlowOrchestrator.SampleApp.Steps;
+
+/// <summary>
+/// Simulates a camera capture at a warehouse location: a short exposure delay, then a
+/// scanned barcode for the location the robot reached.
+/// </summary>
+/// <remarks>
+/// Runs inside <c>WarehouseRobotFlow</c>'s ForEach scope. Its <c>Location</c> input is the
+/// scope-relative expression <c>@steps('wait_robot_goto').output.Location</c>, so each
+/// iteration photographs the location <b>its own</b> robot signal reported — the log line
+/// makes a wrong-scope resolve (every iteration reading iteration 0) immediately visible.
+/// </remarks>
+public sealed class OpenCameraStep : IStepHandler<OpenCameraInput>
+{
+    private readonly ILogger<OpenCameraStep> _logger;
+
+    /// <summary>Initialises the step handler with the application logger.</summary>
+    public OpenCameraStep(ILogger<OpenCameraStep> logger) => _logger = logger;
+
+    /// <inheritdoc/>
+    public async ValueTask<object?> ExecuteAsync(
+        IExecutionContext ctx,
+        IFlowDefinition flow,
+        IStepInstance<OpenCameraInput> step)
+    {
+        var location = AsText(step.Inputs.Location) ?? "(unknown)";
+        var orderNo = AsText(step.Inputs.OrderNo) ?? "(no order)";
+
+        // Simulated exposure time — long enough to be visible on the run timeline,
+        // short enough not to slow the demo down.
+        await Task.Delay(TimeSpan.FromMilliseconds(RandomNumberGenerator.GetInt32(250, 700)));
+
+        var barcode = $"SKU-{RandomNumberGenerator.GetInt32(100_000, 999_999).ToString(CultureInfo.InvariantCulture)}";
+        _logger.LogInformation(
+            "[WarehouseRobot] RunId={RunId} Step={StepKey} => camera captured {Barcode} at location {Location} (order {OrderNo})",
+            ctx.RunId, step.Key, barcode, location, orderNo);
+
+        return new StepResult<OpenCameraOutput>
+        {
+            Key = step.Key,
+            Value = new OpenCameraOutput
+            {
+                Location = location,
+                Barcode = barcode,
+                CapturedAt = DateTimeOffset.UtcNow
+            }
+        };
+    }
+
+    // Inputs arrive as object? because @steps()/@triggerBody() expressions resolve to
+    // JsonElement at runtime; static manifest values arrive as plain strings.
+    private static string? AsText(object? value) => value switch
+    {
+        null => null,
+        string s => s,
+        JsonElement { ValueKind: JsonValueKind.String } el => el.GetString(),
+        JsonElement { ValueKind: JsonValueKind.Null or JsonValueKind.Undefined } => null,
+        JsonElement el => el.GetRawText(),
+        _ => value.ToString()
+    };
+}
+
+/// <summary>Typed inputs for the <c>OpenCamera</c> step.</summary>
+public sealed class OpenCameraInput
+{
+    /// <summary>Location the robot reported reaching — resolved from the sibling waiter's output.</summary>
+    public object? Location { get; set; }
+
+    /// <summary>Warehouse order the scan job belongs to — resolved from the trigger body.</summary>
+    public object? OrderNo { get; set; }
+}
+
+/// <summary>Camera capture result persisted as the step output.</summary>
+public sealed class OpenCameraOutput
+{
+    /// <summary>Location that was photographed.</summary>
+    public string? Location { get; set; }
+
+    /// <summary>Barcode decoded from the captured frame.</summary>
+    public string? Barcode { get; set; }
+
+    /// <summary>UTC capture timestamp.</summary>
+    public DateTimeOffset CapturedAt { get; set; }
+}

--- a/samples/FlowOrchestrator.SampleApp/Steps/RobotCallbackStep.cs
+++ b/samples/FlowOrchestrator.SampleApp/Steps/RobotCallbackStep.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Execution;
+
+namespace FlowOrchestrator.SampleApp.Steps;
+
+/// <summary>
+/// Final step of <c>WarehouseRobotFlow</c>: notifies the robot controller that the whole scan
+/// job finished. Reads the ForEach step's own output (<c>@steps('scan_process').output.iterations</c>)
+/// for the summary line.
+/// </summary>
+/// <remarks>
+/// This step declares <c>RunAfter = { scan_process: [Succeeded] }</c>, so the loop completion
+/// barrier (v1.30.1, issue #169) guarantees it executes only after every location was scanned.
+/// The log line is the cheapest possible ordering probe: if it ever appears before the last
+/// <c>open_camera</c> capture line, the barrier is broken.
+/// </remarks>
+public sealed class RobotCallbackStep : IStepHandler<RobotCallbackInput>
+{
+    private readonly ILogger<RobotCallbackStep> _logger;
+
+    /// <summary>Initialises the step handler with the application logger.</summary>
+    public RobotCallbackStep(ILogger<RobotCallbackStep> logger) => _logger = logger;
+
+    /// <inheritdoc/>
+    public ValueTask<object?> ExecuteAsync(
+        IExecutionContext ctx,
+        IFlowDefinition flow,
+        IStepInstance<RobotCallbackInput> step)
+    {
+        var orderNo = AsText(step.Inputs.OrderNo) ?? "(no order)";
+        var scanned = AsInt(step.Inputs.ScannedCount);
+
+        _logger.LogInformation(
+            "[WarehouseRobot] RunId={RunId} Step={StepKey} => scan job {OrderNo} complete: {ScannedCount} location(s) scanned; robot released",
+            ctx.RunId, step.Key, orderNo, scanned);
+
+        return ValueTask.FromResult<object?>(new StepResult<RobotCallbackOutput>
+        {
+            Key = step.Key,
+            Value = new RobotCallbackOutput
+            {
+                OrderNo = orderNo,
+                ScannedCount = scanned,
+                NotifiedAt = DateTimeOffset.UtcNow
+            }
+        });
+    }
+
+    private static string? AsText(object? value) => value switch
+    {
+        null => null,
+        string s => s,
+        JsonElement { ValueKind: JsonValueKind.String } el => el.GetString(),
+        JsonElement { ValueKind: JsonValueKind.Null or JsonValueKind.Undefined } => null,
+        JsonElement el => el.GetRawText(),
+        _ => value.ToString()
+    };
+
+    private static int AsInt(object? value) => value switch
+    {
+        int i => i,
+        JsonElement { ValueKind: JsonValueKind.Number } el when el.TryGetInt32(out var n) => n,
+        _ => 0
+    };
+}
+
+/// <summary>Typed inputs for the <c>RobotCallback</c> step.</summary>
+public sealed class RobotCallbackInput
+{
+    /// <summary>Warehouse order the scan job belongs to — resolved from the trigger body.</summary>
+    public object? OrderNo { get; set; }
+
+    /// <summary>Iteration count read from the ForEach step's own output.</summary>
+    public object? ScannedCount { get; set; }
+}
+
+/// <summary>Callback acknowledgement persisted as the step output.</summary>
+public sealed class RobotCallbackOutput
+{
+    /// <summary>Order number echoed back for correlation.</summary>
+    public string? OrderNo { get; set; }
+
+    /// <summary>Number of locations the job scanned.</summary>
+    public int ScannedCount { get; set; }
+
+    /// <summary>UTC time the robot controller was notified.</summary>
+    public DateTimeOffset NotifiedAt { get; set; }
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,104 @@
+# FlowOrchestrator Samples
+
+`FlowOrchestrator.SampleApp` is one ASP.NET Core app that the Aspire AppHost
+(`FlowOrchestrator.AppHost`) runs **four times**, pinned to different (storage, runtime)
+combinations — so every sample flow below runs on every backend:
+
+| Instance | URL | Storage | Runtime |
+|---|---|---|---|
+| `flow-sqlserver`  | http://localhost:5101 | SQL Server | Hangfire |
+| `flow-postgresql` | http://localhost:5102 | PostgreSQL | Hangfire |
+| `flow-inmemory`   | http://localhost:5103 | InMemory   | InMemory |
+| `flow-servicebus` | http://localhost:5104 | InMemory   | Azure Service Bus (emulator) |
+
+```bash
+dotnet run --project ./FlowOrchestrator.AppHost/FlowOrchestrator.AppHost.csproj   # needs Docker
+```
+
+Dashboard: `/flows` on each instance, Basic Auth `admin` / `admin`.
+
+## Core-feature coverage map
+
+Which core capability each flow exists to demonstrate. When something breaks in the engine,
+this table says which flow makes it visible on the dashboard.
+
+| Flow (ID suffix) | Core surface exercised | Watch it here |
+|---|---|---|
+| `HelloWorldFlow` (…0001) | Cron trigger (`*/1 * * * *`), `IRecurringTriggerDispatcher`, schedule overrides (`Scheduler.PersistOverrides`) | A new run every minute; edit the cron in the dashboard and it survives restart |
+| `OrderFulfillmentFlow` (…0002, SQL only) | Business-table access, `PollableStepHandler<T>` against a real API, `@steps()` chaining into a DB write | `fetch_orders → submit_to_wms → save_result` |
+| `ShipmentTrackingFlow` (…0003) | Poll-and-reschedule cycle: `Pending` + `DelayNextStep`, dispatch release/re-claim | `check_shipment_status` goes `Running → Pending → … → Succeeded` |
+| `PaymentEventFlow` (…0004) | Webhook trigger, `@triggerBody()` path expressions, `@triggerHeaders()` | POST to `/flows/api/webhook/payment-event` |
+| `OrderBatchFlow` (…0005) | ForEach fan-out, per-iteration inputs (`__loopItem`/`__loopIndex`), scope-relative `@steps()` sibling reads (issue #166), idempotency keys (`Idempotency-Key` header) | 3-item batch → 9 steps; replay the same Idempotency-Key and get the same RunId |
+| `ParallelHealthCheckFlow` (…0006) | Multiple DAG entry steps, all-of join, partial-failure tolerance, graph validation | Fan-out/fan-in on the run graph |
+| `ApprovalWorkflowFlow` (…0007) | `WaitForSignal` park + resume, signal API | "Send Signal" button on the parked step |
+| `ConditionalSkipDemoFlow` (…0008) | Skip on unmet prerequisites (`prerequisites_unmet`), failure-handler branch | `charge_customer` Skipped, `handle_decline` runs |
+| `SkipVariantsDemoFlow` (…0009) | Mid-chain skip vs. dead-end skip in one run | Two skip shapes side by side |
+| `DeadEndSkipDemoFlow` (…0010) | Entry failure → transitive skip → run-level `Failed` classification | `RunTerminationClassifier` rules 1–2 |
+| `FinalStepSkipDemoFlow` (…0011) | Leaf skip with run-level `Succeeded` classification | Classifier rule 3–4 |
+| `AmountThresholdFlow` (…0012) | `When` clauses on `RunAfter` (`when_false` skips + evaluation traces) | Trigger with `{"amount":10}` vs `{"amount":10000}` |
+| `WarehouseRobotFlow` (…0013) | **Loop completion barrier (issue #169, v1.30.1)**: `WaitForSignal` inside ForEach, loop step `Running` until every iteration is terminal, downstream gated on the loop; scope-relative sibling reads; loop-output reads (`@steps('scan_process').output.iterations`) | See below |
+| `WebhookEnterpriseSampleFlow` (…0125) | Webhook hardening (v1.25): HMAC (GitHub scheme), replay nonces, rate limit, DLQ | "Webhooks" dashboard tab |
+
+Cross-cutting features every run exercises: run timeout latch (`RunControl.DefaultRunTimeout`),
+retention sweep (`Retention`), event persistence + OpenTelemetry (`Observability` — spans, metrics,
+and structured logs land in the Aspire dashboard), health checks (`/health`), crash recovery
+(`FlowRunRecoveryHostedService` re-dispatches on startup).
+
+## WarehouseRobotFlow — the "like production" sample
+
+The exact manifest shape from issue #169, driven end-to-end by a **simulated robot**
+(`RobotSimulatorHostedService`), so one trigger plays out a realistic multi-step job while you
+watch:
+
+```
+scan_start ─► scan_process ─► [0] wait_robot_goto ─► open_camera      (robot drives ~2-4 s per stop)
+   (log)      (ForEach,       [1] wait_robot_goto ─► open_camera
+               Running the    [2] wait_robot_goto ─► open_camera
+               whole time)                                        └──► robot_callback_success
+```
+
+Trigger it (any instance):
+
+```bash
+curl -u admin:admin -X POST "http://localhost:5101/flows/api/flows/00000000-0000-0000-0000-000000000013/trigger" \
+  -H 'Content-Type: application/json' \
+  -d '{"OrderNo":"WH-1042","Locations":["A-01-03","A-02-07","B-11-01"]}'
+```
+
+Then open the run in the dashboard and watch:
+
+- `scan_process` stays **Running** while the robot works — before v1.30.1 it reported
+  `Succeeded` at fan-out and `robot_callback_success` ran *first*, which is the bug the loop
+  completion barrier fixed.
+- each iteration parks on `wait_robot_goto` (Pending), resumes when the simulator delivers the
+  signal, and `open_camera` logs the location **its own** waiter reported — a wrong-scope
+  `@steps()` resolve would photograph the same location three times.
+- `robot_callback_success` appears only after the last capture, reading the loop's own output
+  for the summary (`ScannedCount`).
+
+The app log tells the same story in order (`[RobotSimulator] robot driving…`,
+`[WarehouseRobot] camera captured…`, `…scan job complete: 3 location(s) scanned`), and the
+run's Events tab shows the engine's own record (`step.pending` for the parked loop,
+`step.completed` for the loop only at the very end).
+
+The simulator talks to the app exclusively through public surfaces (`IFlowRunStore`,
+`IFlowSignalDispatcher`) — the same integration surface a real robot controller would use.
+Set `ROBOT_SIMULATOR=false` to drive the signals yourself:
+
+```bash
+curl -u admin:admin -X POST "http://localhost:5101/flows/api/runs/<runId>/signals/robot_goto" \
+  -H 'Content-Type: application/json' -d '{"Location":"A-01-03"}'
+```
+
+## Where the rest of the core is proven
+
+Samples are demos, not the safety net. The engine's invariants live in the test tree:
+
+- `tests/unit/` — planner, barrier (`LoopBarrierTests`), classifier, expression resolution.
+- `tests/integration/FlowOrchestrator.Testing.IntegrationTests/` — full engine + InMemory
+  runtime end-to-end, including the issue #166/#169 manifests verbatim
+  (`ForEachSignalSiblingTests`, `ForEachLoopBarrierTests`, `ForEachLoopBarrierEdgeCaseTests`).
+- `tests/integration/FlowOrchestrator.{SqlServer,PostgreSQL,ServiceBus,Hangfire,Dashboard}.IntegrationTests/`
+  — per-backend contracts (Testcontainers / emulator).
+- `tests/regression/` — timing-sensitive cron/polling/timeout and concurrency stress.
+- `.claude/skills/e2e` — the four-instance smoke matrix run before every release.

--- a/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Continuation.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Continuation.cs
@@ -128,6 +128,16 @@ public sealed partial class FlowOrchestratorEngine
                 if (++safetyCounter > flow.Manifest.Steps.Count + 4) break;
 
                 statuses = await _runtimeStore.GetStepStatusesAsync(ctx.RunId).ConfigureAwait(false);
+
+                // A When-skip recorded just above may have been the LAST outstanding child of an
+                // enclosing loop — and it happened after the settle pass at the top of this method,
+                // with no later step completion to re-trigger it. Settle here so the loop's
+                // downstream steps become ready in the next sweep instead of parking the run.
+                if (await SettleEnclosingLoopsAsync(ctx, flow, step, statuses).ConfigureAwait(false))
+                {
+                    statuses = await _runtimeStore.GetStepStatusesAsync(ctx.RunId).ConfigureAwait(false);
+                }
+
                 evaluation = _graphPlanner.Evaluate(flow, statuses);
             }
         }
@@ -172,9 +182,18 @@ public sealed partial class FlowOrchestratorEngine
     /// <param name="statuses">Status map read after the blocked-step pass.</param>
     /// <returns><see langword="true"/> when at least one loop step was settled.</returns>
     /// <remarks>
+    /// <para>
     /// A loop step is the only step whose completion is decided outside its own handler, so its
     /// <c>step.completed</c> event and <see cref="StepCompletedEvent"/> are published here rather
     /// than in <c>RunStepAsync</c> — at the point the loop is actually finished, not at fan-out.
+    /// </para>
+    /// <para>
+    /// The completed step itself is a candidate when it is scoped, which covers re-running a loop
+    /// step whose iterations already finished: <see cref="RetryStepAsync"/> clears the dispatch
+    /// ledger for the retried key only, so the re-executed <c>ForEach</c> re-arms the barrier while
+    /// its children are suppressed as already-dispatched and can never settle it again. On the
+    /// ordinary fan-out path this candidate is a no-op — the children have no status rows yet.
+    /// </para>
     /// </remarks>
     private async Task<bool> SettleEnclosingLoopsAsync(
         IExecutionContext ctx,
@@ -182,7 +201,7 @@ public sealed partial class FlowOrchestratorEngine
         IStepInstance step,
         IReadOnlyDictionary<string, StepStatus> statuses)
     {
-        var candidates = LoopBarrier.EnclosingLoopKeys(step.Key);
+        var candidates = LoopBarrier.SettleCandidatesFor(flow, step.Key);
         if (candidates.Count == 0)
         {
             return false;

--- a/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Step.cs
+++ b/src/FlowOrchestrator.Core/Execution/FlowOrchestratorEngine.Step.cs
@@ -119,15 +119,24 @@ public sealed partial class FlowOrchestratorEngine
                 }
             }
 
-            try
+            // A Running result under the graph runtime is a scoped step parked on its LoopBarrier —
+            // not a completion. RecordStepStartAsync already stamped the row Running, so skipping the
+            // completion write keeps CompletedAt null until the barrier settles the step for real
+            // (the settle pass writes Succeeded + the loop output). The barrier reads the iteration
+            // count from IOutputsRepository (SaveStepOutputAsync above), not from this row.
+            var isBarrierParked = result.Status == StepStatus.Running && _runtimeStore is not null;
+            if (!isBarrierParked)
             {
-                var outputJson = SafeSerialize(result.Result);
-                await _runStore.RecordStepCompleteAsync(ctx.RunId, step.Key, result.Status.ToString(), outputJson, result.FailedReason)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                EngineLog.StepCompletionTrackingFailed(_logger, ex);
+                try
+                {
+                    var outputJson = SafeSerialize(result.Result);
+                    await _runStore.RecordStepCompleteAsync(ctx.RunId, step.Key, result.Status.ToString(), outputJson, result.FailedReason)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    EngineLog.StepCompletionTrackingFailed(_logger, ex);
+                }
             }
 
             var stepExecutionMs = Stopwatch.GetElapsedTime(stepExecutionStart).TotalMilliseconds;

--- a/src/FlowOrchestrator.Core/Execution/Internal/LoopBarrier.cs
+++ b/src/FlowOrchestrator.Core/Execution/Internal/LoopBarrier.cs
@@ -68,6 +68,31 @@ internal static class LoopBarrier
     }
 
     /// <summary>
+    /// Returns the loop steps whose barrier the completion of <paramref name="runtimeStepKey"/>
+    /// can settle, innermost first: the step itself when it is scoped, then its enclosing loops.
+    /// </summary>
+    /// <param name="flow">Flow whose manifest classifies the step.</param>
+    /// <param name="runtimeStepKey">Runtime key of the step that just reached a terminal status.</param>
+    /// <remarks>
+    /// Including the step itself matters when a loop step re-executes over iterations that already
+    /// finished — a retried <c>ForEach</c> re-arms the barrier, but its children are suppressed by
+    /// the dispatch ledger and so can never settle it a second time. On first fan-out the children
+    /// have no status rows yet, so the self-candidate simply does not settle.
+    /// </remarks>
+    public static IReadOnlyList<string> SettleCandidatesFor(IFlowDefinition flow, string runtimeStepKey)
+    {
+        var enclosing = EnclosingLoopKeys(runtimeStepKey);
+        if (flow.Manifest.Steps.FindStep(runtimeStepKey) is not IScopedStep)
+        {
+            return enclosing;
+        }
+
+        var candidates = new List<string>(enclosing.Count + 1) { runtimeStepKey };
+        candidates.AddRange(enclosing);
+        return candidates;
+    }
+
+    /// <summary>
     /// Reads the iteration count a loop step recorded in its output.
     /// </summary>
     /// <param name="loopOutput">

--- a/tests/integration/FlowOrchestrator.Testing.IntegrationTests/Fixtures/LoopBarrierEdgeCaseFlows.cs
+++ b/tests/integration/FlowOrchestrator.Testing.IntegrationTests/Fixtures/LoopBarrierEdgeCaseFlows.cs
@@ -1,0 +1,274 @@
+using FlowOrchestrator.Core.Abstractions;
+
+namespace FlowOrchestrator.Testing.Tests.Fixtures;
+
+/// <summary>
+/// Nested loops: an outer <c>ForEach</c> whose body is another <c>ForEach</c>, followed by a
+/// top-level step gated on the outer loop. Proves the inner barrier settles before the outer one
+/// and that the downstream step waits for the whole two-level fan-out.
+/// </summary>
+public sealed class NestedForEachFlow : IFlowDefinition
+{
+    /// <summary>Stable flow identifier.</summary>
+    public Guid Id { get; } = new("66666666-6666-6666-6666-666666666661");
+
+    /// <summary>Schema version.</summary>
+    public string Version => "1.0";
+
+    /// <summary>Outer loop over the trigger payload, inner loop over a static pair.</summary>
+    public FlowManifest Manifest { get; set; } = new()
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            ["outer"] = new LoopStepMetadata
+            {
+                Type = "ForEach",
+                ForEach = "@triggerBody()?.groups",
+                ConcurrencyLimit = 2,
+                Steps = new StepCollection
+                {
+                    ["inner"] = new LoopStepMetadata
+                    {
+                        Type = "ForEach",
+                        ForEach = new List<object?> { "x", "y" },
+                        ConcurrencyLimit = 2,
+                        Steps = new StepCollection
+                        {
+                            ["leaf"] = new StepMetadata
+                            {
+                                Type = "Echo",
+                                Inputs = new Dictionary<string, object?> { ["label"] = "leaf" }
+                            }
+                        }
+                    }
+                }
+            },
+            ["after_outer"] = new StepMetadata
+            {
+                Type = "Echo",
+                RunAfter = new RunAfterCollection { ["outer"] = [StepStatus.Succeeded] },
+                Inputs = new Dictionary<string, object?> { ["label"] = "after" }
+            }
+        }
+    };
+}
+
+/// <summary>
+/// A loop whose first child always throws, blocking its sibling. Locks the documented semantics:
+/// a failed iteration still settles the barrier (`Failed` and `Skipped` are terminal), so the
+/// step gated on the loop still runs — only its timing changed.
+/// </summary>
+public sealed class ForEachFailingChildFlow : IFlowDefinition
+{
+    /// <summary>Stable flow identifier.</summary>
+    public Guid Id { get; } = new("66666666-6666-6666-6666-666666666662");
+
+    /// <summary>Schema version.</summary>
+    public string Version => "1.0";
+
+    /// <summary>Loop body pairs a throwing step with a dependent that can never run.</summary>
+    public FlowManifest Manifest { get; set; } = new()
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            ["loop"] = new LoopStepMetadata
+            {
+                Type = "ForEach",
+                ForEach = "@triggerBody()?.items",
+                ConcurrencyLimit = 2,
+                Steps = new StepCollection
+                {
+                    ["boom"] = new StepMetadata { Type = "Boom" },
+                    ["never"] = new StepMetadata
+                    {
+                        Type = "Echo",
+                        RunAfter = new RunAfterCollection { ["boom"] = [StepStatus.Succeeded] },
+                        Inputs = new Dictionary<string, object?> { ["label"] = "never" }
+                    }
+                }
+            },
+            ["after_loop"] = new StepMetadata
+            {
+                Type = "Echo",
+                RunAfter = new RunAfterCollection { ["loop"] = [StepStatus.Succeeded] },
+                Inputs = new Dictionary<string, object?> { ["label"] = "after" }
+            }
+        }
+    };
+}
+
+/// <summary>
+/// A loop whose second child carries a <c>When</c> clause that evaluates to <see langword="false"/>.
+/// The engine records it <see cref="StepStatus.Skipped"/>, which must count as terminal for the
+/// barrier — otherwise a `When`-gated loop body would park the loop forever.
+/// </summary>
+public sealed class ForEachWhenSkipFlow : IFlowDefinition
+{
+    /// <summary>Stable flow identifier.</summary>
+    public Guid Id { get; } = new("66666666-6666-6666-6666-666666666663");
+
+    /// <summary>Schema version.</summary>
+    public string Version => "1.0";
+
+    /// <summary>Loop body whose consumer is gated on a false trigger-body condition.</summary>
+    public FlowManifest Manifest { get; set; } = new()
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            ["loop"] = new LoopStepMetadata
+            {
+                Type = "ForEach",
+                ForEach = "@triggerBody()?.items",
+                ConcurrencyLimit = 1,
+                Steps = new StepCollection
+                {
+                    ["first"] = new StepMetadata
+                    {
+                        Type = "Echo",
+                        Inputs = new Dictionary<string, object?> { ["label"] = "first" }
+                    },
+                    ["gated"] = new StepMetadata
+                    {
+                        Type = "Echo",
+                        RunAfter = new RunAfterCollection
+                        {
+                            ["first"] = new RunAfterCondition
+                            {
+                                Statuses = [StepStatus.Succeeded],
+                                When = "@triggerBody().amount > 1000"
+                            }
+                        },
+                        Inputs = new Dictionary<string, object?> { ["label"] = "gated" }
+                    }
+                }
+            },
+            ["after_loop"] = new StepMetadata
+            {
+                Type = "Echo",
+                RunAfter = new RunAfterCollection { ["loop"] = [StepStatus.Succeeded] },
+                Inputs = new Dictionary<string, object?> { ["label"] = "after" }
+            }
+        }
+    };
+}
+
+/// <summary>
+/// A loop body that parks on a <c>WaitForSignal</c> with a short timeout and is never signalled.
+/// The waiter fails on expiry, which must settle the barrier rather than strand the run.
+/// </summary>
+public sealed class ForEachSignalTimeoutFlow : IFlowDefinition
+{
+    /// <summary>Stable flow identifier.</summary>
+    public Guid Id { get; } = new("66666666-6666-6666-6666-666666666664");
+
+    /// <summary>Schema version.</summary>
+    public string Version => "1.0";
+
+    /// <summary>Loop body waiting on a signal nobody sends.</summary>
+    public FlowManifest Manifest { get; set; } = new()
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            ["loop"] = new LoopStepMetadata
+            {
+                Type = "ForEach",
+                ForEach = "@triggerBody()?.items",
+                ConcurrencyLimit = 2,
+                Steps = new StepCollection
+                {
+                    ["wait"] = new StepMetadata
+                    {
+                        Type = "WaitForSignal",
+                        Inputs = new Dictionary<string, object?>
+                        {
+                            ["signalName"] = "never_sent",
+                            ["timeoutSeconds"] = 1
+                        }
+                    }
+                }
+            },
+            ["after_loop"] = new StepMetadata
+            {
+                Type = "Echo",
+                RunAfter = new RunAfterCollection { ["loop"] = [StepStatus.Succeeded] },
+                Inputs = new Dictionary<string, object?> { ["label"] = "after" }
+            }
+        }
+    };
+}
+
+/// <summary>
+/// Two loops chained by <c>RunAfter</c>. The second loop must not fan out until the first one's
+/// barrier settled, and the tail step must run after both.
+/// </summary>
+public sealed class SequentialForEachFlow : IFlowDefinition
+{
+    /// <summary>Stable flow identifier.</summary>
+    public Guid Id { get; } = new("66666666-6666-6666-6666-666666666665");
+
+    /// <summary>Schema version.</summary>
+    public string Version => "1.0";
+
+    /// <summary>`loop_a` → `loop_b` → `tail`.</summary>
+    public FlowManifest Manifest { get; set; } = new()
+    {
+        Triggers = new FlowTriggerCollection
+        {
+            ["manual"] = new TriggerMetadata { Type = TriggerType.Manual }
+        },
+        Steps = new StepCollection
+        {
+            ["loop_a"] = new LoopStepMetadata
+            {
+                Type = "ForEach",
+                ForEach = "@triggerBody()?.items",
+                ConcurrencyLimit = 2,
+                Steps = new StepCollection
+                {
+                    ["work_a"] = new StepMetadata
+                    {
+                        Type = "Echo",
+                        Inputs = new Dictionary<string, object?> { ["label"] = "a" }
+                    }
+                }
+            },
+            ["loop_b"] = new LoopStepMetadata
+            {
+                Type = "ForEach",
+                RunAfter = new RunAfterCollection { ["loop_a"] = [StepStatus.Succeeded] },
+                ForEach = "@triggerBody()?.items",
+                ConcurrencyLimit = 2,
+                Steps = new StepCollection
+                {
+                    ["work_b"] = new StepMetadata
+                    {
+                        Type = "Echo",
+                        Inputs = new Dictionary<string, object?> { ["label"] = "b" }
+                    }
+                }
+            },
+            ["tail"] = new StepMetadata
+            {
+                Type = "Echo",
+                RunAfter = new RunAfterCollection { ["loop_b"] = [StepStatus.Succeeded] },
+                Inputs = new Dictionary<string, object?> { ["label"] = "tail" }
+            }
+        }
+    };
+}

--- a/tests/integration/FlowOrchestrator.Testing.IntegrationTests/ForEachLoopBarrierEdgeCaseTests.cs
+++ b/tests/integration/FlowOrchestrator.Testing.IntegrationTests/ForEachLoopBarrierEdgeCaseTests.cs
@@ -1,0 +1,282 @@
+using FlowOrchestrator.Core.Abstractions;
+using FlowOrchestrator.Core.Execution;
+using FlowOrchestrator.Core.Storage;
+using FlowOrchestrator.Testing.Tests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FlowOrchestrator.Testing.Tests;
+
+/// <summary>
+/// Edge-case coverage for the ForEach completion barrier introduced for issue #169: nesting,
+/// failing and skipped iterations, a waiter that times out, chained loops, and re-running a loop
+/// step whose iterations already finished.
+/// </summary>
+/// <remarks>
+/// Every ordering assertion compares persisted <c>StartedAt</c> / <c>CompletedAt</c> stamps of
+/// steps that are causally ordered by the barrier, never an elapsed-time bound — a slow CI box
+/// changes the durations but never the order.
+/// </remarks>
+public sealed class ForEachLoopBarrierEdgeCaseTests
+{
+    private static readonly TimeSpan TerminalTimeout = TimeSpan.FromSeconds(45);
+
+    private static void AssertRanAfter(FlowTestRunResult result, string downstreamKey, string childKeyPrefix)
+    {
+        var startedAt = result.Steps[downstreamKey].StartedAt;
+        Assert.NotNull(startedAt);
+
+        var children = result.Steps
+            .Where(kvp => kvp.Key.StartsWith(childKeyPrefix, StringComparison.Ordinal))
+            .ToList();
+        Assert.NotEmpty(children);
+
+        foreach (var (key, child) in children)
+        {
+            Assert.NotNull(child.CompletedAt);
+            Assert.True(
+                startedAt >= child.CompletedAt,
+                $"'{downstreamKey}' started at {startedAt:O} — before '{key}' completed at {child.CompletedAt:O}.");
+        }
+    }
+
+    [Fact]
+    public async Task NestedForEach_settlesInnerThenOuter_beforeTheDownstreamStep()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<NestedForEachFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithHandler<ForEachStepHandler>("ForEach")
+            .BuildAsync();
+
+        // Act
+        var result = await host.TriggerAsync(
+            body: new { groups = new[] { "g0", "g1", "g2" } },
+            timeout: TerminalTimeout);
+
+        // Assert — 3 outer iterations × (1 inner loop + 2 leaves) all terminal, both barrier
+        // levels settled, and the downstream step ran after every leaf.
+        Assert.False(result.TimedOut);
+        Assert.Equal(RunStatus.Succeeded, result.Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["outer"].Status);
+        for (var outer = 0; outer < 3; outer++)
+        {
+            Assert.Equal(StepStatus.Succeeded, result.Steps[$"outer.{outer}.inner"].Status);
+            for (var inner = 0; inner < 2; inner++)
+            {
+                Assert.Equal(StepStatus.Succeeded, result.Steps[$"outer.{outer}.inner.{inner}.leaf"].Status);
+            }
+
+            // The inner loop step cannot settle before its own leaves.
+            var innerLoop = result.Steps[$"outer.{outer}.inner"];
+            for (var inner = 0; inner < 2; inner++)
+            {
+                var leaf = result.Steps[$"outer.{outer}.inner.{inner}.leaf"];
+                Assert.True(
+                    innerLoop.CompletedAt >= leaf.CompletedAt,
+                    $"inner loop {outer} settled at {innerLoop.CompletedAt:O} before leaf {inner} completed at {leaf.CompletedAt:O}.");
+            }
+        }
+
+        AssertRanAfter(result, "after_outer", "outer.");
+    }
+
+    [Fact]
+    public async Task FailingIteration_stillSettlesTheLoop_andRunsTheDownstreamStep()
+    {
+        // Arrange — every iteration's first child throws, blocking its sibling.
+        await using var host = await FlowTestHost.For<ForEachFailingChildFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithHandler<BoomStepHandler>("Boom")
+            .WithHandler<ForEachStepHandler>("ForEach")
+            .BuildAsync();
+
+        // Act
+        var result = await host.TriggerAsync(
+            body: new { items = new[] { "a", "b" } },
+            timeout: TerminalTimeout);
+
+        // Assert — Failed and Skipped are terminal, so the barrier settles and the gated step runs.
+        Assert.False(result.TimedOut);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["loop"].Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["after_loop"].Status);
+        for (var index = 0; index < 2; index++)
+        {
+            Assert.Equal(StepStatus.Failed, result.Steps[$"loop.{index}.boom"].Status);
+            Assert.Equal(StepStatus.Skipped, result.Steps[$"loop.{index}.never"].Status);
+        }
+
+        AssertRanAfter(result, "after_loop", "loop.");
+    }
+
+    [Fact]
+    public async Task WhenSkippedIteration_countsAsTerminal_andSettlesTheLoop()
+    {
+        // Arrange — the loop's second child is gated on a false When clause.
+        await using var host = await FlowTestHost.For<ForEachWhenSkipFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithHandler<ForEachStepHandler>("ForEach")
+            .BuildAsync();
+
+        // Act
+        var result = await host.TriggerAsync(
+            body: new { amount = 10, items = new[] { "a", "b" } },
+            timeout: TerminalTimeout);
+
+        // Assert
+        Assert.False(result.TimedOut);
+        Assert.Equal(RunStatus.Succeeded, result.Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["loop"].Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["after_loop"].Status);
+        for (var index = 0; index < 2; index++)
+        {
+            Assert.Equal(StepStatus.Succeeded, result.Steps[$"loop.{index}.first"].Status);
+            Assert.Equal(StepStatus.Skipped, result.Steps[$"loop.{index}.gated"].Status);
+        }
+    }
+
+    [Fact]
+    public async Task WaiterThatTimesOutInsideALoop_settlesTheBarrier_insteadOfStrandingTheRun()
+    {
+        // Arrange — the loop parks on a signal nobody sends; each waiter expires after 1 s.
+        await using var host = await FlowTestHost.For<ForEachSignalTimeoutFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithHandler<ForEachStepHandler>("ForEach")
+            .WithFastPolling()
+            .BuildAsync();
+
+        // Act
+        var result = await host.TriggerAsync(
+            body: new { items = new[] { "a", "b" } },
+            timeout: TerminalTimeout);
+
+        // Assert
+        Assert.False(result.TimedOut);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["loop"].Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["after_loop"].Status);
+        for (var index = 0; index < 2; index++)
+        {
+            Assert.Equal(StepStatus.Failed, result.Steps[$"loop.{index}.wait"].Status);
+        }
+
+        AssertRanAfter(result, "after_loop", "loop.");
+    }
+
+    [Fact]
+    public async Task ChainedLoops_secondLoopFansOutOnlyAfterTheFirstOneSettled()
+    {
+        // Arrange
+        await using var host = await FlowTestHost.For<SequentialForEachFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithHandler<ForEachStepHandler>("ForEach")
+            .BuildAsync();
+
+        // Act
+        var result = await host.TriggerAsync(
+            body: new { items = new[] { "a", "b", "c" } },
+            timeout: TerminalTimeout);
+
+        // Assert
+        Assert.False(result.TimedOut);
+        Assert.Equal(RunStatus.Succeeded, result.Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["loop_a"].Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["loop_b"].Status);
+
+        // loop_b's own children must all start after every loop_a child finished.
+        var firstBStart = result.Steps
+            .Where(kvp => kvp.Key.StartsWith("loop_b.", StringComparison.Ordinal))
+            .Min(kvp => kvp.Value.StartedAt);
+        var lastAEnd = result.Steps
+            .Where(kvp => kvp.Key.StartsWith("loop_a.", StringComparison.Ordinal))
+            .Max(kvp => kvp.Value.CompletedAt);
+        Assert.NotNull(firstBStart);
+        Assert.NotNull(lastAEnd);
+        Assert.True(
+            firstBStart >= lastAEnd,
+            $"loop_b started at {firstBStart:O} — before loop_a finished at {lastAEnd:O}.");
+
+        AssertRanAfter(result, "tail", "loop_b.");
+    }
+
+    [Fact]
+    public async Task RetryingASettledLoopStep_doesNotStrandTheRunOnItsBarrier()
+    {
+        // Arrange — a completed run, then an operator re-runs the loop step from the dashboard.
+        // RetryStepAsync clears the dispatch ledger for the retried key only, so the re-executed
+        // ForEach re-arms the barrier while its children are suppressed as already-dispatched;
+        // the loop can only settle again from its own continuation.
+        await using var host = await FlowTestHost.For<ForEachTestFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithHandler<ForEachStepHandler>("ForEach")
+            .BuildAsync();
+
+        var first = await host.TriggerAsync(
+            body: new { items = new[] { "a", "b" } },
+            timeout: TerminalTimeout);
+        Assert.Equal(RunStatus.Succeeded, first.Status);
+
+        // Act
+        using (var scope = host.Services.CreateScope())
+        {
+            var orchestrator = scope.ServiceProvider.GetRequiredService<IFlowOrchestrator>();
+            var flow = scope.ServiceProvider.GetServices<IFlowDefinition>().OfType<ForEachTestFlow>().First();
+            await orchestrator.RetryStepAsync(flow.Id, first.RunId, "process_items");
+        }
+
+        var result = await host.WaitForRunAsync(first.RunId, TerminalTimeout);
+
+        // Assert — the run reaches a terminal state again and the loop is not left Running.
+        Assert.False(result.TimedOut);
+        Assert.Equal(RunStatus.Succeeded, result.Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["process_items"].Status);
+        Assert.Equal(StepStatus.Succeeded, result.Steps["finalize"].Status);
+    }
+
+    [Fact]
+    public async Task LoopStepIsRunningWhileItsIterationsAreInFlight_andCountsAsInFlightWork()
+    {
+        // Arrange — a single parked iteration is enough to prove the loop is a live step, not a
+        // completed one: the run must stay Running rather than being classified terminal.
+        await using var host = await FlowTestHost.For<ForEachLoopBarrierFlow>()
+            .WithHandler<EchoStepHandler>("Echo")
+            .WithHandler<ForEachStepHandler>("ForEach")
+            .WithFastPolling()
+            .BuildAsync();
+
+        using var scope = host.Services.CreateScope();
+        var orchestrator = scope.ServiceProvider.GetRequiredService<IFlowOrchestrator>();
+        var flow = scope.ServiceProvider.GetServices<IFlowDefinition>().OfType<ForEachLoopBarrierFlow>().First();
+        var body = new Dictionary<string, object?> { ["Steps"] = new[] { "only-one" } };
+        var ctx = new TriggerContext
+        {
+            Flow = flow,
+            Trigger = new Trigger("manual", "Manual", body),
+            RunId = Guid.Empty,
+            TriggerData = body
+        };
+
+        // Act
+        await orchestrator.TriggerAsync(ctx);
+        var signalStore = host.Services.GetRequiredService<IFlowSignalStore>();
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (sw.Elapsed < TimeSpan.FromSeconds(15)
+               && await signalStore.GetWaiterAsync(ctx.RunId, "scan_process.0.wait_robot_goto") is null)
+        {
+            await Task.Delay(25);
+        }
+
+        // Assert
+        var runStore = host.Services.GetRequiredService<IFlowRunStore>();
+        var detail = await runStore.GetRunDetailAsync(ctx.RunId);
+        Assert.NotNull(detail);
+        Assert.Equal("Running", detail!.Status);
+        var loopStep = detail.Steps!.Single(step => step.StepKey == "scan_process");
+        Assert.Equal(nameof(StepStatus.Running), loopStep.Status);
+        Assert.Null(loopStep.CompletedAt);
+        Assert.DoesNotContain(detail.Steps!, step => step.StepKey == "robot_callback_success");
+
+        // Cleanup — release the waiter so the host disposes without a parked run.
+        var signals = host.Services.GetRequiredService<IFlowSignalDispatcher>();
+        await signals.DispatchAsync(ctx.RunId, "robot_goto", """{"Location":"BAY-A"}""");
+        await host.WaitForRunAsync(ctx.RunId, TerminalTimeout);
+    }
+}

--- a/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/Internal/LoopBarrierTests.cs
+++ b/tests/unit/FlowOrchestrator.Core.UnitTests/Execution/Internal/LoopBarrierTests.cs
@@ -84,6 +84,72 @@ public class LoopBarrierTests
         Assert.Equal(["outer.1.inner", "outer"], keys);
     }
 
+    [Fact]
+    public void SettleCandidatesFor_ScopedStep_ReturnsItselfFirst()
+    {
+        // Arrange — a retried loop step must be able to settle its own re-armed barrier.
+        var flow = SingleLoopFlow();
+
+        // Act
+        var candidates = LoopBarrier.SettleCandidatesFor(flow, "loop");
+
+        // Assert
+        Assert.Equal(["loop"], candidates);
+    }
+
+    [Fact]
+    public void SettleCandidatesFor_PlainChild_ReturnsOnlyEnclosingLoops()
+    {
+        // Arrange
+        var flow = SingleLoopFlow();
+
+        // Act
+        var candidates = LoopBarrier.SettleCandidatesFor(flow, "loop.1.consume");
+
+        // Assert
+        Assert.Equal(["loop"], candidates);
+    }
+
+    [Fact]
+    public void SettleCandidatesFor_NestedLoopChildThatIsItselfALoop_ReturnsSelfThenOuter()
+    {
+        // Arrange
+        var flow = FlowWith(new StepCollection
+        {
+            ["outer"] = new LoopStepMetadata
+            {
+                Type = "ForEach",
+                Steps = new StepCollection
+                {
+                    ["inner"] = new LoopStepMetadata
+                    {
+                        Type = "ForEach",
+                        Steps = new StepCollection { ["child"] = new StepMetadata { Type = "Echo" } }
+                    }
+                }
+            }
+        });
+
+        // Act
+        var candidates = LoopBarrier.SettleCandidatesFor(flow, "outer.0.inner");
+
+        // Assert — the inner loop settles itself first, which can then settle the outer one.
+        Assert.Equal(["outer.0.inner", "outer"], candidates);
+    }
+
+    [Fact]
+    public void SettleCandidatesFor_TopLevelPlainStep_ReturnsEmpty()
+    {
+        // Arrange
+        var flow = SingleLoopFlow();
+
+        // Act
+        var candidates = LoopBarrier.SettleCandidatesFor(flow, "after");
+
+        // Assert
+        Assert.Empty(candidates);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(7)]


### PR DESCRIPTION
## Summary

Stacked on #170 (review that first). Core review follow-up: three real defects found in the barrier by widening the test net, plus a realistic self-playing sample of the issue #169 scenario.

## Fixes

1. **When-skip settle** — a `When` clause skipping the **last** outstanding child of a loop was recorded *after* the continuation's barrier pass, with no later completion to re-trigger it: the loop (and run) parked forever. The ready-set sweep now re-runs the settle pass after each When-skip round. `WhenSkippedIteration_countsAsTerminal_andSettlesTheLoop` reproduced the hang (45 s timeout) before the fix.
2. **Loop-step retry** — `RetryStepAsync` clears the dispatch ledger for the retried key only, so a re-executed ForEach re-armed its barrier while every child was suppressed as already-dispatched: nothing could settle it again. The completed step is now its own settle candidate (`LoopBarrier.SettleCandidatesFor`) — a no-op on first fan-out (children have no status rows yet), an immediate settle on retry. Covered by `RetryingASettledLoopStep_doesNotStrandTheRunOnItsBarrier`.
3. **Live Running row** — the fan-out result was persisted via `RecordStepCompleteAsync`, stamping `CompletedAt` on a step that had not completed. The engine now skips the completion write for a barrier-parked `Running` result; the row receives status/output/`CompletedAt` only when the barrier settles, so the dashboard shows a live loop.

## Sample: WarehouseRobotFlow (…0013)

The issue #169 manifest as a first-class, production-shaped demo: webhook/manual scan job → ForEach over storage locations (`ConcurrencyLimit = 1`, one robot) → each iteration parks on `robot_goto` → `open_camera` reads its own waiter's payload scope-relatively → `robot_callback_success` gated on the loop. `RobotSimulatorHostedService` plays the robot through the same public surfaces a real controller integration would use (`IFlowRunStore` + `IFlowSignalDispatcher`; `ROBOT_SIMULATOR=false` for manual driving). One trigger plays the whole job out on the dashboard: iterations light up one by one, `scan_process` stays `Running` throughout, callback appears last.

`samples/README.md` adds a sample → core-feature coverage map. AppHost registers the new flow ID for the Service Bus subscription topology.

## Tests added

- Integration (`ForEachLoopBarrierEdgeCaseTests`, 7): nested loops (inner settles before outer), failing iteration still settles + downstream runs, When-skipped iteration, waiter timeout inside a loop, chained loops (`loop_a → loop_b → tail` ordering), loop-step retry, in-flight probe (loop `Running`, no `CompletedAt`, run stays `Running`).
- Unit (`LoopBarrierTests`, +4): `SettleCandidatesFor` shapes.
- Sample test (`WarehouseRobotFlowTests`): full scan job with manual signals, per-iteration location assertion, callback-last ordering.

## Verification

| Gate | Result |
|---|---|
| `dotnet build FlowOrchestrator.slnx` | 0 error, 0 warning |
| Unit | 331/331 per TFM (net8/9/10) |
| Testing integration | 28/28 per TFM |
| Regression | 56/56 per TFM |
| e2e matrix (4 Aspire instances) | 40/40 — `WarehouseRobotFlow` additionally verified hands-free on InMemory and ServiceBus runtimes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxVQF5XuSXT4AMpHNM8B51
